### PR TITLE
ci: allow manual validation runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_dispatch:
 
 jobs:
   validate:


### PR DESCRIPTION
## Summary

- enable manual CI runs with `workflow_dispatch`
- keep existing push and pull request validation unchanged

## Validation

- `git diff --check`
- this pull request CI run validates the workflow before merge