### PR TITLE
docs: explain Grok 4.5 and unified usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ kimi
 
 ### Grok Build
 
-Pick Grok Build for xAI's agentic CLI in Obsidian, backed by SuperGrok credits or API keys.
+Pick Grok Build for xAI's agentic CLI in Obsidian. Sign in with Grok OAuth or use an xAI API key.
 
 ```bash
 grok
@@ -237,9 +237,13 @@ grok
 
 Install the Grok CLI from xAI, authenticate with grok.com OAuth or configure API keys, then enable Grok Build in Grimoire.
 
-- [Grok Build](https://grok.com/build)
+- [Grok Build documentation](https://docs.x.ai/build/overview)
+- [Grok 4.5](https://docs.x.ai/developers/grok-4-5)
+- [Usage and limits](https://docs.x.ai/grok/faq)
 
-Inside Grimoire, Grok Build runs over ACP via `grok agent stdio` with Grimoire-managed launch artifacts under `.grimoire/grok/`, persistent runtime, native JSONL history hydration, plan mode, image input, provider commands, reasoning effort on native models, rewind, and fork. SuperGrok credit usage appears next to the model selector when OAuth auth is available; API spend aggregates from session cost metadata when reported.
+Grok 4.5 is currently the default model powering Grok Build. Grimoire discovers the available model catalog from the authenticated Grok CLI account instead of maintaining a static list, so availability can vary by account and CLI version and update automatically.
+
+Inside Grimoire, Grok Build runs over ACP via `grok agent stdio` with Grimoire-managed launch artifacts under `.grimoire/grok/`, persistent runtime, native JSONL history hydration, plan mode, image input, provider commands, reasoning effort on native models, rewind, and fork. With OAuth, Grimoire shows the shared weekly Grok usage allowance, reset time, and Extra Usage Credits when available; API spend aggregates from session cost metadata when reported.
 
 ## Your first chat
 
@@ -285,7 +289,7 @@ A badge next to the model selector keeps the active provider's usage in view, wi
 | OpenCode | Monthly spend aggregated from ACP and session cost metadata |
 | MiMoCode | Monthly spend aggregated from ACP and session cost metadata |
 | Kimi Code | Monthly spend aggregated from ACP and session cost metadata |
-| Grok Build | SuperGrok credit windows from grok.com billing when OAuth is available; monthly API spend from session cost metadata |
+| Grok Build | Shared weekly Grok usage, reset time, and Extra Usage Credits through OAuth; monthly API spend from session cost metadata |
 
 ### Plan mode
 

--- a/docs/readme/README.de.md
+++ b/docs/readme/README.de.md
@@ -233,7 +233,7 @@ In Grimoire läuft Kimi Code über ACP mit persistent runtime, native history, p
 
 ### Grok Build
 
-Wähle Grok Build für xAIs agentic CLI in Obsidian, unterstützt durch SuperGrok credits oder API keys.
+Wähle Grok Build für xAIs agentic CLI in Obsidian. Melde dich über Grok OAuth an oder verwende einen xAI API-Key.
 
 ```bash
 grok
@@ -241,9 +241,13 @@ grok
 
 Installiere die Grok CLI von xAI, authentifiziere dich über grok.com OAuth oder konfiguriere API keys, und aktiviere dann Grok Build in Grimoire.
 
-- [Grok Build](https://grok.com/build)
+- [Grok-Build-Dokumentation](https://docs.x.ai/build/overview)
+- [Grok 4.5](https://docs.x.ai/developers/grok-4-5)
+- [Nutzung und Limits](https://docs.x.ai/grok/faq)
 
-In Grimoire läuft Grok Build über ACP via `grok agent stdio` mit Grimoire-managed launch artifacts unter `.grimoire/grok/`, persistent runtime, native JSONL history hydration, plan mode, image input, provider commands, reasoning effort auf native models, rewind und fork. SuperGrok credit usage erscheint neben dem model selector, wenn OAuth auth verfügbar ist; API spend wird aus session cost metadata aggregiert, wenn gemeldet.
+Grok 4.5 ist derzeit das Standardmodell hinter Grok Build. Grimoire liest den verfügbaren Modellkatalog aus dem authentifizierten Grok CLI statt aus einer statischen Liste; daher kann er je nach Konto und CLI-Version variieren und sich automatisch aktualisieren.
+
+In Grimoire läuft Grok Build über ACP via `grok agent stdio` mit Grimoire-managed launch artifacts unter `.grimoire/grok/`, persistent runtime, native JSONL history hydration, plan mode, image input, provider commands, reasoning effort auf native models, rewind und fork. Bei OAuth-Authentifizierung zeigt Grimoire die gemeinsame wöchentliche Grok-Nutzung, den Reset-Zeitpunkt und verfügbare Extra Usage Credits an; API spend wird aus session cost metadata aggregiert, wenn gemeldet.
 
 ## Dein erster Chat
 
@@ -289,7 +293,7 @@ Ein badge neben dem model selector hält die usage des aktiven provider sichtbar
 | OpenCode | Monthly spend aggregiert aus ACP und session cost metadata |
 | MiMoCode | Monthly spend aggregiert aus ACP und session cost metadata |
 | Kimi Code | Monthly spend aggregiert aus ACP und session cost metadata |
-| Grok Build | SuperGrok credit windows aus grok.com billing bei OAuth auth; monthly API spend aus session cost metadata |
+| Grok Build | Gemeinsame wöchentliche Grok-Nutzung, Reset-Zeitpunkt und Extra Usage Credits über OAuth; monthly API spend aus session cost metadata |
 
 ### Plan mode
 

--- a/docs/readme/README.es.md
+++ b/docs/readme/README.es.md
@@ -233,7 +233,7 @@ Dentro de Grimoire, Kimi Code corre sobre ACP con persistent runtime, native his
 
 ### Grok Build
 
-Elige Grok Build para el agentic CLI de xAI en Obsidian, respaldado por SuperGrok credits o API keys.
+Elige Grok Build para el agentic CLI de xAI en Obsidian. Inicia sesión con OAuth de Grok o usa una clave de API de xAI.
 
 ```bash
 grok
@@ -241,9 +241,13 @@ grok
 
 Instala la Grok CLI de xAI, autentícate con grok.com OAuth o configura API keys, y luego activa Grok Build en Grimoire.
 
-- [Grok Build](https://grok.com/build)
+- [Documentación de Grok Build](https://docs.x.ai/build/overview)
+- [Grok 4.5](https://docs.x.ai/developers/grok-4-5)
+- [Uso y límites](https://docs.x.ai/grok/faq)
 
-Dentro de Grimoire, Grok Build corre sobre ACP via `grok agent stdio` con Grimoire-managed launch artifacts bajo `.grimoire/grok/`, persistent runtime, native JSONL history hydration, plan mode, image input, provider commands, reasoning effort en native models, rewind y fork. SuperGrok credit usage aparece junto al model selector cuando OAuth auth está disponible; API spend se agrega desde session cost metadata cuando se reporta.
+Grok 4.5 es actualmente el modelo predeterminado de Grok Build. Grimoire obtiene el catálogo de modelos disponible desde la cuenta autenticada del CLI de Grok en lugar de mantener una lista estática, por lo que la disponibilidad puede variar según la cuenta y la versión del CLI y actualizarse automáticamente.
+
+Dentro de Grimoire, Grok Build corre sobre ACP via `grok agent stdio` con Grimoire-managed launch artifacts bajo `.grimoire/grok/`, persistent runtime, native JSONL history hydration, plan mode, image input, provider commands, reasoning effort en native models, rewind y fork. Con OAuth, Grimoire muestra el límite semanal compartido de Grok, la hora de reinicio y los Extra Usage Credits disponibles; API spend se agrega desde session cost metadata cuando se reporta.
 
 ## Tu primer chat
 
@@ -289,7 +293,7 @@ Un badge junto al model selector mantiene visible el usage del provider activo. 
 | OpenCode | Monthly spend agregado desde ACP y session cost metadata |
 | MiMoCode | Monthly spend agregado desde ACP y session cost metadata |
 | Kimi Code | Monthly spend agregado desde ACP y session cost metadata |
-| Grok Build | SuperGrok credit windows desde grok.com billing cuando OAuth auth está disponible; monthly API spend desde session cost metadata |
+| Grok Build | Límite semanal compartido de Grok, hora de reinicio y Extra Usage Credits mediante OAuth; monthly API spend desde session cost metadata |
 
 ### Plan mode
 

--- a/docs/readme/README.fr.md
+++ b/docs/readme/README.fr.md
@@ -235,7 +235,7 @@ Dans Grimoire, Kimi Code tourne via ACP avec persistent runtime, native history,
 
 ### Grok Build
 
-Choisissez Grok Build pour le CLI agentique de xAI dans Obsidian, alimenté par des SuperGrok credits ou des API keys.
+Choisissez Grok Build pour le CLI agentique de xAI dans Obsidian. Connectez-vous avec Grok OAuth ou utilisez une clé API xAI.
 
 ```bash
 grok
@@ -243,9 +243,13 @@ grok
 
 Installez la Grok CLI de xAI, authentifiez-vous via grok.com OAuth ou configurez des API keys, puis activez Grok Build dans Grimoire.
 
-- [Grok Build](https://grok.com/build)
+- [Documentation de Grok Build](https://docs.x.ai/build/overview)
+- [Grok 4.5](https://docs.x.ai/developers/grok-4-5)
+- [Utilisation et limites](https://docs.x.ai/grok/faq)
 
-Dans Grimoire, Grok Build tourne via ACP avec `grok agent stdio` et des Grimoire-managed launch artifacts sous `.grimoire/grok/`, plus persistent runtime, native JSONL history hydration, plan mode, image input, provider commands, reasoning effort sur les native models, rewind et fork. SuperGrok credit usage apparaît à côté du model selector lorsque OAuth auth est disponible ; API spend est agrégé depuis session cost metadata lorsqu'il est rapporté.
+Grok 4.5 est actuellement le modèle par défaut de Grok Build. Grimoire récupère le catalogue de modèles disponible depuis le CLI Grok authentifié au lieu de maintenir une liste statique ; la disponibilité peut donc varier selon le compte et la version du CLI et se mettre à jour automatiquement.
+
+Dans Grimoire, Grok Build tourne via ACP avec `grok agent stdio` et des Grimoire-managed launch artifacts sous `.grimoire/grok/`, plus persistent runtime, native JSONL history hydration, plan mode, image input, provider commands, reasoning effort sur les native models, rewind et fork. Avec OAuth, Grimoire affiche la limite hebdomadaire partagée de Grok, l'heure de réinitialisation et les Extra Usage Credits disponibles ; API spend est agrégé depuis session cost metadata lorsqu'il est rapporté.
 
 ## Votre premier chat
 
@@ -291,7 +295,7 @@ Un badge près du model selector garde l'usage du provider actif visible. Le mod
 | OpenCode | Monthly spend agrégé depuis ACP et session cost metadata |
 | MiMoCode | Monthly spend agrégé depuis ACP et session cost metadata |
 | Kimi Code | Monthly spend agrégé depuis ACP et session cost metadata |
-| Grok Build | SuperGrok credit windows depuis grok.com billing lorsque OAuth auth est disponible ; monthly API spend depuis session cost metadata |
+| Grok Build | Limite hebdomadaire partagée de Grok, heure de réinitialisation et Extra Usage Credits via OAuth ; monthly API spend depuis session cost metadata |
 
 ### Plan mode
 

--- a/docs/readme/README.ja.md
+++ b/docs/readme/README.ja.md
@@ -235,7 +235,7 @@ Grimoire 内では、Kimi Code は ACP で動作し、persistent runtime、nativ
 
 ### Grok Build
 
-Obsidian で xAI の agentic CLI を使う場合は Grok Build を選びます。SuperGrok credits または API keys で利用できます。
+Obsidian で xAI の agentic CLI を使う場合は Grok Build を選びます。Grok OAuth でサインインするか、xAI API キーを使用します。
 
 ```bash
 grok
@@ -243,9 +243,13 @@ grok
 
 xAI の Grok CLI をインストールし、grok.com OAuth で認証するか API keys を設定してから、Grimoire で Grok Build を有効化します。
 
-- [Grok Build](https://grok.com/build)
+- [Grok Build ドキュメント](https://docs.x.ai/build/overview)
+- [Grok 4.5](https://docs.x.ai/developers/grok-4-5)
+- [使用量と制限](https://docs.x.ai/grok/faq)
 
-Grimoire 内では、Grok Build は `grok agent stdio` 経由の ACP で動作し、`.grimoire/grok/` 配下の Grimoire-managed launch artifacts、persistent runtime、native JSONL history hydration、plan mode、image input、provider commands、native models 向け reasoning effort、rewind、fork をサポートします。OAuth auth が利用できる場合、SuperGrok credit usage は model selector の横に表示されます。API spend は session cost metadata が報告されたときに集計されます。
+Grok 4.5 は現在、Grok Build を支えるデフォルトモデルです。Grimoire は静的リストを保持するのではなく、認証済み Grok CLI アカウントから利用可能なモデルカタログを取得するため、モデルの提供状況はアカウントや CLI バージョンによって異なり、自動的に更新される場合があります。
+
+Grimoire 内では、Grok Build は `grok agent stdio` 経由の ACP で動作し、`.grimoire/grok/` 配下の Grimoire-managed launch artifacts、persistent runtime、native JSONL history hydration、plan mode、image input、provider commands、native models 向け reasoning effort、rewind、fork をサポートします。OAuth 認証時には、共有の週間 Grok 使用枠、リセット時刻、利用可能な Extra Usage Credits を表示します。API spend は session cost metadata が報告されたときに集計されます。
 
 ## 最初のチャット
 
@@ -291,7 +295,7 @@ Model selector の横の badge が active provider の usage を表示します�
 | OpenCode | ACP と session cost metadata から集計した monthly spend |
 | MiMoCode | ACP と session cost metadata から集計した monthly spend |
 | Kimi Code | ACP と session cost metadata から集計した monthly spend |
-| Grok Build | OAuth auth が利用できる場合の grok.com billing からの SuperGrok credit windows；session cost metadata からの monthly API spend |
+| Grok Build | OAuth 認証による共有の週間 Grok 使用枠、リセット時刻、Extra Usage Credits；session cost metadata からの monthly API spend |
 
 ### Plan mode
 

--- a/docs/readme/README.ru.md
+++ b/docs/readme/README.ru.md
@@ -239,7 +239,7 @@ kimi
 
 ### Grok Build
 
-Выбирайте Grok Build для agentic CLI от xAI в Obsidian, с поддержкой SuperGrok credits или API keys.
+Выбирайте Grok Build для agentic CLI от xAI в Obsidian. Авторизуйтесь через Grok OAuth или используйте API-ключ xAI.
 
 ```bash
 grok
@@ -247,9 +247,13 @@ grok
 
 Установите Grok CLI от xAI, авторизуйтесь через grok.com OAuth или настройте API keys, затем включите Grok Build в Grimoire.
 
-- [Grok Build](https://grok.com/build)
+- [Документация Grok Build](https://docs.x.ai/build/overview)
+- [Grok 4.5](https://docs.x.ai/developers/grok-4-5)
+- [Использование и лимиты](https://docs.x.ai/grok/faq)
 
-Внутри Grimoire Grok Build работает через ACP via `grok agent stdio` с Grimoire-managed launch artifacts в `.grimoire/grok/`, persistent runtime, native JSONL history hydration, plan mode, image input, provider commands, reasoning effort на native models, rewind и fork. SuperGrok credit usage отображается рядом с model selector при OAuth auth; API spend агрегируется из session cost metadata, когда доступна.
+Сейчас Grok 4.5 — модель по умолчанию, на которой работает Grok Build. Grimoire получает доступный каталог моделей из авторизованного Grok CLI, а не из статического списка, поэтому набор моделей может зависеть от аккаунта и версии CLI и обновляться автоматически.
+
+Внутри Grimoire Grok Build работает через ACP via `grok agent stdio` с Grimoire-managed launch artifacts в `.grimoire/grok/`, persistent runtime, native JSONL history hydration, plan mode, image input, provider commands, reasoning effort на native models, rewind и fork. При OAuth-авторизации Grimoire показывает общий недельный лимит Grok, время сброса и Extra Usage Credits, когда они доступны; API spend агрегируется из session cost metadata, когда доступна.
 
 ## Первый чат
 
@@ -295,7 +299,7 @@ Badge рядом с model selector показывает usage активного
 | OpenCode | Monthly spend, агрегированный из ACP и session cost metadata |
 | MiMoCode | Monthly spend, агрегированный из ACP и session cost metadata |
 | Kimi Code | Monthly spend, агрегированный из ACP и session cost metadata |
-| Grok Build | SuperGrok credit windows из grok.com billing при OAuth auth; monthly API spend из session cost metadata |
+| Grok Build | Общий недельный лимит Grok, время сброса и Extra Usage Credits при OAuth-авторизации; monthly API spend из session cost metadata |
 
 ### Plan mode
 

--- a/docs/readme/README.zh-CN.md
+++ b/docs/readme/README.zh-CN.md
@@ -227,7 +227,7 @@ kimi
 
 ### Grok Build
 
-若要在 Obsidian 中使用 xAI 的 agentic CLI，可选择 Grok Build，支持 SuperGrok credits 或 API keys。
+若要在 Obsidian 中使用 xAI 的 agentic CLI，可选择 Grok Build。通过 Grok OAuth 登录，或使用 xAI API 密钥。
 
 ```bash
 grok
@@ -235,9 +235,13 @@ grok
 
 安装 xAI 的 Grok CLI，通过 grok.com OAuth 认证或配置 API keys，然后在 Grimoire 中启用 Grok Build。
 
-- [Grok Build](https://grok.com/build)
+- [Grok Build 文档](https://docs.x.ai/build/overview)
+- [Grok 4.5](https://docs.x.ai/developers/grok-4-5)
+- [使用量与限制](https://docs.x.ai/grok/faq)
 
-在 Grimoire 中，Grok Build 通过 `grok agent stdio` 以 ACP 运行，使用 `.grimoire/grok/` 下的 Grimoire-managed launch artifacts，并支持 persistent runtime、native JSONL history hydration、plan mode、image input、provider commands、native models 上的 reasoning effort、rewind 和 fork。OAuth auth 可用时，SuperGrok credit usage 会显示在 model selector 旁；API spend 会在 session cost metadata 上报时聚合显示。
+Grok 4.5 目前是 Grok Build 的默认模型。Grimoire 从已认证的 Grok CLI 账户获取可用模型目录，而不是维护静态列表，因此模型可用性可能会因账户和 CLI 版本而异，并自动更新。
+
+在 Grimoire 中，Grok Build 通过 `grok agent stdio` 以 ACP 运行，使用 `.grimoire/grok/` 下的 Grimoire-managed launch artifacts，并支持 persistent runtime、native JSONL history hydration、plan mode、image input、provider commands、native models 上的 reasoning effort、rewind 和 fork。使用 OAuth 时，Grimoire 会显示共享的每周 Grok 使用额度、重置时间以及可用的 Extra Usage Credits；API spend 会在 session cost metadata 上报时聚合显示。
 
 ## 第一次聊天
 
@@ -283,7 +287,7 @@ Model selector 旁边的 badge 会持续显示当前 provider 的 usage；model 
 | OpenCode | 从 ACP 和 session cost metadata 聚合的 monthly spend |
 | MiMoCode | 从 ACP 和 session cost metadata 聚合的 monthly spend |
 | Kimi Code | 从 ACP 和 session cost metadata 聚合的 monthly spend |
-| Grok Build | OAuth auth 可用时来自 grok.com billing 的 SuperGrok credit windows；来自 session cost metadata 的 monthly API spend |
+| Grok Build | 通过 OAuth 显示共享的每周 Grok 使用额度、重置时间和 Extra Usage Credits；来自 session cost metadata 的 monthly API spend |
 
 ### Plan mode
 

--- a/docs/readme/README.zh-TW.md
+++ b/docs/readme/README.zh-TW.md
@@ -227,7 +227,7 @@ kimi
 
 ### Grok Build
 
-若要在 Obsidian 中使用 xAI 的 agentic CLI，可選擇 Grok Build，支援 SuperGrok credits 或 API keys。
+若要在 Obsidian 中使用 xAI 的 agentic CLI，可選擇 Grok Build。透過 Grok OAuth 登入，或使用 xAI API 金鑰。
 
 ```bash
 grok
@@ -235,9 +235,13 @@ grok
 
 安裝 xAI 的 Grok CLI，透過 grok.com OAuth 認證或設定 API keys，然後在 Grimoire 中啟用 Grok Build。
 
-- [Grok Build](https://grok.com/build)
+- [Grok Build 文件](https://docs.x.ai/build/overview)
+- [Grok 4.5](https://docs.x.ai/developers/grok-4-5)
+- [使用量與限制](https://docs.x.ai/grok/faq)
 
-在 Grimoire 中，Grok Build 透過 `grok agent stdio` 以 ACP 執行，使用 `.grimoire/grok/` 下的 Grimoire-managed launch artifacts，並支援 persistent runtime、native JSONL history hydration、plan mode、image input、provider commands、native models 上的 reasoning effort、rewind 和 fork。OAuth auth 可用時，SuperGrok credit usage 會顯示在 model selector 旁；API spend 會在 session cost metadata 回報時聚合顯示。
+Grok 4.5 目前是 Grok Build 的預設模型。Grimoire 從已驗證的 Grok CLI 帳戶取得可用模型目錄，而不是維護靜態清單，因此模型可用性可能會因帳戶和 CLI 版本而異，並自動更新。
+
+在 Grimoire 中，Grok Build 透過 `grok agent stdio` 以 ACP 執行，使用 `.grimoire/grok/` 下的 Grimoire-managed launch artifacts，並支援 persistent runtime、native JSONL history hydration、plan mode、image input、provider commands、native models 上的 reasoning effort、rewind 和 fork。使用 OAuth 時，Grimoire 會顯示共用的每週 Grok 使用額度、重設時間以及可用的 Extra Usage Credits；API spend 會在 session cost metadata 回報時聚合顯示。
 
 ## 第一次聊天
 
@@ -283,7 +287,7 @@ Model selector 旁邊的 badge 會持續顯示目前 provider 的 usage；model 
 | OpenCode | 從 ACP 和 session cost metadata 聚合的 monthly spend |
 | MiMoCode | 從 ACP 和 session cost metadata 聚合的 monthly spend |
 | Kimi Code | 從 ACP 和 session cost metadata 聚合的 monthly spend |
-| Grok Build | OAuth auth 可用時來自 grok.com billing 的 SuperGrok credit windows；來自 session cost metadata 的 monthly API spend |
+| Grok Build | 透過 OAuth 顯示共用的每週 Grok 使用額度、重設時間和 Extra Usage Credits；來自 session cost metadata 的 monthly API spend |
 
 ### Plan mode
 


### PR DESCRIPTION
## Problem

The README still described Grok Build in terms of the older SuperGrok credit windows and did not explain the current Grok 4.5 model or Grimoire's dynamic model discovery.

## Root Cause

xAI now documents Grok 4.5 as the default model powering Grok Build and describes usage as a unified weekly pool shared across Grok products. The repository documentation had not yet been reconciled with those current product semantics.

## Approach

- explain Grok 4.5 and dynamic model-catalog discovery from the authenticated CLI
- document OAuth, xAI API-key fallback, shared weekly usage, reset timing, and Extra Usage Credits
- link directly to the official Grok Build, Grok 4.5, and Grok usage documentation
- apply the same update to English, German, Spanish, French, Japanese, Russian, Simplified Chinese, and Traditional Chinese READMEs

## Architecture

- [x] Provider-native behavior remains inside `src/providers/<provider>/`.
- [x] Shared code is provider-neutral and used by at least two providers, or the PR explains why it belongs there.
- [x] I checked sibling providers when changing a shared ACP or provider contract.

Architecture notes:

Documentation-only change. No runtime, provider, or shared contract changes.

## Security And Privacy

- [x] Provider/session/model data is treated as untrusted input.
- [x] Permission changes cannot silently widen persistent authorization.
- [x] Filesystem, process, credential, MCP, and external-path boundaries are unchanged or explained below.
- [x] Logs and fixtures contain no secrets, prompts, note contents, local paths, or unsanitized provider payloads.

Security notes:

No security boundary change. The new external references point only to official xAI documentation.

## Verification

Automated commands run:

```text
node structural parity check across all 8 README files
git diff --check
npm run lint
```

Manual verification:

Reviewed all localized sections for equivalent structure and links. No application workflow changed.

## Generated Artifacts

- [x] `main.js`, `styles.css`, and `dist/grimoire` match `npm run build:release` when source changes require them.
- [x] `package-lock.json` matches `package.json` when dependencies change.
- [x] No unrelated or local-only artifacts are included.

## Review Checklist

- [x] The PR is focused on one coherent problem.
- [x] Behavior changes have focused regression tests.
- [x] Protocol tests use real structured payloads and error codes.
- [x] Documentation and user-facing copy are in English.
- [x] The PR description accurately distinguishes automated tests from manual verification.
