### PR TITLE
fix(test): stop path.test realpathSync mock from leaking

### DIFF
--- a/tests/unit/utils/path.test.ts
+++ b/tests/unit/utils/path.test.ts
@@ -355,15 +355,21 @@ describe('isPathWithinDirectory', () => {
   });
 
   it('blocks symlink escapes from the allowed directory', () => {
-    const realpathMock = jest.fn((input: fsType.PathLike) => {
+    // Use spyOn (not property reassignment) so afterEach restoreAllMocks can
+    // put realpathSync back — reassignment leaked into later suites and broke
+    // resolveWorkspacePath symlink containment on shared CI workers.
+    const realpathImpl = (input: fsType.PathLike): string => {
       const value = String(input);
       if (value === '/home/test/.claude') return '/home/test/.claude';
       if (value === '/home/test/.claude/skills/link') return '/home/test/.ssh';
       return path.resolve(value);
+    };
+    const realpathSpy = jest.spyOn(fs, 'realpathSync').mockImplementation(realpathImpl as typeof fs.realpathSync);
+    Object.defineProperty(fs.realpathSync, 'native', {
+      configurable: true,
+      value: realpathSpy,
+      writable: true,
     });
-
-    (fs.realpathSync as any) = realpathMock;
-    (fs.realpathSync as any).native = realpathMock;
 
     expect(isPathWithinDirectory('/home/test/.claude/skills/link', '/home/test/.claude', '/vault')).toBe(false);
   });

--- a/tests/unit/utils/path.test.ts
+++ b/tests/unit/utils/path.test.ts
@@ -364,7 +364,7 @@ describe('isPathWithinDirectory', () => {
       if (value === '/home/test/.claude/skills/link') return '/home/test/.ssh';
       return path.resolve(value);
     };
-    const realpathSpy = jest.spyOn(fs, 'realpathSync').mockImplementation(realpathImpl as typeof fs.realpathSync);
+    const realpathSpy = jest.spyOn(fs, 'realpathSync').mockImplementation(realpathImpl);
     Object.defineProperty(fs.realpathSync, 'native', {
       configurable: true,
       value: realpathSpy,


### PR DESCRIPTION
## Summary
- Root cause of intermittent/order-dependent main CI failures in `resolveWorkspacePath` symlink containment.
- `tests/unit/utils/path.test.ts` reassigned `fs.realpathSync` with a mock; `jest.restoreAllMocks()` does **not** undo property reassignment, so later suites saw a fake `realpath` that never follows symlinks.
- Switched to `jest.spyOn` so restore works between files.

## Repro (before)
```bash
npx jest --selectProjects unit --runInBand --runTestsByPath \
  tests/unit/utils/path.test.ts \
  tests/unit/providers/acp/resolveWorkspacePath.test.ts
# resolveWorkspacePath symlink escape test fails: did not throw
```

## Test plan
- [x] Forced order: path.test then resolveWorkspacePath — both pass
- [x] Full unit suite `--runInBand` — 6892 passed
- [ ] CI green