### PR TITLE
feat(opencode): support WSL launches on Windows

### DIFF
--- a/src/app/settings/GrimoireSettingsStorage.ts
+++ b/src/app/settings/GrimoireSettingsStorage.ts
@@ -187,7 +187,7 @@ function normalizeProviderConfigs(value: unknown): ProviderConfigMap {
 const HOST_SCOPED_PROVIDER_CONFIG_FIELDS: Record<string, string[]> = {
   claude: ['cliPathsByHost'],
   codex: ['cliPathsByHost', 'installationMethodsByHost', 'wslDistroOverridesByHost'],
-  opencode: ['cliPathsByHost'],
+  opencode: ['cliPathsByHost', 'installationMethodsByHost', 'wslDistroOverridesByHost'],
 };
 
 function hasHostScopedProviderConfigNormalization(

--- a/src/providers/acp/AcpSubprocess.ts
+++ b/src/providers/acp/AcpSubprocess.ts
@@ -10,6 +10,9 @@ export interface AcpSubprocessLaunchSpec {
   command: string;
   cwd: string;
   env: NodeJS.ProcessEnv;
+  /** Explicit shell requirement. When set, overrides the Windows relative-command
+   * heuristic so native executables (e.g. wsl.exe) can be spawned directly. */
+  shell?: boolean;
 }
 
 type CloseListener = (error?: Error) => void;
@@ -50,7 +53,7 @@ export class AcpSubprocess {
     const proc = spawn(this.launchSpec.command, this.launchSpec.args, {
       cwd: this.launchSpec.cwd,
       env: this.launchSpec.env,
-      shell: shouldUseShell(this.launchSpec.command),
+      shell: this.launchSpec.shell ?? shouldUseShell(this.launchSpec.command),
       stdio: 'pipe',
       windowsHide: true,
     });

--- a/src/providers/opencode/runtime/OpencodeAuxQueryRunner.ts
+++ b/src/providers/opencode/runtime/OpencodeAuxQueryRunner.ts
@@ -22,6 +22,8 @@ import {
   type OpencodeManagedAgentConfig,
   prepareOpencodeLaunchArtifacts,
 } from './OpencodeLaunchArtifacts';
+import { buildOpencodeLaunchSpec } from './OpencodeLaunchSpecBuilder';
+import type { OpencodeLaunchSpec } from './opencodeLaunchTypes';
 import { buildOpencodeRuntimeEnv } from './OpencodeRuntimeEnvironment';
 
 type OpencodeAuxAgentProfile = 'passive' | 'readonly';
@@ -50,6 +52,7 @@ export class OpencodeAuxQueryRunner implements AuxQueryRunner {
   private connection: AcpClientConnection | null = null;
   private currentModelId: string | null = null;
   private currentLaunchKey: string | null = null;
+  private launchSpec: OpencodeLaunchSpec | null = null;
   private process: AcpSubprocess | null = null;
   private readonly sessionCwds = new Map<string, string>();
   private sessionId: string | null = null;
@@ -154,6 +157,7 @@ export class OpencodeAuxQueryRunner implements AuxQueryRunner {
     this.sessionCwds.clear();
     this.currentModelId = null;
     this.currentLaunchKey = null;
+    this.launchSpec = null;
     this.connection?.dispose();
     this.connection = null;
     this.transport?.dispose();
@@ -170,6 +174,12 @@ export class OpencodeAuxQueryRunner implements AuxQueryRunner {
 
     const settings = this.plugin.settings as unknown as Record<string, unknown>;
     const runtimeEnv = buildOpencodeRuntimeEnv(settings, resolvedCliPath);
+    const artifactLaunchSpec = buildOpencodeLaunchSpec({
+      settings: this.plugin.settings,
+      resolvedCliCommand: resolvedCliPath,
+      hostVaultPath: cwd,
+      env: runtimeEnv,
+    });
     const auxAgentId = OPENCODE_AUX_AGENT_IDS[this.options.agentProfile];
     const artifacts = await prepareOpencodeLaunchArtifacts({
       artifactsSubdir: `opencode/auxiliary/${this.options.artifactPurpose}`,
@@ -178,13 +188,24 @@ export class OpencodeAuxQueryRunner implements AuxQueryRunner {
       runtimeEnv,
       systemPromptKey: systemPrompt,
       systemPromptText: systemPrompt,
+      targetPathMapper: (hostPath) => artifactLaunchSpec.pathMapper.toTargetPath(hostPath),
       userName: typeof settings.userName === 'string' ? settings.userName : undefined,
       workspaceRoot: cwd,
     });
+    const launchRuntimeEnv = buildOpencodeRuntimeEnv(settings, resolvedCliPath, artifacts.databasePath);
+    const launchSpec = buildOpencodeLaunchSpec({
+      settings: this.plugin.settings,
+      resolvedCliCommand: resolvedCliPath,
+      hostVaultPath: cwd,
+      env: launchRuntimeEnv,
+    });
     const nextLaunchKey = JSON.stringify({
       artifactKey: artifacts.launchKey,
-      command: resolvedCliPath,
-      configPath: artifacts.configPath,
+      command: launchSpec.command,
+      args: launchSpec.args,
+      spawnCwd: launchSpec.spawnCwd,
+      targetCwd: launchSpec.targetCwd,
+      target: launchSpec.target,
       envText: getRuntimeEnvironmentText(settings, 'opencode'),
     });
 
@@ -201,11 +222,9 @@ export class OpencodeAuxQueryRunner implements AuxQueryRunner {
 
     this.reset();
     await this.startProcess({
-      command: resolvedCliPath,
+      launchSpec,
       configPath: artifacts.configPath,
       configContent: artifacts.configContent,
-      cwd,
-      runtimeEnv,
     });
     this.currentLaunchKey = nextLaunchKey;
   }
@@ -217,7 +236,7 @@ export class OpencodeAuxQueryRunner implements AuxQueryRunner {
 
     try {
       const response = await this.connection.newSession({
-        cwd,
+        cwd: this.launchSpec?.targetCwd ?? cwd,
         mcpServers: [],
       });
       this.syncSessionModelState({
@@ -239,25 +258,32 @@ export class OpencodeAuxQueryRunner implements AuxQueryRunner {
   }
 
   private async startProcess(params: {
-    command: string;
+    launchSpec: OpencodeLaunchSpec;
     configPath: string;
     configContent: string;
-    cwd: string;
-    runtimeEnv: NodeJS.ProcessEnv;
   }): Promise<void> {
+    const { launchSpec } = params;
+    const targetConfigPath = launchSpec.pathMapper.toTargetPath(params.configPath) ?? params.configPath;
     const processEnv: NodeJS.ProcessEnv = {
       ...process.env,
-      ...params.runtimeEnv,
-      OPENCODE_CONFIG: params.configPath,
+      ...launchSpec.env,
+      OPENCODE_CONFIG: targetConfigPath,
       OPENCODE_CONFIG_CONTENT: params.configContent,
-      PATH: params.runtimeEnv.PATH,
     };
 
+    if (launchSpec.target.method === 'wsl') {
+      delete processEnv.PATH;
+    } else {
+      processEnv.PATH = launchSpec.env.PATH;
+    }
+    this.launchSpec = launchSpec;
+
     this.process = new AcpSubprocess({
-      args: ['acp'],
-      command: params.command,
-      cwd: params.cwd,
+      args: [...launchSpec.args],
+      command: launchSpec.command,
+      cwd: launchSpec.spawnCwd,
       env: processEnv,
+      shell: launchSpec.shell,
     });
     this.process.start();
 
@@ -365,7 +391,8 @@ export class OpencodeAuxQueryRunner implements AuxQueryRunner {
     const cwd = this.sessionCwds.get(sessionId)
       ?? getVaultPath(this.plugin.app)
       ?? process.cwd();
-    return resolveWorkspacePath(cwd, rawPath, {
+    const hostPath = this.launchSpec?.pathMapper.toHostPath(rawPath) ?? rawPath;
+    return resolveWorkspacePath(cwd, hostPath, {
       containmentMessage: 'OpenCode aux read access is limited to the current workspace.',
     });
   }

--- a/src/providers/opencode/runtime/OpencodeChatRuntime.ts
+++ b/src/providers/opencode/runtime/OpencodeChatRuntime.ts
@@ -97,6 +97,8 @@ import { getOpencodeProviderSettings, updateOpencodeProviderSettings } from '../
 import { getOpencodeState, type OpencodeProviderState } from '../types';
 import { buildOpencodePromptBlocks, buildOpencodePromptText } from './buildOpencodePrompt';
 import { prepareOpencodeLaunchArtifacts } from './OpencodeLaunchArtifacts';
+import { buildOpencodeLaunchSpec } from './OpencodeLaunchSpecBuilder';
+import type { OpencodeLaunchSpec } from './opencodeLaunchTypes';
 import { buildOpencodeRuntimeEnv } from './OpencodeRuntimeEnvironment';
 
 interface ActiveTurn {
@@ -170,6 +172,7 @@ export class OpencodeChatRuntime implements ChatRuntime {
   private currentTurnSawAcpCost = false;
   private currentTurnMetadata: ChatTurnMetadata = {};
   private cleanupPromise: Promise<void> | null = null;
+  private launchSpec: OpencodeLaunchSpec | null = null;
   private lifecycleGeneration = 0;
   private loadedSessionId: string | null = null;
   private permissionModeSyncCallback: ((mode: string) => void) | null = null;
@@ -228,7 +231,7 @@ export class OpencodeChatRuntime implements ChatRuntime {
       this.currentSessionEffortValues = new Set<string>();
       this.currentSessionModelId = null;
       this.currentSessionModeId = null;
-      this.sessionInvalidated = false;
+      this.launchSpec = null;
       this.setSupportedCommands([]);
     }
     this.sessionId = nextSessionId;
@@ -301,10 +304,17 @@ export class OpencodeChatRuntime implements ChatRuntime {
       resolvedCliPath,
       this.currentDatabasePath,
     );
+    const artifactLaunchSpec = buildOpencodeLaunchSpec({
+      settings: this.plugin.settings,
+      resolvedCliCommand: resolvedCliPath,
+      hostVaultPath: cwd,
+      env: runtimeEnv,
+    });
     const promptSettings = this.getSystemPromptSettings(cwd);
     const artifacts = await prepareOpencodeLaunchArtifacts({
       runtimeEnv,
       settings: promptSettings,
+      targetPathMapper: (hostPath) => artifactLaunchSpec.pathMapper.toTargetPath(hostPath),
       workspaceRoot: cwd,
     });
     if (lifecycleGeneration !== this.lifecycleGeneration) {
@@ -312,12 +322,26 @@ export class OpencodeChatRuntime implements ChatRuntime {
     }
     this.currentDatabasePath = artifacts.databasePath;
 
+    const launchRuntimeEnv = this.buildRuntimeEnv(
+      resolvedCliPath,
+      artifacts.databasePath,
+    );
+    const launchSpec = buildOpencodeLaunchSpec({
+      settings: this.plugin.settings,
+      resolvedCliCommand: resolvedCliPath,
+      hostVaultPath: cwd,
+      env: launchRuntimeEnv,
+    });
+
     const nextLaunchKey = JSON.stringify({
-      command: resolvedCliPath,
-      configPath: artifacts.configPath,
+      artifactKey: artifacts.launchKey,
+      command: launchSpec.command,
+      args: launchSpec.args,
+      spawnCwd: launchSpec.spawnCwd,
+      targetCwd: launchSpec.targetCwd,
+      target: launchSpec.target,
       envText: getRuntimeEnvironmentText(this.plugin.settings, 'opencode'),
       promptKey: computeSystemPromptKey(promptSettings),
-      artifactKey: artifacts.launchKey,
     });
 
     const shouldRestart = !this.process
@@ -334,10 +358,8 @@ export class OpencodeChatRuntime implements ChatRuntime {
         return false;
       }
       await this.startProcess({
-        command: resolvedCliPath,
+        launchSpec,
         configPath: artifacts.configPath,
-        cwd,
-        runtimeEnv,
       });
       if (lifecycleGeneration !== this.lifecycleGeneration) {
         await this.cleanupPromise;
@@ -345,6 +367,8 @@ export class OpencodeChatRuntime implements ChatRuntime {
       }
       this.currentLaunchKey = nextLaunchKey;
       this.loadedSessionId = null;
+    } else {
+      this.launchSpec = launchSpec;
     }
 
     if (targetSessionId) {
@@ -380,7 +404,13 @@ export class OpencodeChatRuntime implements ChatRuntime {
 
     const lifecycleGeneration = this.lifecycleGeneration;
     if (!(await this.ensureReadyForQuery(lifecycleGeneration))) {
-      yield { type: 'error', content: 'Failed to start OpenCode. Check the CLI path and login state.' };
+      const stderr = this.process?.getStderrSnapshot();
+      yield {
+        type: 'error',
+        content: stderr
+          ? `${t('chat.ui.errors.provider.startFailed', { provider: ProviderRegistry.getProviderDisplayNameOrId('opencode') })}\n\n${stderr}`
+          : t('chat.ui.errors.provider.startFailed', { provider: ProviderRegistry.getProviderDisplayNameOrId('opencode') }),
+      };
       yield { type: 'done' };
       return;
     }
@@ -663,26 +693,33 @@ export class OpencodeChatRuntime implements ChatRuntime {
   }
 
   private async startProcess(params: {
-    command: string;
+    launchSpec: OpencodeLaunchSpec;
     configPath: string;
-    cwd: string;
-    runtimeEnv: NodeJS.ProcessEnv;
   }): Promise<void> {
+    const { launchSpec } = params;
+    const targetConfigPath = launchSpec.pathMapper.toTargetPath(params.configPath) ?? params.configPath;
     const processEnv: NodeJS.ProcessEnv = {
       ...process.env,
-      ...params.runtimeEnv,
-      OPENCODE_CONFIG: params.configPath,
-      PATH: getEnhancedPath(
-        params.runtimeEnv.PATH,
-        path.isAbsolute(params.command) ? params.command : undefined,
-      ),
+      ...launchSpec.env,
+      OPENCODE_CONFIG: targetConfigPath,
     };
 
+    if (launchSpec.target.method === 'wsl') {
+      delete processEnv.PATH;
+    } else {
+      processEnv.PATH = getEnhancedPath(
+        launchSpec.env.PATH,
+        path.isAbsolute(launchSpec.command) ? launchSpec.command : undefined,
+      );
+    }
+    this.launchSpec = launchSpec;
+
     this.process = new AcpSubprocess({
-      args: ['acp'],
-      command: params.command,
-      cwd: params.cwd,
+      args: [...launchSpec.args],
+      command: launchSpec.command,
+      cwd: launchSpec.spawnCwd,
       env: processEnv,
+      shell: launchSpec.shell,
     });
     this.process.start();
 
@@ -1175,7 +1212,7 @@ export class OpencodeChatRuntime implements ChatRuntime {
     try {
       this.setSupportedCommands([]);
       const response = await this.connection.newSession({
-        cwd,
+        cwd: this.launchSpec?.targetCwd ?? cwd,
         mcpServers: [],
       });
       this.sessionInvalidated = false;
@@ -1204,7 +1241,7 @@ export class OpencodeChatRuntime implements ChatRuntime {
     try {
       this.setSupportedCommands([]);
       const response = await this.connection.loadSession({
-        cwd,
+        cwd: this.launchSpec?.targetCwd ?? cwd,
         mcpServers: [],
         sessionId,
       });
@@ -1425,11 +1462,12 @@ export class OpencodeChatRuntime implements ChatRuntime {
     const cwd = this.sessionCwds.get(sessionId)
       ?? getVaultPath(this.plugin.app)
       ?? process.cwd();
+    const hostPath = this.launchSpec?.pathMapper.toHostPath(rawPath) ?? rawPath;
     // Active (full-access) mode opts into unrestricted file access; safe and
     // plan modes confine ACP-delegated reads/writes to the session workspace.
     const allowOutsideWorkspace =
       coercePermissionMode(this.getProviderSettings().permissionMode) === 'full_access';
-    return resolveWorkspacePath(cwd, rawPath, { allowOutsideWorkspace });
+    return resolveWorkspacePath(cwd, hostPath, { allowOutsideWorkspace });
   }
 
   private formatRuntimeError(error: unknown): string {

--- a/src/providers/opencode/runtime/OpencodeCliResolver.ts
+++ b/src/providers/opencode/runtime/OpencodeCliResolver.ts
@@ -1,15 +1,31 @@
 import * as fs from 'node:fs';
 
 import { getRuntimeEnvironmentText } from '../../../core/providers/providerEnvironment';
+import type { HostnameCliPaths } from '../../../core/types/settings';
 import { getHostnameKey } from '../../../utils/env';
 import { expandHomePath } from '../../../utils/path';
-import { getOpencodeProviderSettings } from '../settings';
+import {
+  getOpencodeProviderSettings,
+  type OpencodeInstallationMethod,
+} from '../settings';
+
+function isWindowsStyleCliReference(value: string | null | undefined): boolean {
+  const trimmed = (value ?? '').trim();
+  if (!trimmed) {
+    return false;
+  }
+
+  return /^[A-Za-z]:[\\/]/.test(trimmed)
+    || trimmed.startsWith('\\\\')
+    || /\.(?:exe|cmd|bat|ps1)$/i.test(trimmed);
+}
 
 export class OpencodeCliResolver {
   private readonly cachedHostname = getHostnameKey();
   private lastCliPath = '';
   private lastHostnamePath = '';
   private lastEnvText = '';
+  private lastInstallationMethod = '';
   private resolvedPath: string | null = null;
 
   resolveFromSettings(settings: Record<string, unknown>): string | null {
@@ -17,12 +33,14 @@ export class OpencodeCliResolver {
     const cliPath = opencodeSettings.cliPath.trim();
     const hostnamePath = (opencodeSettings.cliPathsByHost[this.cachedHostname] ?? '').trim();
     const envText = getRuntimeEnvironmentText(settings, 'opencode');
+    const installationMethod = opencodeSettings.installationMethod;
 
     if (
       this.resolvedPath !== null
       && cliPath === this.lastCliPath
       && hostnamePath === this.lastHostnamePath
       && envText === this.lastEnvText
+      && installationMethod === this.lastInstallationMethod
     ) {
       return this.resolvedPath;
     }
@@ -30,20 +48,37 @@ export class OpencodeCliResolver {
     this.lastCliPath = cliPath;
     this.lastHostnamePath = hostnamePath;
     this.lastEnvText = envText;
+    this.lastInstallationMethod = installationMethod;
     this.resolvedPath = this.resolve(
       opencodeSettings.cliPathsByHost,
       cliPath,
       envText,
+      {
+        installationMethod,
+      },
     );
     return this.resolvedPath;
   }
 
   resolve(
-    hostnamePaths: Record<string, string> | undefined,
+    hostnamePaths: HostnameCliPaths | undefined,
     legacyPath: string,
     _envText: string,
+    options: {
+      installationMethod?: OpencodeInstallationMethod;
+      hostPlatform?: NodeJS.Platform;
+    } = {},
   ): string | null {
+    const hostPlatform = options.hostPlatform ?? process.platform;
     const hostnamePath = (hostnamePaths?.[this.cachedHostname] ?? '').trim();
+
+    if (hostPlatform === 'win32' && options.installationMethod === 'wsl') {
+      const configuredCommand = [hostnamePath, legacyPath]
+        .map(value => (value ?? '').trim())
+        .find(value => value.length > 0 && !isWindowsStyleCliReference(value));
+      return configuredCommand || 'opencode';
+    }
+
     return resolveConfiguredCliPath(hostnamePath) ?? resolveConfiguredCliPath(legacyPath.trim());
   }
 
@@ -51,6 +86,7 @@ export class OpencodeCliResolver {
     this.lastCliPath = '';
     this.lastHostnamePath = '';
     this.lastEnvText = '';
+    this.lastInstallationMethod = '';
     this.resolvedPath = null;
   }
 }

--- a/src/providers/opencode/runtime/OpencodeExecutionTargetResolver.ts
+++ b/src/providers/opencode/runtime/OpencodeExecutionTargetResolver.ts
@@ -1,0 +1,139 @@
+import { execFileSync } from 'child_process';
+
+import { resolveWslExecutablePath } from '@/utils/env';
+
+import { getOpencodeProviderSettings } from '../settings';
+import type {
+  OpencodeExecutionPlatformFamily,
+  OpencodeExecutionPlatformOs,
+  OpencodeExecutionTarget,
+  OpencodeWslHostFlavor,
+} from './opencodeLaunchTypes';
+
+export interface ResolveOpencodeExecutionTargetOptions {
+  settings: Record<string, unknown>;
+  hostPlatform?: NodeJS.Platform;
+  hostVaultPath?: string | null;
+  resolveDefaultWslDistro?: () => string | undefined;
+}
+
+function resolveHostPlatformOs(hostPlatform: NodeJS.Platform): OpencodeExecutionPlatformOs {
+  if (hostPlatform === 'win32') {
+    return 'windows';
+  }
+
+  if (hostPlatform === 'darwin') {
+    return 'macos';
+  }
+
+  return 'linux';
+}
+
+function resolveHostPlatformFamily(hostPlatform: NodeJS.Platform): OpencodeExecutionPlatformFamily {
+  return hostPlatform === 'win32' ? 'windows' : 'unix';
+}
+
+function inferWslHostFlavorFromWindowsPath(
+  hostPath: string | null | undefined,
+): OpencodeWslHostFlavor | undefined {
+  if (!hostPath) {
+    return undefined;
+  }
+
+  const normalized = hostPath.replace(/\//g, '\\');
+  if (/^\\\\wsl\.localhost\\/i.test(normalized)) {
+    return 'wsl.localhost';
+  }
+
+  if (/^\\\\wsl\$\\/i.test(normalized)) {
+    return 'wsl$';
+  }
+
+  return undefined;
+}
+
+export function inferWslDistroFromWindowsPath(hostPath: string | null | undefined): string | undefined {
+  if (!hostPath) {
+    return undefined;
+  }
+
+  const normalized = hostPath.replace(/\//g, '\\');
+  const match = normalized.match(/^\\\\wsl(?:\.localhost|\$)\\([^\\]+)(?:\\|$)/i);
+  return match?.[1] || undefined;
+}
+
+export function parseDefaultWslDistroListOutput(output: string): string | undefined {
+  for (const line of output.replace(/\uFEFF/g, '').split(/\r?\n/)) {
+    const trimmed = line.trimStart();
+    if (!trimmed.startsWith('*')) {
+      continue;
+    }
+
+    const candidate = trimmed.slice(1).trimStart().split(/\s{2,}/)[0]?.trim();
+    if (candidate) {
+      return candidate;
+    }
+  }
+
+  return undefined;
+}
+
+export function decodeWslListOutput(raw: Buffer): string {
+  // wsl.exe writes UTF-16LE (with a BOM) when stdout is redirected instead of
+  // a console. WSL_UTF8=1 makes newer builds emit UTF-8, but older builds
+  // ignore it, so detect the BOM and decode accordingly.
+  if (raw.length >= 2 && raw[0] === 0xff && raw[1] === 0xfe) {
+    return raw.subarray(2).toString('utf16le');
+  }
+
+  return raw.toString('utf8');
+}
+
+function resolveDefaultWslDistroName(): string | undefined {
+  try {
+    const output = execFileSync(resolveWslExecutablePath(), ['--list', '--verbose'], {
+      env: { ...process.env, WSL_UTF8: '1' },
+      stdio: ['ignore', 'pipe', 'ignore'],
+      windowsHide: true,
+    });
+    return parseDefaultWslDistroListOutput(decodeWslListOutput(output));
+  } catch {
+    return undefined;
+  }
+}
+
+export function resolveOpencodeExecutionTarget(
+  options: ResolveOpencodeExecutionTargetOptions,
+): OpencodeExecutionTarget {
+  const hostPlatform = options.hostPlatform ?? process.platform;
+  if (hostPlatform !== 'win32') {
+    return {
+      method: 'host-native',
+      platformFamily: resolveHostPlatformFamily(hostPlatform),
+      platformOs: resolveHostPlatformOs(hostPlatform),
+    };
+  }
+
+  const opencodeSettings = getOpencodeProviderSettings(options.settings);
+  if (opencodeSettings.installationMethod === 'wsl') {
+    const wslHostFlavor = inferWslHostFlavorFromWindowsPath(options.hostVaultPath);
+    const distroName = opencodeSettings.wslDistroOverride
+      || inferWslDistroFromWindowsPath(options.hostVaultPath)
+      || options.resolveDefaultWslDistro?.()
+      || resolveDefaultWslDistroName();
+
+    return {
+      method: 'wsl',
+      platformFamily: 'unix',
+      platformOs: 'linux',
+      distroName,
+      wslHostFlavor,
+    };
+  }
+
+  return {
+    method: 'native-windows',
+    platformFamily: 'windows',
+    platformOs: 'windows',
+  };
+}

--- a/src/providers/opencode/runtime/OpencodeLaunchArtifacts.ts
+++ b/src/providers/opencode/runtime/OpencodeLaunchArtifacts.ts
@@ -65,6 +65,7 @@ export interface PrepareOpencodeLaunchArtifactsParams {
   settings?: SystemPromptSettings;
   systemPromptKey?: string;
   systemPromptText?: string;
+  targetPathMapper?: (hostPath: string) => string | null;
   userName?: string;
   workspaceRoot: string;
 }
@@ -79,6 +80,7 @@ export async function prepareOpencodeLaunchArtifacts(
   );
   const systemPromptPath = path.join(artifactsDir, 'system.md');
   const configPath = path.join(artifactsDir, 'config.json');
+  const targetSystemPromptPath = params.targetPathMapper?.(systemPromptPath) ?? systemPromptPath;
   const systemPrompt = normalizeSystemPrompt(
     params.systemPromptText ?? buildSystemPrompt(requireSettings(params)),
   );
@@ -93,7 +95,7 @@ export async function prepareOpencodeLaunchArtifacts(
   const configContent = `${JSON.stringify(
     buildOpencodeManagedConfig(
       baseConfig,
-      systemPromptPath,
+      targetSystemPromptPath,
       params.userName ?? params.settings?.userName,
       params.managedAgents,
       params.defaultAgentId,

--- a/src/providers/opencode/runtime/OpencodeLaunchSpecBuilder.ts
+++ b/src/providers/opencode/runtime/OpencodeLaunchSpecBuilder.ts
@@ -1,0 +1,119 @@
+import { resolveWslExecutablePath } from '@/utils/env';
+
+import {
+  inferWslDistroFromWindowsPath,
+  resolveOpencodeExecutionTarget,
+} from './OpencodeExecutionTargetResolver';
+import type {
+  OpencodeExecutionTarget,
+  OpencodeLaunchSpec,
+  OpencodePathMapper,
+} from './opencodeLaunchTypes';
+import { createOpencodePathMapper } from './OpencodePathMapper';
+
+export interface BuildOpencodeLaunchSpecOptions {
+  settings: Record<string, unknown>;
+  resolvedCliCommand: string | null;
+  hostVaultPath: string | null;
+  env: NodeJS.ProcessEnv;
+  hostPlatform?: NodeJS.Platform;
+  resolveDefaultWslDistro?: () => string | undefined;
+}
+
+const OPENCODE_ACP_ARGS = Object.freeze(['acp']);
+
+export function buildOpencodeLaunchSpec(
+  options: BuildOpencodeLaunchSpecOptions,
+): OpencodeLaunchSpec {
+  const target = resolveOpencodeExecutionTarget({
+    settings: options.settings,
+    hostPlatform: options.hostPlatform,
+    hostVaultPath: options.hostVaultPath,
+    resolveDefaultWslDistro: options.resolveDefaultWslDistro,
+  });
+  const pathMapper = createOpencodePathMapper(target);
+  const spawnCwd = options.hostVaultPath ?? process.cwd();
+
+  const workspaceDistro = inferWslDistroFromWindowsPath(options.hostVaultPath);
+  if (
+    target.method === 'wsl'
+    && target.distroName
+    && workspaceDistro
+    && target.distroName.toLowerCase() !== workspaceDistro.toLowerCase()
+  ) {
+    throw new Error(
+      `WSL distro override "${target.distroName}" does not match workspace distro "${workspaceDistro}"`,
+    );
+  }
+
+  if (target.method === 'wsl' && !target.distroName) {
+    throw new Error(
+      'Unable to determine the WSL distro. Set WSL distro override or configure a default WSL distro.',
+    );
+  }
+
+  const targetCwd = pathMapper.toTargetPath(spawnCwd);
+
+  if (!targetCwd) {
+    throw new Error('WSL mode only supports Windows drive paths and \\\\wsl$ or \\\\wsl.localhost workspace paths');
+  }
+
+  const env = mapOpencodePathEnv(options.env, pathMapper, target);
+
+  const resolvedCliCommand = options.resolvedCliCommand?.trim() || 'opencode';
+  if (target.method === 'wsl') {
+    const args = [
+      ...(target.distroName ? ['--distribution', target.distroName] : []),
+      '--cd',
+      targetCwd,
+      resolvedCliCommand,
+      ...OPENCODE_ACP_ARGS,
+    ];
+
+    return {
+      target,
+      command: resolveWslExecutablePath(options.env),
+      args,
+      spawnCwd,
+      targetCwd,
+      env,
+      pathMapper,
+      shell: false,
+    };
+  }
+
+  return {
+    target,
+    command: resolvedCliCommand,
+    args: [...OPENCODE_ACP_ARGS],
+    spawnCwd,
+    targetCwd,
+    env,
+    pathMapper,
+  };
+}
+
+function mapOpencodePathEnv(
+  env: NodeJS.ProcessEnv,
+  pathMapper: OpencodePathMapper,
+  target: OpencodeExecutionTarget,
+): NodeJS.ProcessEnv {
+  if (target.method !== 'wsl') {
+    return env;
+  }
+
+  const nextEnv = { ...env };
+  delete nextEnv.PATH;
+
+  const databasePath = env.OPENCODE_DB;
+  if (typeof databasePath !== 'string' || !databasePath) {
+    return nextEnv;
+  }
+
+  const targetDatabasePath = pathMapper.toTargetPath(databasePath);
+  if (!targetDatabasePath) {
+    return nextEnv;
+  }
+
+  return { ...nextEnv, OPENCODE_DB: targetDatabasePath };
+}

--- a/src/providers/opencode/runtime/OpencodePathMapper.ts
+++ b/src/providers/opencode/runtime/OpencodePathMapper.ts
@@ -1,0 +1,157 @@
+import * as path from 'path';
+
+import type {
+  OpencodeExecutionTarget,
+  OpencodePathMapper,
+  OpencodeWslHostFlavor,
+} from './opencodeLaunchTypes';
+
+function normalizeWindowsPath(value: string): string {
+  if (!value) {
+    return '';
+  }
+
+  let normalized = value.replace(/\//g, '\\');
+  if (normalized.startsWith('\\?\\UNC\\')) {
+    normalized = `\\${normalized.slice('\\?\\UNC\\'.length)}`;
+  } else if (normalized.startsWith('\\?\\')) {
+    normalized = normalized.slice('\\?\\'.length);
+  }
+
+  return path.win32.normalize(normalized);
+}
+
+function normalizePosixPath(value: string): string {
+  if (!value) {
+    return '';
+  }
+
+  const normalized = path.posix.normalize(value.replace(/\\/g, '/'));
+  return normalized === '/' ? normalized : normalized.replace(/\/+$/, '');
+}
+
+function maybeMapWindowsDriveToWsl(hostPath: string): string | null {
+  const normalized = normalizeWindowsPath(hostPath);
+  const match = normalized.match(/^([A-Za-z]):(?:\\(.*))?$/);
+  if (!match) {
+    return null;
+  }
+
+  const drive = match[1].toLowerCase();
+  const tail = (match[2] ?? '').replace(/\\/g, '/');
+  return tail ? `/mnt/${drive}/${tail}` : `/mnt/${drive}`;
+}
+
+function maybeMapWslUncToLinux(hostPath: string, distroName?: string): string | null {
+  const normalized = normalizeWindowsPath(hostPath);
+  const match = normalized.match(/^\\\\wsl(?:\.localhost|\$)\\([^\\]+)(?:\\(.*))?$/i);
+  if (!match) {
+    return null;
+  }
+
+  const uncDistro = match[1];
+  if (distroName && uncDistro.toLowerCase() !== distroName.toLowerCase()) {
+    return null;
+  }
+
+  const tail = match[2] ? match[2].replace(/\\/g, '/') : '';
+  return tail ? `/${tail}` : '/';
+}
+
+function maybeMapLinuxToWindowsDrive(targetPath: string): string | null {
+  const normalized = normalizePosixPath(targetPath);
+  const match = normalized.match(/^\/mnt\/([a-zA-Z])(?:\/(.*))?$/);
+  if (!match) {
+    return null;
+  }
+
+  const drive = match[1].toUpperCase();
+  const tail = match[2] ? match[2].replace(/\//g, '\\') : '';
+  return tail ? `${drive}:\\${tail}` : `${drive}:\\`;
+}
+
+function maybeMapLinuxToWslUnc(
+  targetPath: string,
+  distroName?: string,
+  hostFlavor: OpencodeWslHostFlavor = 'wsl$',
+): string | null {
+  if (!distroName) {
+    return null;
+  }
+
+  const normalized = normalizePosixPath(targetPath);
+  if (!normalized.startsWith('/')) {
+    return null;
+  }
+
+  const tail = normalized === '/' ? '' : normalized.slice(1).replace(/\//g, '\\');
+  return tail
+    ? `\\\\${hostFlavor}\\${distroName}\\${tail}`
+    : `\\\\${hostFlavor}\\${distroName}`;
+}
+
+function createIdentityMapper(target: OpencodeExecutionTarget): OpencodePathMapper {
+  const toTargetPath = (hostPath: string): string | null => {
+    if (!hostPath) {
+      return null;
+    }
+
+    return target.platformFamily === 'windows'
+      ? normalizeWindowsPath(hostPath)
+      : normalizePosixPath(hostPath);
+  };
+
+  const toHostPath = (targetPath: string): string | null => {
+    if (!targetPath) {
+      return null;
+    }
+
+    return target.platformFamily === 'windows'
+      ? normalizeWindowsPath(targetPath)
+      : normalizePosixPath(targetPath);
+  };
+
+  return {
+    target,
+    toTargetPath,
+    toHostPath,
+    canRepresentHostPath(hostPath: string): boolean {
+      return toTargetPath(hostPath) !== null;
+    },
+  };
+}
+
+function createWslPathMapper(target: OpencodeExecutionTarget): OpencodePathMapper {
+  const toTargetPath = (hostPath: string): string | null => {
+    if (!hostPath) {
+      return null;
+    }
+
+    return maybeMapWslUncToLinux(hostPath, target.distroName)
+      ?? maybeMapWindowsDriveToWsl(hostPath);
+  };
+
+  const toHostPath = (targetPath: string): string | null => {
+    if (!targetPath) {
+      return null;
+    }
+
+    return maybeMapLinuxToWindowsDrive(targetPath)
+      ?? maybeMapLinuxToWslUnc(targetPath, target.distroName, target.wslHostFlavor ?? 'wsl$');
+  };
+
+  return {
+    target,
+    toTargetPath,
+    toHostPath,
+    canRepresentHostPath(hostPath: string): boolean {
+      return toTargetPath(hostPath) !== null;
+    },
+  };
+}
+
+export function createOpencodePathMapper(target: OpencodeExecutionTarget): OpencodePathMapper {
+  return target.method === 'wsl'
+    ? createWslPathMapper(target)
+    : createIdentityMapper(target);
+}

--- a/src/providers/opencode/runtime/opencodeLaunchTypes.ts
+++ b/src/providers/opencode/runtime/opencodeLaunchTypes.ts
@@ -1,0 +1,34 @@
+import type { OpencodeInstallationMethod } from '../settings';
+
+export type OpencodeExecutionMethod = 'host-native' | OpencodeInstallationMethod;
+export type OpencodeExecutionPlatformOs = 'windows' | 'linux' | 'macos';
+export type OpencodeExecutionPlatformFamily = 'windows' | 'unix';
+export type OpencodeWslHostFlavor = 'wsl$' | 'wsl.localhost';
+
+export interface OpencodeExecutionTarget {
+  method: OpencodeExecutionMethod;
+  platformFamily: OpencodeExecutionPlatformFamily;
+  platformOs: OpencodeExecutionPlatformOs;
+  distroName?: string;
+  wslHostFlavor?: OpencodeWslHostFlavor;
+}
+
+export interface OpencodePathMapper {
+  target: OpencodeExecutionTarget;
+  toTargetPath(hostPath: string): string | null;
+  toHostPath(targetPath: string): string | null;
+  canRepresentHostPath(hostPath: string): boolean;
+}
+
+export interface OpencodeLaunchSpec {
+  target: OpencodeExecutionTarget;
+  command: string;
+  args: string[];
+  spawnCwd: string;
+  targetCwd: string;
+  env: NodeJS.ProcessEnv;
+  pathMapper: OpencodePathMapper;
+  /** Whether the command must be spawned through a shell. Overrides AcpSubprocess's
+   * Windows relative-command heuristic (e.g. wsl.exe must be spawned directly). */
+  shell?: boolean;
+}

--- a/src/providers/opencode/settings.ts
+++ b/src/providers/opencode/settings.ts
@@ -27,17 +27,28 @@ import {
   type OpencodeMode,
 } from './modes';
 
+export type OpencodeInstallationMethod = 'native-windows' | 'wsl';
+export type HostnameInstallationMethods = Record<string, OpencodeInstallationMethod>;
+
+function normalizeOpencodeInstallationMethod(value: unknown): OpencodeInstallationMethod {
+  return value === 'wsl' ? 'wsl' : 'native-windows';
+}
+
 export interface PersistedOpencodeProviderSettings {
   cliPath: string;
   cliPathsByHost: HostnameCliPaths;
   enabled: boolean;
   environmentHash: string;
   environmentVariables: string;
+  installationMethod: OpencodeInstallationMethod;
+  installationMethodsByHost: HostnameInstallationMethods;
   modelAliases: Record<string, string>;
   preferredThinkingByModel: Record<string, string>;
   selectedMode: string;
   thinkingOptionsByModel: OpencodeThinkingOptionsByModel;
   visibleModels: string[];
+  wslDistroOverride: string;
+  wslDistroOverridesByHost: HostnameCliPaths;
 }
 
 export interface OpencodeProviderSettings extends PersistedOpencodeProviderSettings {
@@ -53,11 +64,15 @@ export const DEFAULT_OPENCODE_PROVIDER_SETTINGS: Readonly<PersistedOpencodeProvi
   enabled: false,
   environmentHash: '',
   environmentVariables: OPENCODE_DEFAULT_ENVIRONMENT_VARIABLES,
+  installationMethod: 'native-windows',
+  installationMethodsByHost: {},
   modelAliases: {},
   preferredThinkingByModel: {},
   selectedMode: '',
   thinkingOptionsByModel: {},
   visibleModels: [],
+  wslDistroOverride: '',
+  wslDistroOverridesByHost: {},
 });
 
 function normalizeHostnameCliPaths(value: unknown): HostnameCliPaths {
@@ -69,6 +84,20 @@ function normalizeHostnameCliPaths(value: unknown): HostnameCliPaths {
   for (const [key, entry] of Object.entries(value)) {
     if (typeof entry === 'string' && entry.trim()) {
       result[key] = entry.trim();
+    }
+  }
+  return result;
+}
+
+function normalizeInstallationMethodsByHost(value: unknown): HostnameInstallationMethods {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return {};
+  }
+
+  const result: HostnameInstallationMethods = {};
+  for (const [key, entry] of Object.entries(value)) {
+    if (typeof key === 'string' && key.trim()) {
+      result[key] = normalizeOpencodeInstallationMethod(entry);
     }
   }
   return result;
@@ -157,14 +186,41 @@ export function getOpencodeProviderSettings(
   settings: Record<string, unknown>,
 ): OpencodeProviderSettings {
   const config = getProviderConfig(settings, 'opencode');
+  const hostnameKey = getHostnameKey();
   const normalizedCliPathsByHost = normalizeHostnameCliPaths(config.cliPathsByHost);
-  const cliPathsByHost = Object.keys(normalizedCliPathsByHost).length > 0
-    ? migrateLegacyHostnameKeyedMap(
-      normalizedCliPathsByHost,
-      getHostnameKey(),
-      getLegacyHostnameKey(),
-    )
+  const normalizedInstallationMethodsByHost = normalizeInstallationMethodsByHost(
+    config.installationMethodsByHost,
+  );
+  const normalizedWslDistroOverridesByHost = normalizeHostnameCliPaths(
+    config.wslDistroOverridesByHost,
+  );
+  const hasLegacyHostnameKeyedSettings = Object.keys(normalizedCliPathsByHost).length > 0
+    || Object.keys(normalizedInstallationMethodsByHost).length > 0
+    || Object.keys(normalizedWslDistroOverridesByHost).length > 0;
+  const legacyHostnameKey = hasLegacyHostnameKeyedSettings ? getLegacyHostnameKey() : '';
+  const cliPathsByHost = hasLegacyHostnameKeyedSettings
+    ? migrateLegacyHostnameKeyedMap(normalizedCliPathsByHost, hostnameKey, legacyHostnameKey)
     : normalizedCliPathsByHost;
+  const installationMethodsByHost = hasLegacyHostnameKeyedSettings
+    ? migrateLegacyHostnameKeyedMap(
+      normalizedInstallationMethodsByHost,
+      hostnameKey,
+      legacyHostnameKey,
+    )
+    : normalizedInstallationMethodsByHost;
+  const wslDistroOverridesByHost = hasLegacyHostnameKeyedSettings
+    ? migrateLegacyHostnameKeyedMap(
+      normalizedWslDistroOverridesByHost,
+      hostnameKey,
+      legacyHostnameKey,
+    )
+    : normalizedWslDistroOverridesByHost;
+  const hasHostScopedInstallationMethods = Object.keys(installationMethodsByHost).length > 0;
+  const hasHostScopedWslDistroOverrides = Object.keys(wslDistroOverridesByHost).length > 0;
+  const legacyInstallationMethod = normalizeOpencodeInstallationMethod(config.installationMethod);
+  const legacyWslDistroOverride = typeof config.wslDistroOverride === 'string'
+    ? config.wslDistroOverride.trim()
+    : '';
   seedOpencodeDiscoveryStateFromLegacyConfig(settings, config);
   const discoveryState = getOpencodeDiscoveryState(settings);
   const availableModes = discoveryState.availableModes;
@@ -191,6 +247,13 @@ export function getOpencodeProviderSettings(
     environmentVariables: (config.environmentVariables as string | undefined)
       ?? getProviderEnvironmentVariables(settings, 'opencode')
       ?? DEFAULT_OPENCODE_PROVIDER_SETTINGS.environmentVariables,
+    installationMethod: installationMethodsByHost[hostnameKey]
+      ?? (
+        hasHostScopedInstallationMethods
+          ? DEFAULT_OPENCODE_PROVIDER_SETTINGS.installationMethod
+          : legacyInstallationMethod
+      ),
+    installationMethodsByHost,
     modelAliases: normalizeOpencodeModelAliases(config.modelAliases, discoveredModels),
     preferredThinkingByModel: normalizeOpencodePreferredThinkingByModel(
       config.preferredThinkingByModel,
@@ -199,6 +262,13 @@ export function getOpencodeProviderSettings(
     selectedMode: normalizeManagedOpencodeSelectedMode(config.selectedMode, availableModes),
     thinkingOptionsByModel,
     visibleModels: normalizeOpencodeVisibleModels(config.visibleModels, discoveredModels),
+    wslDistroOverride: wslDistroOverridesByHost[hostnameKey]
+      ?? (
+        hasHostScopedWslDistroOverrides
+          ? DEFAULT_OPENCODE_PROVIDER_SETTINGS.wslDistroOverride
+          : legacyWslDistroOverride
+      ),
+    wslDistroOverridesByHost,
   };
 }
 
@@ -244,6 +314,27 @@ export function updateOpencodeProviderSettings(
   const nextCliPathsByHost = 'cliPathsByHost' in updates
     ? normalizeHostnameCliPaths(updates.cliPathsByHost)
     : { ...current.cliPathsByHost };
+  const nextInstallationMethodsByHost = 'installationMethodsByHost' in updates
+    ? normalizeInstallationMethodsByHost(updates.installationMethodsByHost)
+    : { ...current.installationMethodsByHost };
+  const nextWslDistroOverridesByHost = 'wslDistroOverridesByHost' in updates
+    ? normalizeHostnameCliPaths(updates.wslDistroOverridesByHost)
+    : { ...current.wslDistroOverridesByHost };
+
+  if (
+    Object.keys(nextInstallationMethodsByHost).length === 0
+    && current.installationMethod !== DEFAULT_OPENCODE_PROVIDER_SETTINGS.installationMethod
+  ) {
+    nextInstallationMethodsByHost[hostnameKey] = current.installationMethod;
+  }
+
+  if (
+    Object.keys(nextWslDistroOverridesByHost).length === 0
+    && current.wslDistroOverride
+  ) {
+    nextWslDistroOverridesByHost[hostnameKey] = current.wslDistroOverride;
+  }
+
   let nextCliPath = 'cliPathsByHost' in updates
     ? (
       typeof updates.cliPath === 'string'
@@ -262,6 +353,23 @@ export function updateOpencodeProviderSettings(
     nextCliPath = DEFAULT_OPENCODE_PROVIDER_SETTINGS.cliPath;
   }
 
+  if ('installationMethod' in updates) {
+    nextInstallationMethodsByHost[hostnameKey] = normalizeOpencodeInstallationMethod(
+      updates.installationMethod,
+    );
+  }
+
+  if ('wslDistroOverride' in updates) {
+    const normalizedDistroOverride = typeof updates.wslDistroOverride === 'string'
+      ? updates.wslDistroOverride.trim()
+      : '';
+    if (normalizedDistroOverride) {
+      nextWslDistroOverridesByHost[hostnameKey] = normalizedDistroOverride;
+    } else {
+      delete nextWslDistroOverridesByHost[hostnameKey];
+    }
+  }
+
   const next: OpencodeProviderSettings = {
     ...current,
     ...updates,
@@ -269,6 +377,9 @@ export function updateOpencodeProviderSettings(
     cliPath: nextCliPath,
     cliPathsByHost: nextCliPathsByHost,
     discoveredModels: nextDiscoveredModels,
+    installationMethod: nextInstallationMethodsByHost[hostnameKey]
+      ?? DEFAULT_OPENCODE_PROVIDER_SETTINGS.installationMethod,
+    installationMethodsByHost: nextInstallationMethodsByHost,
     modelAliases: nextModelAliases,
     preferredThinkingByModel: normalizeOpencodePreferredThinkingByModel(
       updates.preferredThinkingByModel ?? current.preferredThinkingByModel,
@@ -277,6 +388,9 @@ export function updateOpencodeProviderSettings(
     selectedMode: nextSelectedMode,
     thinkingOptionsByModel: nextThinkingOptionsByModel,
     visibleModels: nextVisibleModels,
+    wslDistroOverride: nextWslDistroOverridesByHost[hostnameKey]
+      ?? DEFAULT_OPENCODE_PROVIDER_SETTINGS.wslDistroOverride,
+    wslDistroOverridesByHost: nextWslDistroOverridesByHost,
   };
 
   if (updates.visibleModels !== undefined) {
@@ -294,11 +408,13 @@ export function updateOpencodeProviderSettings(
     enabled: next.enabled,
     environmentHash: next.environmentHash,
     environmentVariables: next.environmentVariables,
+    installationMethodsByHost: next.installationMethodsByHost,
     modelAliases: next.modelAliases,
     preferredThinkingByModel: next.preferredThinkingByModel,
     selectedMode: next.selectedMode,
     thinkingOptionsByModel: persistedThinkingOptionsByModel,
     visibleModels: next.visibleModels,
+    wslDistroOverridesByHost: next.wslDistroOverridesByHost,
   });
 
   return next;

--- a/src/providers/opencode/ui/OpencodeSettingsTab.ts
+++ b/src/providers/opencode/ui/OpencodeSettingsTab.ts
@@ -42,6 +42,8 @@ export const opencodeSettingsTabRenderer: ProviderSettingsTabRenderer = {
     const settingsBag = context.plugin.settings as unknown as Record<string, unknown>;
     const opencodeSettings = getOpencodeProviderSettings(settingsBag);
     const hostnameKey = getHostnameKey();
+    const isWindowsHost = process.platform === 'win32';
+    let installationMethod = opencodeSettings.installationMethod;
 
     if (!opencodeSettings.enabled) {
       renderProviderDisabledNotice(container, 'OpenCode');
@@ -49,17 +51,69 @@ export const opencodeSettingsTabRenderer: ProviderSettingsTabRenderer = {
 
     new Setting(container).setName('Setup').setHeading();
 
+    if (isWindowsHost) {
+      new Setting(container)
+        .setName(t('settings.providerTabs.codex.installationMethod.name'))
+        .setDesc(t('settings.providerTabs.codex.installationMethod.desc').replace('Codex', 'OpenCode'))
+        .addDropdown((dropdown) => {
+          dropdown
+            .addOption('native-windows', t('settings.providerTabs.codex.installationMethod.nativeWindows'))
+            .addOption('wsl', 'WSL')
+            .setValue(installationMethod)
+            .onChange(async (value) => {
+              installationMethod = value === 'wsl' ? 'wsl' : 'native-windows';
+              updateOpencodeProviderSettings(settingsBag, { installationMethod });
+              refreshInstallationMethodUI();
+              await context.plugin.saveSettings();
+              await recycleOpencodeRuntime();
+            });
+        });
+    }
+
+    const getCliPathCopy = (): { desc: string; placeholder: string } => {
+      if (!isWindowsHost) {
+        return {
+          desc: t('settings.providerTabs.acp.cliPath.desc', {
+            command: 'opencode',
+            provider: 'OpenCode',
+          }),
+          placeholder: '/usr/local/bin/opencode',
+        };
+      }
+
+      if (installationMethod === 'wsl') {
+        return {
+          desc: t('settings.providerTabs.codex.cliPath.descWsl').replace('Codex', 'OpenCode').replace('codex', 'opencode'),
+          placeholder: 'opencode',
+        };
+      }
+
+      return {
+        desc: t('settings.providerTabs.codex.cliPath.descWindows').replace('Codex', 'OpenCode').replace('codex.exe', 'opencode.cmd'),
+        placeholder: 'C:\\Users\\you\\AppData\\Roaming\\npm\\opencode.cmd',
+      };
+    };
+
     const cliPathSetting = new Setting(container)
-      .setName('CLI path')
-      .setDesc('Optional absolute path to the OpenCode CLI for this computer. Leave empty to use `opencode` from PATH.');
+      .setName(t('settings.providerTabs.acp.cliPath.name', { provider: 'OpenCode' }))
+      .setDesc(getCliPathCopy().desc);
 
     const validationEl = container.createDiv({
       cls: 'grimoire-cli-path-validation grimoire-setting-validation grimoire-setting-validation-error grimoire-hidden',
     });
 
+    const shouldValidateCliPathAsFile = (): boolean => !isWindowsHost || installationMethod !== 'wsl';
+
     const validatePath = (value: string): string | null => {
       const trimmed = value.trim();
       if (!trimmed) {
+        return null;
+      }
+
+      if (!shouldValidateCliPathAsFile()) {
+        if (isWindowsStyleCliReference(trimmed)) {
+          return t('settings.providerTabs.codex.cliPath.wslValidation');
+        }
         return null;
       }
 
@@ -97,6 +151,23 @@ export const opencodeSettingsTabRenderer: ProviderSettingsTabRenderer = {
     const cliPathsByHost = { ...opencodeSettings.cliPathsByHost };
     const currentValue = opencodeSettings.cliPathsByHost[hostnameKey] || '';
     let cliPathInputEl: HTMLInputElement | null = null;
+    let wslDistroSettingEl: HTMLElement | null = null;
+    let wslDistroInputEl: HTMLInputElement | null = null;
+
+    const refreshInstallationMethodUI = (): void => {
+      const cliCopy = getCliPathCopy();
+      cliPathSetting.setDesc(cliCopy.desc);
+      if (cliPathInputEl) {
+        cliPathInputEl.placeholder = cliCopy.placeholder;
+        updateCliPathValidation(cliPathInputEl.value, cliPathInputEl);
+      }
+      if (wslDistroSettingEl) {
+        wslDistroSettingEl.toggleClass('grimoire-hidden', installationMethod !== 'wsl');
+      }
+      if (wslDistroInputEl) {
+        wslDistroInputEl.disabled = installationMethod !== 'wsl';
+      }
+    };
 
     const persistCliPath = async (value: string): Promise<boolean> => {
       const isValid = updateCliPathValidation(value, cliPathInputEl ?? undefined);
@@ -136,9 +207,7 @@ export const opencodeSettingsTabRenderer: ProviderSettingsTabRenderer = {
 
     cliPathSetting.addText((text) => {
       text
-        .setPlaceholder(process.platform === 'win32'
-          ? 'C:\\Users\\you\\AppData\\Roaming\\npm\\opencode.cmd'
-          : '/usr/local/bin/opencode')
+        .setPlaceholder(getCliPathCopy().placeholder)
         .setValue(currentValue)
         .onChange(async (value) => {
           await persistCliPath(value);
@@ -149,6 +218,30 @@ export const opencodeSettingsTabRenderer: ProviderSettingsTabRenderer = {
 
       updateCliPathValidation(currentValue, text.inputEl);
     });
+
+    if (isWindowsHost) {
+      const wslDistroSetting = new Setting(container)
+        .setName(t('settings.providerTabs.codex.wslDistro.name'))
+        .setDesc(t('settings.providerTabs.codex.wslDistro.desc'));
+
+      wslDistroSettingEl = wslDistroSetting.settingEl;
+      wslDistroSetting.addText((text) => {
+        text
+          .setPlaceholder('Ubuntu')
+          .setValue(opencodeSettings.wslDistroOverride)
+          .onChange(async (value) => {
+            updateOpencodeProviderSettings(settingsBag, { wslDistroOverride: value });
+            await context.plugin.saveSettings();
+            await recycleOpencodeRuntime();
+          });
+
+        text.inputEl.addClass('grimoire-settings-cli-path-input');
+        text.inputEl.disabled = installationMethod !== 'wsl';
+        wslDistroInputEl = text.inputEl;
+      });
+    }
+
+    refreshInstallationMethodUI();
 
     new Setting(container).setName('Models').setHeading();
 
@@ -623,6 +716,17 @@ export const opencodeSettingsTabRenderer: ProviderSettingsTabRenderer = {
     });
   },
 };
+
+function isWindowsStyleCliReference(value: string | null | undefined): boolean {
+  const trimmed = (value ?? '').trim();
+  if (!trimmed) {
+    return false;
+  }
+
+  return /^[A-Za-z]:[\\/]/.test(trimmed)
+    || trimmed.startsWith('\\\\')
+    || /\.(?:exe|cmd|bat|ps1)$/i.test(trimmed);
+}
 
 function buildEnrichedModels(
   discoveredModels: OpencodeDiscoveredModel[],

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -321,6 +321,49 @@ export function getEnhancedPath(additionalPaths?: string, cliPath?: string): str
   return unique.join(PATH_SEPARATOR);
 }
 
+function getEnvValueCaseInsensitive(
+  env: NodeJS.ProcessEnv,
+  ...names: string[]
+): string | undefined {
+  for (const name of names) {
+    const directValue = env[name];
+    if (directValue) {
+      return directValue;
+    }
+
+    const loweredName = name.toLowerCase();
+    for (const [key, value] of Object.entries(env)) {
+      if (value && key.toLowerCase() === loweredName) {
+        return value;
+      }
+    }
+  }
+
+  return undefined;
+}
+
+export function resolveWslExecutablePath(env: NodeJS.ProcessEnv = process.env): string {
+  const systemRoot = getEnvValueCaseInsensitive(env, 'SystemRoot', 'WINDIR');
+  if (systemRoot) {
+    const candidates = [
+      `${systemRoot}\\Sysnative\\wsl.exe`,
+      `${systemRoot}\\System32\\wsl.exe`,
+    ];
+    for (const candidate of candidates) {
+      try {
+        if (fs.existsSync(candidate)) {
+          return candidate;
+        }
+      } catch {
+        // Fall through to the next candidate or the deterministic fallback.
+      }
+    }
+
+    return candidates[1];
+  }
+  return 'wsl.exe';
+}
+
 export function parseEnvironmentVariables(input: string): Record<string, string> {
   const result: Record<string, string> = {};
   for (const line of input.split(/\r?\n/)) {

--- a/tests/unit/providers/acp/AcpSubprocess.test.ts
+++ b/tests/unit/providers/acp/AcpSubprocess.test.ts
@@ -82,6 +82,23 @@ describe('AcpSubprocess', () => {
     }));
   });
 
+  it('spawns relative Windows executables directly when the launch spec opts out of a shell', () => {
+    Object.defineProperty(process, 'platform', { value: 'win32' });
+    const mockProc = createMockProcess();
+    spawnMock.mockReturnValue(mockProc);
+
+    new AcpSubprocess({
+      ...createLaunchSpec(),
+      command: 'wsl.exe',
+      shell: false,
+    }).start();
+
+    expect(spawnMock).toHaveBeenCalledWith('wsl.exe', ['acp'], expect.objectContaining({
+      shell: false,
+      windowsHide: true,
+    }));
+  });
+
   it('keeps a hostile workspace path out of the .cmd command line and routes it via the cwd option', () => {
     Object.defineProperty(process, 'platform', { value: 'win32' });
     const mockProc = createMockProcess();

--- a/tests/unit/providers/opencode/OpencodeAcpLaunch.test.ts
+++ b/tests/unit/providers/opencode/OpencodeAcpLaunch.test.ts
@@ -17,6 +17,12 @@ import { prepareOpencodeLaunchArtifacts } from '@/providers/opencode/runtime/Ope
 
 import { AcpClientConnection, AcpJsonRpcTransport, AcpSubprocess } from '../../../../src/providers/acp';
 
+jest.mock('@/utils/env', () => ({
+  ...jest.requireActual('@/utils/env'),
+  getHostnameKey: () => 'host-a',
+  getLegacyHostnameKey: () => 'legacy-host',
+}));
+
 jest.mock('../../../../src/providers/acp', () => {
   const actual = jest.requireActual('../../../../src/providers/acp');
   return {
@@ -45,6 +51,12 @@ describe('OpenCode ACP launch', () => {
   let mockProcess: AcpLaunchMockProcess;
   let mockTransport: AcpLaunchMockTransport;
 
+  const originalPlatform = process.platform;
+
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', { value: originalPlatform });
+  });
+
   beforeEach(() => {
     jest.clearAllMocks();
     mockConnection = createAcpMockConnection();
@@ -69,6 +81,7 @@ describe('OpenCode ACP launch', () => {
   });
 
   it('does not pass the workspace path through OpenCode CLI arguments', async () => {
+    Object.defineProperty(process, 'platform', { value: 'win32' });
     const runtime = new OpencodeChatRuntime(createAcpLaunchMockPlugin({
       cliPath: 'C:\\Tools\\opencode.exe',
       providerId: 'opencode',
@@ -85,5 +98,76 @@ describe('OpenCode ACP launch', () => {
       cwd: WINDOWS_UNICODE_VAULT,
       mcpServers: [],
     });
+  });
+
+  it('spawns WSL launches from the host vault cwd while keeping the session cwd in WSL form', async () => {
+    Object.defineProperty(process, 'platform', { value: 'win32' });
+    const plugin = createAcpLaunchMockPlugin({
+      cliPath: 'opencode',
+      providerId: 'opencode',
+    });
+    plugin.settings.providerConfigs.opencode = {
+      enabled: true,
+      installationMethodsByHost: { 'host-a': 'wsl' },
+      wslDistroOverridesByHost: { 'host-a': 'Ubuntu' },
+    };
+    const runtime = new OpencodeChatRuntime(plugin);
+
+    await expect(runtime.ensureReady()).resolves.toBe(true);
+
+    expect(MockAcpSubprocess).toHaveBeenCalledWith(expect.objectContaining({
+      args: ['--distribution', 'Ubuntu', '--cd', '/mnt/c/Users/Name/OneDrive - 公司/Vault 中文 (test)', 'opencode', 'acp'],
+      command: expect.stringMatching(/wsl\.exe$/i),
+      cwd: WINDOWS_UNICODE_VAULT,
+      shell: false,
+    }));
+    expect(mockConnection.newSession).toHaveBeenCalledWith({
+      cwd: '/mnt/c/Users/Name/OneDrive - 公司/Vault 中文 (test)',
+      mcpServers: [],
+    });
+    expect(MockAcpSubprocess.mock.calls.at(-1)?.[0].env.PATH).toBeUndefined();
+  });
+
+  it('preserves a \\wsl.localhost workspace path when mapping WSL session paths back to the host', async () => {
+    Object.defineProperty(process, 'platform', { value: 'win32' });
+    const wslLocalhostVault = '\\\\wsl.localhost\\Ubuntu\\home\\user\\Vault';
+    const plugin = createAcpLaunchMockPlugin({
+      cliPath: 'opencode',
+      providerId: 'opencode',
+      vaultPath: wslLocalhostVault,
+    });
+    plugin.settings.providerConfigs.opencode = {
+      enabled: true,
+      installationMethodsByHost: { 'host-a': 'wsl' },
+      wslDistroOverridesByHost: { 'host-a': 'Ubuntu' },
+    };
+    mockPrepareOpencodeLaunchArtifacts.mockResolvedValue({
+      configPath: `${wslLocalhostVault}\\.grimoire\\opencode\\config.json`,
+      configContent: '{}\n',
+      databasePath: null,
+      launchKey: 'launch-key',
+      systemPromptPath: `${wslLocalhostVault}\\.grimoire\\opencode\\system.md`,
+    });
+    const runtime = new OpencodeChatRuntime(plugin);
+
+    await expect(runtime.ensureReady()).resolves.toBe(true);
+
+    expect(MockAcpSubprocess).toHaveBeenCalledWith(expect.objectContaining({
+      args: ['--distribution', 'Ubuntu', '--cd', '/home/user/Vault', 'opencode', 'acp'],
+      command: expect.stringMatching(/wsl\.exe$/i),
+      cwd: wslLocalhostVault,
+      shell: false,
+    }));
+    expect(mockConnection.newSession).toHaveBeenCalledWith({
+      cwd: '/home/user/Vault',
+      mcpServers: [],
+    });
+    expect(MockAcpSubprocess.mock.calls.at(-1)?.[0].env.OPENCODE_CONFIG).toBe(
+      '/home/user/Vault/.grimoire/opencode/config.json',
+    );
+
+    expect((runtime as any).launchSpec?.pathMapper.toHostPath('/home/user/Vault/notes/file.md')).toBe(
+      '\\\\wsl.localhost\\Ubuntu\\home\\user\\Vault\\notes\\file.md',
+    );
   });
 });

--- a/tests/unit/providers/opencode/OpencodeAuxQueryRunner.test.ts
+++ b/tests/unit/providers/opencode/OpencodeAuxQueryRunner.test.ts
@@ -4,6 +4,12 @@ import { AcpClientConnection, AcpJsonRpcTransport, AcpSubprocess } from '@/provi
 import { OpencodeAuxQueryRunner } from '@/providers/opencode/runtime/OpencodeAuxQueryRunner';
 import { prepareOpencodeLaunchArtifacts } from '@/providers/opencode/runtime/OpencodeLaunchArtifacts';
 
+jest.mock('@/utils/env', () => ({
+  ...jest.requireActual('@/utils/env'),
+  getHostnameKey: () => 'host-a',
+  getLegacyHostnameKey: () => 'legacy-host',
+}));
+
 jest.mock('@/providers/acp', () => {
   const actual = jest.requireActual('@/providers/acp');
   return {
@@ -195,26 +201,73 @@ describe('OpencodeAuxQueryRunner', () => {
   });
 
   it('does not pass the workspace path through auxiliary OpenCode CLI arguments', async () => {
-    const plugin = createMockPlugin();
-    const vaultPath = 'C:\\Users\\Name\\OneDrive - 公司\\Vault 中文 (test)';
-    plugin.app.vault.adapter.basePath = vaultPath;
-    const runner = new OpencodeAuxQueryRunner(plugin, {
-      agentProfile: 'passive',
-      artifactPurpose: 'title-gen',
-    });
+    const originalPlatform = process.platform;
+    Object.defineProperty(process, 'platform', { value: 'win32' });
+    try {
+      const plugin = createMockPlugin();
+      const vaultPath = 'C:\\Users\\Name\\OneDrive - 公司\\Vault 中文 (test)';
+      plugin.app.vault.adapter.basePath = vaultPath;
+      const runner = new OpencodeAuxQueryRunner(plugin, {
+        agentProfile: 'passive',
+        artifactPurpose: 'title-gen',
+      });
 
-    await expect(runner.query({
-      systemPrompt: 'Use this custom system prompt.',
-    }, 'Generate a title')).resolves.toBe('Fix title now');
+      await expect(runner.query({
+        systemPrompt: 'Use this custom system prompt.',
+      }, 'Generate a title')).resolves.toBe('Fix title now');
 
-    expect(MockAcpSubprocess).toHaveBeenCalledWith(expect.objectContaining({
-      args: ['acp'],
-      cwd: vaultPath,
-    }));
-    expect(mockConnection.newSession).toHaveBeenCalledWith({
-      cwd: vaultPath,
-      mcpServers: [],
-    });
+      expect(MockAcpSubprocess).toHaveBeenCalledWith(expect.objectContaining({
+        args: ['acp'],
+        cwd: vaultPath,
+      }));
+      expect(mockConnection.newSession).toHaveBeenCalledWith({
+        cwd: vaultPath,
+        mcpServers: [],
+      });
+    } finally {
+      Object.defineProperty(process, 'platform', { value: originalPlatform });
+    }
+  });
+
+  it('spawns auxiliary WSL launches from the host vault cwd while keeping the session cwd in WSL form', async () => {
+    const originalPlatform = process.platform;
+    Object.defineProperty(process, 'platform', { value: 'win32' });
+    try {
+      const vaultPath = 'C:\\Users\\Name\\OneDrive - 公司\\Vault 中文 (test)';
+      const plugin = createMockPlugin({
+        providerConfigs: {
+          opencode: {
+            enabled: true,
+            installationMethodsByHost: { 'host-a': 'wsl' },
+            wslDistroOverridesByHost: { 'host-a': 'Ubuntu' },
+          },
+        },
+      });
+      plugin.app.vault.adapter.basePath = vaultPath;
+      plugin.getResolvedProviderCliPath.mockReturnValue('opencode');
+      const runner = new OpencodeAuxQueryRunner(plugin, {
+        agentProfile: 'passive',
+        artifactPurpose: 'title-gen',
+      });
+
+      await expect(runner.query({
+        systemPrompt: 'Use this custom system prompt.',
+      }, 'Generate a title')).resolves.toBe('Fix title now');
+
+      expect(MockAcpSubprocess).toHaveBeenCalledWith(expect.objectContaining({
+        args: ['--distribution', 'Ubuntu', '--cd', '/mnt/c/Users/Name/OneDrive - 公司/Vault 中文 (test)', 'opencode', 'acp'],
+        command: expect.stringMatching(/wsl\.exe$/i),
+        cwd: vaultPath,
+        shell: false,
+      }));
+      expect(mockConnection.newSession).toHaveBeenCalledWith({
+        cwd: '/mnt/c/Users/Name/OneDrive - 公司/Vault 中文 (test)',
+        mcpServers: [],
+      });
+      expect(MockAcpSubprocess.mock.calls.at(-1)?.[0].env.PATH).toBeUndefined();
+    } finally {
+      Object.defineProperty(process, 'platform', { value: originalPlatform });
+    }
   });
 
   it('restarts the auxiliary ACP subprocess when the cached transport closed', async () => {

--- a/tests/unit/providers/opencode/OpencodeCliResolver.test.ts
+++ b/tests/unit/providers/opencode/OpencodeCliResolver.test.ts
@@ -63,4 +63,42 @@ describe('OpencodeCliResolver', () => {
 
     expect(resolved).toBeNull();
   });
+
+  it('uses a Linux-side command in Windows WSL mode', () => {
+    mockedExists.mockReturnValue(false);
+
+    const resolver = new OpencodeCliResolver();
+    const resolved = resolver.resolve(
+      {
+        'current-host': '/home/user/bin/opencode',
+      },
+      'C:\\Users\\user\\AppData\\Roaming\\npm\\opencode.cmd',
+      '',
+      {
+        hostPlatform: 'win32',
+        installationMethod: 'wsl',
+      },
+    );
+
+    expect(resolved).toBe('/home/user/bin/opencode');
+  });
+
+  it('falls back to PATH lookup inside WSL when only Windows-style references are configured', () => {
+    mockedExists.mockReturnValue(false);
+
+    const resolver = new OpencodeCliResolver();
+    const resolved = resolver.resolve(
+      {
+        'current-host': 'C:\\Users\\user\\AppData\\Roaming\\npm\\opencode.cmd',
+      },
+      'C:\\legacy\\opencode.cmd',
+      '',
+      {
+        hostPlatform: 'win32',
+        installationMethod: 'wsl',
+      },
+    );
+
+    expect(resolved).toBe('opencode');
+  });
 });

--- a/tests/unit/providers/opencode/OpencodeExecutionTargetResolver.test.ts
+++ b/tests/unit/providers/opencode/OpencodeExecutionTargetResolver.test.ts
@@ -1,0 +1,203 @@
+import { execFileSync } from 'child_process';
+
+import {
+  decodeWslListOutput,
+  inferWslDistroFromWindowsPath,
+  parseDefaultWslDistroListOutput,
+  resolveOpencodeExecutionTarget,
+} from '@/providers/opencode/runtime/OpencodeExecutionTargetResolver';
+
+jest.mock('child_process');
+jest.mock('@/utils/env', () => ({
+  ...jest.requireActual('@/utils/env'),
+  getHostnameKey: () => 'host-a',
+  getLegacyHostnameKey: () => 'legacy-host',
+}));
+
+const mockedExecFileSync = execFileSync as jest.Mock;
+
+function wslSettings(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    providerConfigs: {
+      opencode: {
+        installationMethodsByHost: { 'host-a': 'wsl' },
+        ...overrides,
+      },
+    },
+  };
+}
+
+describe('OpencodeExecutionTargetResolver', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('parseDefaultWslDistroListOutput', () => {
+    it('returns the distro marked with an asterisk', () => {
+      const output = [
+        '  NAME                   STATE           VERSION',
+        '* Ubuntu                 Running         2',
+        '  Debian                 Stopped         2',
+      ].join('\r\n');
+
+      expect(parseDefaultWslDistroListOutput(output)).toBe('Ubuntu');
+    });
+
+    it('strips a UTF-8 BOM before parsing', () => {
+      const output = '\uFEFF  NAME                   STATE           VERSION\n* Ubuntu                 Running         2';
+
+      expect(parseDefaultWslDistroListOutput(output)).toBe('Ubuntu');
+    });
+
+    it('returns undefined when no distro is marked as default', () => {
+      const output = [
+        '  NAME                   STATE           VERSION',
+        '  Ubuntu                 Running         2',
+        '  Debian                 Stopped         2',
+      ].join('\n');
+
+      expect(parseDefaultWslDistroListOutput(output)).toBeUndefined();
+    });
+
+    it('returns undefined for empty output', () => {
+      expect(parseDefaultWslDistroListOutput('')).toBeUndefined();
+    });
+  });
+
+  describe('decodeWslListOutput', () => {
+    it('decodes UTF-16LE output carrying a BOM', () => {
+      const text = '  NAME                   STATE           VERSION\r\n* Ubuntu                 Running         2';
+      const raw = Buffer.concat([Buffer.from([0xff, 0xfe]), Buffer.from(text, 'utf16le')]);
+
+      expect(decodeWslListOutput(raw)).toBe(text);
+    });
+
+    it('decodes plain UTF-8 output unchanged', () => {
+      const raw = Buffer.from('* Ubuntu                 Running         2', 'utf8');
+
+      expect(decodeWslListOutput(raw)).toBe('* Ubuntu                 Running         2');
+    });
+  });
+
+  describe('inferWslDistroFromWindowsPath', () => {
+    it('extracts the distro from a wsl$ vault path', () => {
+      expect(inferWslDistroFromWindowsPath('\\\\wsl$\\Ubuntu\\notes')).toBe('Ubuntu');
+    });
+
+    it('extracts the distro from a wsl.localhost vault path', () => {
+      expect(inferWslDistroFromWindowsPath('\\\\wsl.localhost\\Ubuntu\\notes')).toBe('Ubuntu');
+    });
+
+    it('returns undefined for a non-wsl path', () => {
+      expect(inferWslDistroFromWindowsPath('C:\\notes')).toBeUndefined();
+    });
+
+    it('returns undefined for missing input', () => {
+      expect(inferWslDistroFromWindowsPath(undefined)).toBeUndefined();
+      expect(inferWslDistroFromWindowsPath('')).toBeUndefined();
+    });
+  });
+
+  describe('resolveOpencodeExecutionTarget', () => {
+    it('returns host-native for a non-Windows host', () => {
+      const target = resolveOpencodeExecutionTarget({ settings: {}, hostPlatform: 'linux' });
+
+      expect(target).toEqual({ method: 'host-native', platformFamily: 'unix', platformOs: 'linux' });
+    });
+
+    it('returns native-windows when the installation method is not wsl', () => {
+      const target = resolveOpencodeExecutionTarget({ settings: {}, hostPlatform: 'win32' });
+
+      expect(target).toEqual({
+        method: 'native-windows',
+        platformFamily: 'windows',
+        platformOs: 'windows',
+      });
+    });
+
+    it('prefers the WSL distro override', () => {
+      const target = resolveOpencodeExecutionTarget({
+        settings: wslSettings({ wslDistroOverridesByHost: { 'host-a': 'Arch' } }),
+        hostPlatform: 'win32',
+      });
+
+      expect(target).toEqual({
+        method: 'wsl',
+        platformFamily: 'unix',
+        platformOs: 'linux',
+        distroName: 'Arch',
+        wslHostFlavor: undefined,
+      });
+      expect(mockedExecFileSync).not.toHaveBeenCalled();
+    });
+
+    it('infers the distro from a wsl$ vault path when no override is set', () => {
+      const target = resolveOpencodeExecutionTarget({
+        settings: wslSettings(),
+        hostPlatform: 'win32',
+        hostVaultPath: '\\\\wsl$\\Ubuntu\\notes',
+      });
+
+      expect(target).toEqual({
+        method: 'wsl',
+        platformFamily: 'unix',
+        platformOs: 'linux',
+        distroName: 'Ubuntu',
+        wslHostFlavor: 'wsl$',
+      });
+      expect(mockedExecFileSync).not.toHaveBeenCalled();
+    });
+
+    it('infers the distro from a wsl.localhost vault path when no override is set', () => {
+      const target = resolveOpencodeExecutionTarget({
+        settings: wslSettings(),
+        hostPlatform: 'win32',
+        hostVaultPath: '\\\\wsl.localhost\\Ubuntu\\notes',
+      });
+
+      expect(target).toEqual({
+        method: 'wsl',
+        platformFamily: 'unix',
+        platformOs: 'linux',
+        distroName: 'Ubuntu',
+        wslHostFlavor: 'wsl.localhost',
+      });
+      expect(mockedExecFileSync).not.toHaveBeenCalled();
+    });
+
+    it('uses an injected default-distro resolver before probing wsl.exe', () => {
+      const target = resolveOpencodeExecutionTarget({
+        settings: wslSettings(),
+        hostPlatform: 'win32',
+        resolveDefaultWslDistro: () => 'Debian',
+      });
+
+      expect(target.distroName).toBe('Debian');
+      expect(mockedExecFileSync).not.toHaveBeenCalled();
+    });
+
+    it('probes wsl.exe with WSL_UTF8 and parses UTF-16LE output as a last resort', () => {
+      const text = '  NAME                   STATE           VERSION\r\n* Ubuntu                 Running         2';
+      const utf16 = Buffer.concat([Buffer.from([0xff, 0xfe]), Buffer.from(text, 'utf16le')]);
+      mockedExecFileSync.mockReturnValue(utf16);
+
+      const target = resolveOpencodeExecutionTarget({
+        settings: wslSettings(),
+        hostPlatform: 'win32',
+      });
+
+      expect(target).toEqual({
+        method: 'wsl',
+        platformFamily: 'unix',
+        platformOs: 'linux',
+        distroName: 'Ubuntu',
+        wslHostFlavor: undefined,
+      });
+      expect(mockedExecFileSync).toHaveBeenCalledWith(
+        expect.stringMatching(/wsl\.exe$/i),
+        ['--list', '--verbose'],
+        expect.objectContaining({ env: expect.objectContaining({ WSL_UTF8: '1' }) }),
+      );
+    });
+  });
+});

--- a/tests/unit/providers/opencode/OpencodeLaunchArtifacts.test.ts
+++ b/tests/unit/providers/opencode/OpencodeLaunchArtifacts.test.ts
@@ -245,6 +245,31 @@ describe('prepareOpencodeLaunchArtifacts', () => {
     expect(first.launchKey).toBe(second.launchKey);
   });
 
+  it('writes target-mapped prompt references into the managed config when provided', async () => {
+    const tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'grimoire-opencode-artifacts-'));
+
+    const result = await prepareOpencodeLaunchArtifacts({
+      runtimeEnv: {
+        HOME: tmpRoot,
+      },
+      settings: {
+        customPrompt: '',
+        mediaFolder: '',
+        userName: 'Test User',
+        vaultPath: tmpRoot,
+      },
+      targetPathMapper: () => '/mnt/c/repo/.grimoire/opencode/system.md',
+      workspaceRoot: tmpRoot,
+    });
+
+    const generatedConfig = JSON.parse(await fs.readFile(result.configPath, 'utf8'));
+    expect(result.systemPromptPath).toBe(path.join(tmpRoot, '.grimoire', 'opencode', 'system.md'));
+    expect(generatedConfig.agent.build.prompt).toBe('{file:/mnt/c/repo/.grimoire/opencode/system.md}');
+    expect(generatedConfig.agent[OPENCODE_FULL_ACCESS_MODE_ID].prompt).toBe(
+      '{file:/mnt/c/repo/.grimoire/opencode/system.md}',
+    );
+  });
+
   it('creates the resolved OpenCode database directory before launch', async () => {
     const tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'grimoire-opencode-artifacts-'));
     const xdgDataHome = path.join(tmpRoot, 'xdg-data');

--- a/tests/unit/providers/opencode/OpencodeSettingsTab.test.ts
+++ b/tests/unit/providers/opencode/OpencodeSettingsTab.test.ts
@@ -30,7 +30,14 @@ jest.mock('obsidian', () => {
     public desc = '';
     public heading = false;
     public textComponents: MockTextComponent[] = [];
+    public dropdownComponents: MockDropdownComponent[] = [];
     public toggleComponents: MockToggleComponent[] = [];
+    public settingEl = {
+      style: {},
+      toggleClass: jest.fn(),
+      addClass: jest.fn(),
+      removeClass: jest.fn(),
+    };
 
     constructor(_container: unknown) {
       createdSettings.push(this);
@@ -54,6 +61,13 @@ jest.mock('obsidian', () => {
     addText(callback: (text: MockTextComponent) => void) {
       const component = createTextComponent();
       this.textComponents.push(component);
+      callback(component);
+      return this;
+    }
+
+    addDropdown(callback: (dropdown: MockDropdownComponent) => void) {
+      const component = createDropdownComponent();
+      this.dropdownComponents.push(component);
       callback(component);
       return this;
     }
@@ -152,11 +166,21 @@ interface MockToggleComponent {
   onChange: jest.MockedFunction<(callback: (value: boolean) => Promise<void> | void) => MockToggleComponent>;
 }
 
+interface MockDropdownComponent {
+  value: string;
+  options: Array<{ value: string; label: string }>;
+  onChangeCallback: ((value: string) => Promise<void> | void) | null;
+  addOption: jest.MockedFunction<(value: string, label: string) => MockDropdownComponent>;
+  setValue: jest.MockedFunction<(value: string) => MockDropdownComponent>;
+  onChange: jest.MockedFunction<(callback: (value: string) => Promise<void> | void) => MockDropdownComponent>;
+}
+
 type MockSettingRecord = {
   name: string;
   desc: string;
   heading: boolean;
   textComponents: MockTextComponent[];
+  dropdownComponents: MockDropdownComponent[];
   toggleComponents: MockToggleComponent[];
 };
 
@@ -206,6 +230,26 @@ function createToggleComponent(): MockToggleComponent {
     return component;
   });
   component.onChange = jest.fn((callback: (value: boolean) => Promise<void> | void) => {
+    component.onChangeCallback = callback;
+    return component;
+  });
+  return component;
+}
+
+function createDropdownComponent(): MockDropdownComponent {
+  const component = {} as MockDropdownComponent;
+  component.value = '';
+  component.options = [];
+  component.onChangeCallback = null;
+  component.addOption = jest.fn((value: string, label: string) => {
+    component.options.push({ value, label });
+    return component;
+  });
+  component.setValue = jest.fn((value: string) => {
+    component.value = value;
+    return component;
+  });
+  component.onChange = jest.fn((callback: (value: string) => Promise<void> | void) => {
     component.onChangeCallback = callback;
     return component;
   });
@@ -411,6 +455,10 @@ function findSetting(name: string): MockSettingRecord {
   return setting;
 }
 
+function findOptionalSetting(name: string): MockSettingRecord | undefined {
+  return createdSettings.find((candidate) => candidate.name === name);
+}
+
 function findElement(tag: string, cls: string): any {
   const element = createdDomElements.find((candidate) => candidate.tag === tag && candidate.cls === cls);
   if (!element) {
@@ -422,6 +470,11 @@ function findElement(tag: string, cls: string): any {
 describe('OpencodeSettingsTab', () => {
   const mockedExistsSync = fs.existsSync as jest.MockedFunction<typeof fs.existsSync>;
   const mockedStatSync = fs.statSync as jest.MockedFunction<typeof fs.statSync>;
+  const originalPlatform = process.platform;
+
+  afterAll(() => {
+    Object.defineProperty(process, 'platform', { value: originalPlatform });
+  });
 
   beforeEach(() => {
     createdSettings.length = 0;
@@ -646,5 +699,127 @@ describe('OpencodeSettingsTab', () => {
       'opencode:deepseek/deepseek-v4-pro',
     );
     expect(context.refreshModelSelectors).toHaveBeenCalled();
+  });
+
+  it('renders installation method and WSL distro override controls on Windows', () => {
+    Object.defineProperty(process, 'platform', { value: 'win32' });
+    const plugin = createPlugin();
+
+    opencodeSettingsTabRenderer.render(createContainer(), createContext(plugin));
+
+    expect(findSetting(t('settings.providerTabs.codex.installationMethod.name')).dropdownComponents).toHaveLength(1);
+    expect(findSetting(t('settings.providerTabs.codex.wslDistro.name')).textComponents).toHaveLength(1);
+  });
+
+  it('hides Windows-only installation controls on non-Windows platforms', () => {
+    Object.defineProperty(process, 'platform', { value: 'darwin' });
+    const plugin = createPlugin();
+
+    opencodeSettingsTabRenderer.render(createContainer(), createContext(plugin));
+
+    expect(findOptionalSetting(t('settings.providerTabs.codex.installationMethod.name'))).toBeUndefined();
+    expect(findOptionalSetting(t('settings.providerTabs.codex.wslDistro.name'))).toBeUndefined();
+  });
+
+  it('uses host-native CLI path behavior on non-Windows even when WSL is saved', async () => {
+    Object.defineProperty(process, 'platform', { value: 'darwin' });
+    const plugin = createPlugin({
+      providerConfigs: {
+        opencode: {
+          enabled: true,
+          cliPath: '',
+          cliPathsByHost: {},
+          installationMethod: 'wsl',
+          installationMethodsByHost: {
+            'host-a': 'wsl',
+          },
+          wslDistroOverride: 'Ubuntu',
+          wslDistroOverridesByHost: {
+            'host-a': 'Ubuntu',
+          },
+        },
+      },
+    });
+
+    opencodeSettingsTabRenderer.render(createContainer(), createContext(plugin));
+
+    const cliPathSetting = findSetting(t('settings.providerTabs.acp.cliPath.name', {
+      provider: 'OpenCode',
+    }));
+    expect(cliPathSetting.desc).toBe(t('settings.providerTabs.acp.cliPath.desc', {
+      command: 'opencode',
+      provider: 'OpenCode',
+    }));
+    expect(cliPathSetting.textComponents[0].placeholder).toBe('/usr/local/bin/opencode');
+
+    await cliPathSetting.textComponents[0].onChangeCallback?.('codex');
+
+    expect(plugin.settings.providerConfigs.opencode.cliPathsByHost['host-a']).toBeUndefined();
+    expect(mockSaveSettings).toHaveBeenCalledTimes(0);
+    expect(mockBroadcastToProviderTabs).toHaveBeenCalledTimes(0);
+  });
+
+  it('accepts a Linux-side CLI command when installation method is WSL', async () => {
+    Object.defineProperty(process, 'platform', { value: 'win32' });
+    const plugin = createPlugin();
+
+    opencodeSettingsTabRenderer.render(createContainer(), createContext(plugin));
+
+    const installationMethodSetting = findSetting(t('settings.providerTabs.codex.installationMethod.name'));
+    await installationMethodSetting.dropdownComponents[0].onChangeCallback?.('wsl');
+
+    const cliPathSetting = findSetting(t('settings.providerTabs.acp.cliPath.name', {
+      provider: 'OpenCode',
+    }));
+    await cliPathSetting.textComponents[0].onChangeCallback?.('opencode');
+
+    expect(plugin.settings.providerConfigs.opencode.installationMethodsByHost).toEqual({
+      'host-a': 'wsl',
+    });
+    expect(plugin.settings.providerConfigs.opencode.cliPathsByHost['host-a']).toBe('opencode');
+    expect(mockSaveSettings).toHaveBeenCalled();
+    expect(mockBroadcastToProviderTabs).toHaveBeenCalled();
+  });
+
+  it('rejects a Windows-native CLI path when installation method is WSL', async () => {
+    Object.defineProperty(process, 'platform', { value: 'win32' });
+    const plugin = createPlugin({
+      providerConfigs: {
+        opencode: {
+          enabled: true,
+          cliPath: '',
+          cliPathsByHost: {
+            'host-a': 'C:\\Users\\me\\AppData\\Roaming\\npm\\opencode.cmd',
+          },
+          installationMethod: 'wsl',
+          installationMethodsByHost: {
+            'host-a': 'wsl',
+          },
+          wslDistroOverride: 'Ubuntu',
+          wslDistroOverridesByHost: {
+            'host-a': 'Ubuntu',
+          },
+        },
+      },
+    });
+
+    opencodeSettingsTabRenderer.render(createContainer(), createContext(plugin));
+
+    const installationMethodSetting = findSetting(t('settings.providerTabs.codex.installationMethod.name'));
+    await installationMethodSetting.dropdownComponents[0].onChangeCallback?.('wsl');
+
+    const cliPathSetting = findSetting(t('settings.providerTabs.acp.cliPath.name', {
+      provider: 'OpenCode',
+    }));
+    await cliPathSetting.textComponents[0].onChangeCallback?.('C:\\Users\\me\\AppData\\Roaming\\npm\\opencode.cmd');
+
+    expect(plugin.settings.providerConfigs.opencode.installationMethodsByHost).toEqual({
+      'host-a': 'wsl',
+    });
+    expect(plugin.settings.providerConfigs.opencode.cliPathsByHost['host-a']).toBe(
+      'C:\\Users\\me\\AppData\\Roaming\\npm\\opencode.cmd',
+    );
+    expect(mockSaveSettings).toHaveBeenCalledTimes(1);
+    expect(mockBroadcastToProviderTabs).toHaveBeenCalledTimes(2);
   });
 });

--- a/tests/unit/providers/opencode/runtime/OpencodeLaunchSpecBuilder.test.ts
+++ b/tests/unit/providers/opencode/runtime/OpencodeLaunchSpecBuilder.test.ts
@@ -1,0 +1,149 @@
+import { buildOpencodeLaunchSpec } from '@/providers/opencode/runtime/OpencodeLaunchSpecBuilder';
+
+jest.mock('@/utils/env', () => ({
+  ...jest.requireActual('@/utils/env'),
+  getHostnameKey: () => 'host-a',
+  getLegacyHostnameKey: () => 'legacy-host',
+}));
+
+function wslSettings(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    providerConfigs: {
+      opencode: {
+        installationMethodsByHost: { 'host-a': 'wsl' },
+        ...overrides,
+      },
+    },
+  };
+}
+
+describe('buildOpencodeLaunchSpec', () => {
+  it('spawns wsl.exe directly without a shell in WSL mode', () => {
+    const spec = buildOpencodeLaunchSpec({
+      settings: wslSettings({ wslDistroOverridesByHost: { 'host-a': 'Ubuntu' } }),
+      resolvedCliCommand: 'opencode',
+      hostVaultPath: 'C:\\repo',
+      env: { SystemRoot: 'C:\\WINDOWS' },
+      hostPlatform: 'win32',
+    });
+
+    expect(spec.command).toBe('C:\\WINDOWS\\System32\\wsl.exe');
+    expect(spec.shell).toBe(false);
+    expect(spec.args).toEqual([
+      '--distribution',
+      'Ubuntu',
+      '--cd',
+      '/mnt/c/repo',
+      'opencode',
+      'acp',
+    ]);
+    expect(spec.target).toMatchObject({
+      method: 'wsl',
+      distroName: 'Ubuntu',
+      platformOs: 'linux',
+    });
+  });
+
+  it('uses the default WSL distro when no override is configured', () => {
+    const spec = buildOpencodeLaunchSpec({
+      settings: wslSettings(),
+      resolvedCliCommand: 'opencode',
+      hostVaultPath: 'C:\\repo',
+      env: {},
+      hostPlatform: 'win32',
+      resolveDefaultWslDistro: () => 'Debian',
+    });
+
+    expect(spec.command).toBe('wsl.exe');
+    expect(spec.shell).toBe(false);
+    expect(spec.target.distroName).toBe('Debian');
+    expect(spec.args).toEqual([
+      '--distribution',
+      'Debian',
+      '--cd',
+      '/mnt/c/repo',
+      'opencode',
+      'acp',
+    ]);
+  });
+
+  it('accepts \\wsl.localhost workspace paths and preserves that UNC flavor for mapped host paths', () => {
+    const spec = buildOpencodeLaunchSpec({
+      settings: wslSettings(),
+      resolvedCliCommand: 'opencode',
+      hostVaultPath: '\\\\wsl.localhost\\Ubuntu\\home\\user\\repo',
+      env: {},
+      hostPlatform: 'win32',
+      resolveDefaultWslDistro: () => 'Ubuntu',
+    });
+
+    expect(spec.command).toBe('wsl.exe');
+    expect(spec.targetCwd).toBe('/home/user/repo');
+    expect(spec.target.wslHostFlavor).toBe('wsl.localhost');
+    expect(spec.args).toEqual([
+      '--distribution',
+      'Ubuntu',
+      '--cd',
+      '/home/user/repo',
+      'opencode',
+      'acp',
+    ]);
+    expect(spec.pathMapper.toHostPath('/home/user/repo/.grimoire/opencode')).toBe(
+      '\\\\wsl.localhost\\Ubuntu\\home\\user\\repo\\.grimoire\\opencode',
+    );
+  });
+
+  it('drops the host PATH and remaps OPENCODE_DB for WSL launches', () => {
+    const spec = buildOpencodeLaunchSpec({
+      settings: wslSettings({ wslDistroOverridesByHost: { 'host-a': 'Ubuntu' } }),
+      resolvedCliCommand: 'opencode',
+      hostVaultPath: 'C:\\repo',
+      env: {
+        OPENCODE_DB: 'C:\\repo\\.opencode\\app.db',
+        PATH: 'C:\\WINDOWS\\System32;C:\\Tools',
+      },
+      hostPlatform: 'win32',
+    });
+
+    expect(spec.env.OPENCODE_DB).toBe('/mnt/c/repo/.opencode/app.db');
+    expect(spec.env.PATH).toBeUndefined();
+  });
+
+  it('leaves shell selection to the spawn heuristic for host-native launches', () => {
+    const spec = buildOpencodeLaunchSpec({
+      settings: {},
+      resolvedCliCommand: 'opencode.cmd',
+      hostVaultPath: 'C:\\repo',
+      env: {},
+      hostPlatform: 'win32',
+    });
+
+    expect(spec.command).toBe('opencode.cmd');
+    expect(spec.shell).toBeUndefined();
+    expect(spec.args).toEqual(['acp']);
+    expect(spec.target).toMatchObject({ method: 'native-windows' });
+  });
+
+  it('fails fast when WSL mode cannot determine a distro', () => {
+    expect(() => buildOpencodeLaunchSpec({
+      settings: wslSettings(),
+      resolvedCliCommand: 'opencode',
+      hostVaultPath: 'C:\\repo',
+      env: {},
+      hostPlatform: 'win32',
+      resolveDefaultWslDistro: () => undefined,
+    })).toThrow(
+      'Unable to determine the WSL distro. Set WSL distro override or configure a default WSL distro.',
+    );
+  });
+
+  it('fails fast when the workspace path cannot be represented inside WSL', () => {
+    expect(() => buildOpencodeLaunchSpec({
+      settings: wslSettings({ wslDistroOverridesByHost: { 'host-a': 'Ubuntu' } }),
+      resolvedCliCommand: 'opencode',
+      hostVaultPath: '\\\\server\\share\\repo',
+      env: {},
+      hostPlatform: 'win32',
+    })).toThrow('WSL mode only supports Windows drive paths and \\\\wsl$ or \\\\wsl.localhost workspace paths');
+  });
+});

--- a/tests/unit/providers/opencode/runtime/OpencodePathMapper.test.ts
+++ b/tests/unit/providers/opencode/runtime/OpencodePathMapper.test.ts
@@ -1,0 +1,65 @@
+import type { OpencodeExecutionTarget } from '@/providers/opencode/runtime/opencodeLaunchTypes';
+import { createOpencodePathMapper } from '@/providers/opencode/runtime/OpencodePathMapper';
+
+describe('createOpencodePathMapper', () => {
+  it('maps Windows drive paths into /mnt paths for WSL targets', () => {
+    const mapper = createOpencodePathMapper({
+      method: 'wsl',
+      platformFamily: 'unix',
+      platformOs: 'linux',
+      distroName: 'Ubuntu',
+    });
+
+    expect(mapper.toTargetPath('C:\\repo\\src')).toBe('/mnt/c/repo/src');
+    expect(mapper.toHostPath('/mnt/c/repo/src')).toBe('C:\\repo\\src');
+  });
+
+  it('maps \\wsl$ paths into Linux paths for the selected distro', () => {
+    const mapper = createOpencodePathMapper({
+      method: 'wsl',
+      platformFamily: 'unix',
+      platformOs: 'linux',
+      distroName: 'Ubuntu',
+    });
+
+    expect(mapper.toTargetPath('\\\\wsl$\\Ubuntu\\home\\user\\repo')).toBe('/home/user/repo');
+    expect(mapper.toHostPath('/home/user/repo')).toBe('\\\\wsl$\\Ubuntu\\home\\user\\repo');
+  });
+
+  it('maps \\wsl.localhost paths into Linux paths and preserves the UNC flavor on round-trip', () => {
+    const mapper = createOpencodePathMapper({
+      method: 'wsl',
+      platformFamily: 'unix',
+      platformOs: 'linux',
+      distroName: 'Ubuntu',
+      wslHostFlavor: 'wsl.localhost',
+    });
+
+    expect(mapper.toTargetPath('\\\\wsl.localhost\\Ubuntu\\home\\user\\repo')).toBe('/home/user/repo');
+    expect(mapper.toHostPath('/home/user/repo')).toBe('\\\\wsl.localhost\\Ubuntu\\home\\user\\repo');
+  });
+
+  it('rejects WSL UNC paths from a different distro', () => {
+    const mapper = createOpencodePathMapper({
+      method: 'wsl',
+      platformFamily: 'unix',
+      platformOs: 'linux',
+      distroName: 'Ubuntu',
+    });
+
+    expect(mapper.toTargetPath('\\\\wsl$\\Debian\\home\\user\\repo')).toBeNull();
+    expect(mapper.toTargetPath('\\\\wsl.localhost\\Debian\\home\\user\\repo')).toBeNull();
+  });
+
+  it('keeps host-native paths unchanged', () => {
+    const target: OpencodeExecutionTarget = {
+      method: 'host-native',
+      platformFamily: 'unix',
+      platformOs: 'macos',
+    };
+    const mapper = createOpencodePathMapper(target);
+
+    expect(mapper.toTargetPath('/Users/example/repo')).toBe('/Users/example/repo');
+    expect(mapper.toHostPath('/Users/example/repo')).toBe('/Users/example/repo');
+  });
+});

--- a/tests/unit/providers/opencode/settings.test.ts
+++ b/tests/unit/providers/opencode/settings.test.ts
@@ -110,6 +110,159 @@ describe('OpenCode settings normalization', () => {
     });
   });
 
+  it('defaults installation method to native-windows and leaves WSL override empty', () => {
+    const settings = getOpencodeProviderSettings({});
+
+    expect(settings.installationMethod).toBe('native-windows');
+    expect(settings.wslDistroOverride).toBe('');
+    expect(settings.installationMethod).toBe(DEFAULT_OPENCODE_PROVIDER_SETTINGS.installationMethod);
+    expect(settings.wslDistroOverride).toBe(DEFAULT_OPENCODE_PROVIDER_SETTINGS.wslDistroOverride);
+  });
+
+  it('normalizes invalid installationMethod and wslDistroOverride values', () => {
+    const settings = getOpencodeProviderSettings({
+      providerConfigs: {
+        opencode: {
+          installationMethod: 'auto',
+          wslDistroOverride: 123,
+        },
+      },
+    });
+
+    expect(settings.installationMethod).toBe('native-windows');
+    expect(settings.wslDistroOverride).toBe('');
+  });
+
+  it('does not inherit another host installation method once host-scoped values exist', () => {
+    const settings = getOpencodeProviderSettings({
+      providerConfigs: {
+        opencode: {
+          installationMethodsByHost: {
+            'host-b': 'wsl',
+          },
+          wslDistroOverridesByHost: {
+            'host-b': 'Ubuntu',
+          },
+          installationMethod: 'wsl',
+          wslDistroOverride: 'Ubuntu',
+        },
+      },
+    });
+
+    expect(settings.installationMethod).toBe('native-windows');
+    expect(settings.wslDistroOverride).toBe('');
+  });
+
+  it('migrates current legacy hostname-scoped installation settings to the opaque device key', () => {
+    mockGetHostnameKey.mockReturnValue('device:current');
+    mockGetLegacyHostnameKey.mockReturnValue('host-a');
+
+    const settings = getOpencodeProviderSettings({
+      providerConfigs: {
+        opencode: {
+          installationMethodsByHost: {
+            'host-a': 'wsl',
+            'host-b': 'native-windows',
+          },
+          wslDistroOverridesByHost: {
+            'host-a': 'Ubuntu',
+            'host-b': 'Debian',
+          },
+        },
+      },
+    });
+
+    expect(settings.installationMethod).toBe('wsl');
+    expect(settings.installationMethodsByHost).toEqual({
+      'device:current': 'wsl',
+      'host-b': 'native-windows',
+    });
+    expect(settings.wslDistroOverride).toBe('Ubuntu');
+    expect(settings.wslDistroOverridesByHost).toEqual({
+      'device:current': 'Ubuntu',
+      'host-b': 'Debian',
+    });
+  });
+
+  it('round-trips installationMethod and trims wslDistroOverride on update for the current host', () => {
+    const settingsBag: Record<string, unknown> = {
+      providerConfigs: {
+        opencode: {},
+      },
+    };
+
+    const next = updateOpencodeProviderSettings(settingsBag, {
+      installationMethod: 'wsl',
+      wslDistroOverride: '  Ubuntu-24.04  ',
+    });
+
+    expect(next.installationMethod).toBe('wsl');
+    expect(next.wslDistroOverride).toBe('Ubuntu-24.04');
+    expect(getOpencodeProviderSettings(settingsBag)).toMatchObject({
+      installationMethod: 'wsl',
+      wslDistroOverride: 'Ubuntu-24.04',
+      installationMethodsByHost: {
+        'host-a': 'wsl',
+      },
+      wslDistroOverridesByHost: {
+        'host-a': 'Ubuntu-24.04',
+      },
+    });
+  });
+
+  it('preserves another host installation settings when updating the current host', () => {
+    const settingsBag: Record<string, unknown> = {
+      providerConfigs: {
+        opencode: {
+          installationMethodsByHost: {
+            'host-b': 'wsl',
+          },
+          wslDistroOverridesByHost: {
+            'host-b': 'Debian',
+          },
+        },
+      },
+    };
+
+    const next = updateOpencodeProviderSettings(settingsBag, {
+      installationMethod: 'native-windows',
+      wslDistroOverride: '  ',
+    });
+
+    expect(next.installationMethodsByHost).toEqual({
+      'host-b': 'wsl',
+      'host-a': 'native-windows',
+    });
+    expect(next.wslDistroOverridesByHost).toEqual({
+      'host-b': 'Debian',
+    });
+  });
+
+  it('preserves legacy installation settings when applying a full settings snapshot', () => {
+    const settings: Record<string, unknown> = {
+      providerConfigs: {
+        opencode: {
+          installationMethod: 'wsl',
+          wslDistroOverride: 'Ubuntu',
+        },
+      },
+    };
+
+    const snapshot = getOpencodeProviderSettings(settings);
+    const next = updateOpencodeProviderSettings(settings, snapshot);
+
+    expect(next.installationMethod).toBe('wsl');
+    expect(next.wslDistroOverride).toBe('Ubuntu');
+    expect((settings.providerConfigs as Record<string, any>).opencode).toMatchObject({
+      installationMethodsByHost: {
+        'host-a': 'wsl',
+      },
+      wslDistroOverridesByHost: {
+        'host-a': 'Ubuntu',
+      },
+    });
+  });
+
   it('normalizes model aliases to base model ids and trims values', () => {
     expect(normalizeOpencodeModelAliases({
       'anthropic/claude-sonnet-4/high': '  Sonnet  ',

--- a/tests/unit/utils/env.test.ts
+++ b/tests/unit/utils/env.test.ts
@@ -17,6 +17,7 @@ const {
   migrateLegacyHostnameKeyedMap,
   parseContextLimit,
   parseEnvironmentVariables,
+  resolveWslExecutablePath,
 } = env;
 
 const isWindows = process.platform === 'win32';
@@ -639,6 +640,58 @@ describe('getEnhancedPath', () => {
       expect(segments[0]).toBe(userPath);
       expect(segments[1]).toBe(nvmBinDir);
     });
+  });
+});
+
+describe('resolveWslExecutablePath', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('resolves wsl.exe under System32 from SystemRoot', () => {
+    expect(resolveWslExecutablePath({ SystemRoot: 'C:\\WINDOWS' })).toBe(
+      'C:\\WINDOWS\\System32\\wsl.exe',
+    );
+  });
+
+  it('falls back to WINDIR when SystemRoot is absent', () => {
+    expect(resolveWslExecutablePath({ WINDIR: 'C:\\Windows' })).toBe(
+      'C:\\Windows\\System32\\wsl.exe',
+    );
+  });
+
+  it('matches Windows env keys case-insensitively', () => {
+    jest.spyOn(fs, 'existsSync').mockReturnValue(false);
+
+    expect(resolveWslExecutablePath({ systemroot: 'C:\\WINDOWS' })).toBe(
+      'C:\\WINDOWS\\System32\\wsl.exe',
+    );
+  });
+
+  it('prefers Sysnative when it is available', () => {
+    jest.spyOn(fs, 'existsSync').mockImplementation((candidate: fsType.PathLike) => String(candidate).includes('\\Sysnative\\'));
+
+    expect(resolveWslExecutablePath({ SystemRoot: 'C:\\WINDOWS' })).toBe(
+      'C:\\WINDOWS\\Sysnative\\wsl.exe',
+    );
+  });
+
+  it('returns bare wsl.exe when no Windows root is present', () => {
+    expect(resolveWslExecutablePath({})).toBe('wsl.exe');
+  });
+
+  it('defaults to process.env', () => {
+    const previous = process.env.SystemRoot;
+    process.env.SystemRoot = 'C:\\WINDOWS';
+    try {
+      expect(resolveWslExecutablePath()).toBe('C:\\WINDOWS\\System32\\wsl.exe');
+    } finally {
+      if (previous === undefined) {
+        delete process.env.SystemRoot;
+      } else {
+        process.env.SystemRoot = previous;
+      }
+    }
   });
 });
 


### PR DESCRIPTION
## Summary
- add Windows WSL launch support for OpenCode with host-scoped installation settings
- support both `\\wsl$\...` and `\\wsl.localhost\...` vault paths while preserving UNC flavor on path round-trips
- wire WSL-aware launch specs through OpenCode chat and auxiliary runtimes, plus focused tests

## Testing
- npm test -- --runInBand tests/unit/providers/acp/AcpSubprocess.test.ts tests/unit/providers/opencode/settings.test.ts tests/unit/providers/opencode/OpencodeCliResolver.test.ts tests/unit/providers/opencode/OpencodeLaunchArtifacts.test.ts tests/unit/providers/opencode/OpencodeAuxQueryRunner.test.ts tests/unit/providers/opencode/OpencodeSettingsTab.test.ts tests/unit/providers/opencode/OpencodeExecutionTargetResolver.test.ts tests/unit/providers/opencode/runtime/OpencodePathMapper.test.ts tests/unit/providers/opencode/runtime/OpencodeLaunchSpecBuilder.test.ts tests/unit/providers/opencode/OpencodeAcpLaunch.test.ts
- npm run typecheck
- npm run lint
- npm run build:release
