### PR TITLE
fix(review): wave-1 Obsidian source unsafe hardening

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -143,17 +143,34 @@ provider.
 
 ## Obsidian Community Review Gates
 
-Obsidian community plugin review scores CSS and dependency graphs and affects
-how the plugin is rated. Local release checks mirror the durable parts of that
-process:
+Obsidian community plugin review scores CSS, source, and dependency graphs and
+affects how the plugin is rated. Local release checks mirror the durable parts of
+that process:
 
 | Gate | Command | Catches |
 |------|---------|---------|
-| Source | `npm run review:source` | Stricter type-aware ESLint used for review |
+| Source | `npm run review:source` | Type-aware ESLint: no-deprecated, no-explicit-any, no-unsafe-* |
 | CSS | `npm run review:css` | `!important` and CSS features only partially supported by Obsidian's review baseline |
 | Dependencies | `npm run review:deps` | Known advisory floors in the lockfile |
 
 `npm run build:release` runs all three via `prebuild:release`.
+
+### Source / unsafe typing
+
+Local `review:source` already fails the build on `@typescript-eslint/no-unsafe-assignment`
+(and call/return/member/argument) plus `no-explicit-any`. Keep that gate green.
+
+Obsidian’s hosted scanner can still report large `no-unsafe-assignment` lists when
+its TypeScript/`obsidian` type resolution differs from ours. Treat that as a
+scoring signal, not as “local lint is off.” When their report names specific
+files:
+
+1. Prefer type guards and `unknown` over `as` casts.
+2. For storage/MCP/context/path helpers, also keep
+   `@typescript-eslint/no-unsafe-type-assertion` green (enforced for those paths).
+3. Expand path coverage wave-by-wave rather than one giant diff.
+
+### CSS
 
 CSS review is stricter than “works in current Obsidian.” The community lint
 baseline is historically Electron / app **1.11.4**, while Grimoire's

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -61,7 +61,8 @@ export default defineConfig([
         'error',
         { args: 'none', ignoreRestSiblings: true },
       ],
-      '@typescript-eslint/no-explicit-any': 'off',
+      // Obsidian recommended enables no-explicit-any; keep it enforced for src/tests.
+      '@typescript-eslint/no-explicit-any': 'error',
       'simple-import-sort/imports': 'error',
       'simple-import-sort/exports': 'error',
     },
@@ -71,6 +72,21 @@ export default defineConfig([
     rules: {
       ...projectObsidianRuleOverrides,
       'no-console': 'error',
+    },
+  },
+  // Wave-1 Obsidian source-review hardening: ban unsafe assertions in storage /
+  // MCP / context paths that the community scanner lists first.
+  {
+    files: [
+      'src/app/**/*.ts',
+      'src/core/storage/**/*.ts',
+      'src/core/mcp/**/*.ts',
+      'src/core/context/**/*.ts',
+      'src/utils/path.ts',
+      'src/utils/env.ts',
+    ],
+    rules: {
+      '@typescript-eslint/no-unsafe-type-assertion': 'error',
     },
   },
   {

--- a/scripts/reviewSource.js
+++ b/scripts/reviewSource.js
@@ -1,5 +1,6 @@
 const REVIEW_SOURCE_RULES = [
   '@typescript-eslint/no-deprecated:error',
+  '@typescript-eslint/no-explicit-any:error',
   '@typescript-eslint/no-unsafe-assignment:error',
   '@typescript-eslint/no-unsafe-return:error',
   '@typescript-eslint/no-unsafe-call:error',

--- a/src/app/settings/GrimoireSettingsStorage.ts
+++ b/src/app/settings/GrimoireSettingsStorage.ts
@@ -41,6 +41,10 @@ export { GRIMOIRE_SETTINGS_PATH };
 
 export type StoredGrimoireSettings = GrimoireSettings;
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
 const LEGACY_TOP_LEVEL_PROVIDER_FIELDS = [
   'claudeCliPath',
   'claudeCliPathsByHost',
@@ -171,14 +175,15 @@ function shouldPersistTabLayoutNormalization(
 }
 
 function normalizeProviderConfigs(value: unknown): ProviderConfigMap {
-  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+  if (!isRecord(value)) {
     return {};
   }
 
   const result: ProviderConfigMap = {};
-  for (const [providerId, config] of Object.entries(value as Record<string, unknown>)) {
-    if (config && typeof config === 'object' && !Array.isArray(config)) {
-      result[providerId] = { ...(config as Record<string, unknown>) };
+  for (const providerId of Object.keys(value)) {
+    const config = value[providerId];
+    if (isRecord(config)) {
+      result[providerId] = { ...config };
     }
   }
   return result;
@@ -280,11 +285,11 @@ function normalizeEnvSnippets(value: unknown): EnvSnippet[] {
 
   const snippets: EnvSnippet[] = [];
   for (const item of value) {
-    if (!item || typeof item !== 'object' || Array.isArray(item)) {
+    if (!isRecord(item)) {
       continue;
     }
 
-    const candidate = item as Record<string, unknown>;
+    const candidate = item;
     if (
       typeof candidate.id !== 'string'
       || typeof candidate.name !== 'string'
@@ -481,7 +486,8 @@ export class GrimoireSettingsStorage {
   private async readStoredSettings(settingsPath: string): Promise<Record<string, unknown> | null> {
     const content = await this.adapter.read(settingsPath);
     try {
-      return JSON.parse(content) as Record<string, unknown>;
+      const parsed: unknown = JSON.parse(content);
+      return isRecord(parsed) ? parsed : null;
     } catch (error) {
       if (!(error instanceof SyntaxError)) {
         throw error;

--- a/src/app/storage/SharedStorageService.ts
+++ b/src/app/storage/SharedStorageService.ts
@@ -81,6 +81,9 @@ export class SharedStorageService implements SharedAppStorage {
   }
 
   async saveGrimoireSettings(settings: Record<string, unknown>): Promise<void> {
+    // Live plugin settings are always a GrimoireSettings object; storage persists
+    // them as JSON without a full structural re-parse on every save.
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- settings is the live GrimoireSettings instance.
     await this.grimoireSettings.save(settings as StoredGrimoireSettings);
   }
 
@@ -118,22 +121,22 @@ export class SharedStorageService implements SharedAppStorage {
   }
 
   private validateTabManagerState(data: unknown): PersistedTabManagerState | null {
-    if (!data || typeof data !== 'object') {
+    if (!isRecord(data)) {
       return null;
     }
 
-    const state = data as Record<string, unknown>;
+    const state = data;
     if (!Array.isArray(state.openTabs)) {
       return null;
     }
 
     const validatedTabs: PersistedTabState[] = [];
     for (const tab of state.openTabs) {
-      if (!tab || typeof tab !== 'object') {
+      if (!isRecord(tab)) {
         continue;
       }
 
-      const tabObj = tab as Record<string, unknown>;
+      const tabObj = tab;
       if (typeof tabObj.tabId !== 'string') {
         continue;
       }

--- a/src/core/bootstrap/storage.ts
+++ b/src/core/bootstrap/storage.ts
@@ -12,6 +12,7 @@ import type { VaultFileAdapter } from '../storage/VaultFileAdapter';
  */
 export interface SharedAppStorage {
   initialize(): Promise<{ grimoire: Record<string, unknown> }>;
+  /** Callers pass the live plugin settings object (JSON-serializable). */
   saveGrimoireSettings(settings: Record<string, unknown>): Promise<void>;
   setTabManagerState(state: AppTabManagerState): Promise<void>;
   getTabManagerState(): Promise<AppTabManagerState | null>;

--- a/src/core/context/VaultTextIndex.ts
+++ b/src/core/context/VaultTextIndex.ts
@@ -1,4 +1,4 @@
-import type { App } from 'obsidian';
+import type { App, CachedMetadata } from 'obsidian';
 
 import { isPathInExcludedFolder } from './exclusions';
 import { tokenizeSearchText } from './text';
@@ -71,16 +71,12 @@ export class VaultTextIndex {
   }
 }
 
-function extractTags(cache: unknown): Set<string> {
+function extractTags(cache: CachedMetadata | null): Set<string> {
   const tags = new Set<string>();
-  const fileCache = cache as {
-    frontmatter?: { tags?: unknown };
-    tags?: Array<{ tag?: unknown }>;
-  } | null;
 
-  addFrontmatterTags(tags, fileCache?.frontmatter?.tags);
+  addFrontmatterTags(tags, cache?.frontmatter?.tags);
 
-  for (const tag of fileCache?.tags ?? []) {
+  for (const tag of cache?.tags ?? []) {
     if (typeof tag.tag === 'string') {
       tags.add(normalizeTag(tag.tag));
     }
@@ -104,11 +100,10 @@ function addFrontmatterTags(tags: Set<string>, value: unknown): void {
   }
 }
 
-function extractLinks(cache: unknown): Set<string> {
+function extractLinks(cache: CachedMetadata | null): Set<string> {
   const links = new Set<string>();
-  const fileCache = cache as { links?: Array<{ link?: unknown }> } | null;
 
-  for (const link of fileCache?.links ?? []) {
+  for (const link of cache?.links ?? []) {
     if (typeof link.link === 'string') {
       links.add(link.link);
     }

--- a/src/core/mcp/McpTester.ts
+++ b/src/core/mcp/McpTester.ts
@@ -7,7 +7,13 @@ import * as https from 'https';
 
 import { getEnhancedPath } from '../../utils/env';
 import { parseCommand } from '../../utils/mcp';
-import type { ManagedMcpServer } from '../types';
+import type {
+  ManagedMcpServer,
+  McpHttpServerConfig,
+  McpServerConfig,
+  McpSSEServerConfig,
+  McpStdioServerConfig,
+} from '../types';
 import { getMcpServerType } from '../types';
 
 export interface McpTool {
@@ -24,21 +30,13 @@ export interface McpTestResult {
   error?: string;
 }
 
-interface UrlServerConfig {
-  url: string;
-  headers?: Record<string, string>;
-}
-
 type StreamableHttpTransportOptions = ConstructorParameters<typeof StreamableHTTPClientTransport>[1];
-type LegacySseTransportConstructor = new (
-  url: URL,
-  options?: StreamableHttpTransportOptions,
-) => Transport;
 
 function createLegacySseTransport(url: URL, options: StreamableHttpTransportOptions): Transport {
-  // eslint-disable-next-line @typescript-eslint/no-require-imports -- Legacy SSE MCP servers still need the SDK's deprecated compatibility transport.
+  // Legacy SSE MCP servers still need the SDK's optional deprecated transport export.
+  // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-unsafe-type-assertion -- dynamic optional SDK export
   const module = require('@modelcontextprotocol/sdk/client/sse') as {
-    SSEClientTransport: LegacySseTransportConstructor;
+    SSEClientTransport: new (endpoint: URL, opts?: StreamableHttpTransportOptions) => Transport;
   };
   return new module.SSEClientTransport(url, options);
 }
@@ -89,7 +87,7 @@ export function createNodeFetch(): (input: string | URL | Request, init?: Reques
           if (settled) return;
           settled = true;
           signal?.removeEventListener('abort', onAbort);
-          resolve(createFetchResponse(res) as Response);
+          resolve(createFetchResponse(res));
         },
       );
 
@@ -112,17 +110,7 @@ export function createNodeFetch(): (input: string | URL | Request, init?: Reques
   };
 }
 
-interface MinimalFetchResponse {
-  ok: boolean;
-  status: number;
-  statusText: string;
-  headers: Headers;
-  body: ReadableStream<Uint8Array> | null;
-  text: () => Promise<string>;
-  json: () => Promise<unknown>;
-}
-
-function createFetchResponse(res: http.IncomingMessage): MinimalFetchResponse {
+function createFetchResponse(res: http.IncomingMessage): Response {
   const responseHeaders = new Headers();
   for (const [key, value] of Object.entries(res.headers)) {
     if (value === undefined) continue;
@@ -149,51 +137,11 @@ function createFetchResponse(res: http.IncomingMessage): MinimalFetchResponse {
     },
   });
 
-  let bodyUsed = false;
-  const readAsText = async (): Promise<string> => {
-    if (bodyUsed) {
-      throw new TypeError('Body has already been consumed');
-    }
-    bodyUsed = true;
-    const reader = body.getReader();
-    const chunks: Uint8Array[] = [];
-    let total = 0;
-    let done = false;
-    try {
-      while (!done) {
-        const { value, done: streamDone } = await reader.read();
-        done = streamDone;
-        if (done) break;
-        if (value) {
-          chunks.push(value);
-          total += value.byteLength;
-        }
-      }
-    } finally {
-      reader.releaseLock();
-    }
-
-    const merged = new Uint8Array(total);
-    let offset = 0;
-    for (const chunk of chunks) {
-      merged.set(chunk, offset);
-      offset += chunk.byteLength;
-    }
-    return new TextDecoder().decode(merged);
-  };
-
-  return {
-    ok: (res.statusCode ?? 500) >= 200 && (res.statusCode ?? 500) < 300,
+  return new Response(body, {
     status: res.statusCode ?? 500,
     statusText: res.statusMessage ?? '',
     headers: responseHeaders,
-    body,
-    text: readAsText,
-    json: async () => {
-      const parsed: unknown = JSON.parse(await readAsText());
-      return parsed;
-    },
-  };
+  });
 }
 
 function getRequestUrl(input: string | URL | Request): URL {
@@ -228,13 +176,26 @@ async function getRequestBody(body: BodyInit | null | undefined): Promise<Buffer
 
 const nodeFetch = createNodeFetch();
 
+function isStdioServerConfig(config: McpServerConfig): config is McpStdioServerConfig {
+  return 'command' in config && typeof config.command === 'string';
+}
+
+function isUrlServerConfig(
+  config: McpServerConfig,
+): config is McpSSEServerConfig | McpHttpServerConfig {
+  return 'url' in config && typeof config.url === 'string';
+}
+
 export async function testMcpServer(server: ManagedMcpServer): Promise<McpTestResult> {
   const type = getMcpServerType(server.config);
 
   let transport: Transport;
   try {
     if (type === 'stdio') {
-      const config = server.config as { command: string; args?: string[]; env?: Record<string, string> };
+      if (!isStdioServerConfig(server.config)) {
+        return { success: false, tools: [], error: 'Missing command' };
+      }
+      const config = server.config;
       const { cmd, args } = parseCommand(config.command, config.args);
       if (!cmd) {
         return { success: false, tools: [], error: 'Missing command' };
@@ -246,7 +207,10 @@ export async function testMcpServer(server: ManagedMcpServer): Promise<McpTestRe
         stderr: 'ignore',
       });
     } else {
-      const config = server.config as UrlServerConfig;
+      if (!isUrlServerConfig(server.config)) {
+        return { success: false, tools: [], error: 'Invalid server configuration' };
+      }
+      const config = server.config;
       const url = new URL(config.url);
       const options = {
         fetch: nodeFetch,
@@ -275,11 +239,16 @@ export async function testMcpServer(server: ManagedMcpServer): Promise<McpTestRe
     let tools: McpTool[] = [];
     try {
       const result = await client.listTools(undefined, { signal: controller.signal });
-      tools = result.tools.map((t: { name: string; description?: string; inputSchema?: Record<string, unknown> }) => ({
-        name: t.name,
-        description: t.description,
-        inputSchema: t.inputSchema as Record<string, unknown>,
-      }));
+      tools = result.tools.map((tool) => {
+        const inputSchema = tool.inputSchema;
+        return {
+          name: tool.name,
+          description: tool.description,
+          ...(inputSchema && typeof inputSchema === 'object' && !Array.isArray(inputSchema)
+            ? { inputSchema: { ...inputSchema } }
+            : {}),
+        };
+      });
     } catch {
       // listTools failure after successful connect = partial success
     }

--- a/src/core/storage/HomeFileAdapter.ts
+++ b/src/core/storage/HomeFileAdapter.ts
@@ -50,7 +50,9 @@ export class HomeFileAdapter implements Pick<VaultFileAdapter,
     try {
       await fs.promises.unlink(this.resolve(p));
     } catch (err: unknown) {
-      if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
+      if (!isErrnoException(err) || err.code !== 'ENOENT') {
+        throw err;
+      }
     }
   }
 
@@ -77,4 +79,17 @@ export class HomeFileAdapter implements Pick<VaultFileAdapter,
   async ensureFolder(p: string): Promise<void> {
     await fs.promises.mkdir(this.resolve(p), { recursive: true });
   }
+}
+
+function isErrnoException(error: unknown): error is NodeJS.ErrnoException {
+  if (typeof error !== 'object' || error === null) {
+    return false;
+  }
+
+  if (!('code' in error)) {
+    return true;
+  }
+
+  const code = Reflect.get(error, 'code');
+  return code === undefined || typeof code === 'string';
 }

--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -4,7 +4,14 @@ import * as os from 'os';
 import * as path from 'path';
 
 export function getVaultPath(app: App): string | null {
-  const basePath = (app.vault.adapter as { basePath?: unknown } | undefined)?.basePath;
+  const adapter = app.vault.adapter;
+  if (!adapter || typeof adapter !== 'object') {
+    return null;
+  }
+
+  // Use Reflect.get (not `in`) so Electron/Obsidian adapter proxies that hide
+  // the property from `has` still expose basePath.
+  const basePath: unknown = Reflect.get(adapter, 'basePath');
   return typeof basePath === 'string' ? basePath : null;
 }
 

--- a/tests/unit/scripts/reviewGate.test.ts
+++ b/tests/unit/scripts/reviewGate.test.ts
@@ -108,6 +108,7 @@ describe('Obsidian review gate', () => {
       '--max-warnings=0',
       '--rule',
       '@typescript-eslint/no-deprecated:error',
+      '@typescript-eslint/no-explicit-any:error',
       '@typescript-eslint/no-unsafe-assignment:error',
       '@typescript-eslint/no-unsafe-return:error',
       '@typescript-eslint/no-unsafe-call:error',

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,15 @@
 {
   "compilerOptions": {
     "paths": {
-      "@/*": ["./src/*"],
-      "@test/*": ["./tests/*"],
-      "@modelcontextprotocol/sdk/*": ["./node_modules/@modelcontextprotocol/sdk/dist/esm/*"]
+      "@/*": [
+        "./src/*"
+      ],
+      "@test/*": [
+        "./tests/*"
+      ],
+      "@modelcontextprotocol/sdk/*": [
+        "./node_modules/@modelcontextprotocol/sdk/dist/esm/*"
+      ]
     },
     "skipLibCheck": true,
     "inlineSourceMap": true,
@@ -19,10 +25,21 @@
     "noUnusedLocals": true,
     "strictNullChecks": true,
     "resolveJsonModule": true,
-    "types": ["node", "jest"],
-    "lib": ["DOM", "ES2022"],
+    "types": [
+      "node",
+      "jest"
+    ],
+    "lib": [
+      "DOM",
+      "ES2022"
+    ],
     "outDir": "./dist",
-    "rootDir": "."
+    "rootDir": ".",
+    "useUnknownInCatchVariables": true
   },
-  "include": ["src/**/*.ts", "src/**/*.d.ts", "tests/**/*.ts"]
+  "include": [
+    "src/**/*.ts",
+    "src/**/*.d.ts",
+    "tests/**/*.ts"
+  ]
 }


### PR DESCRIPTION
## Summary
- First wave toward better Obsidian community **source** scores: tighten local gates and remove unsafe type assertions in storage / MCP / context / path code.
- Documents that local `review:source` already fails on `no-unsafe-assignment` (and related rules) with **zero findings** under our tsconfig; hosted Obsidian reports can still differ when type resolution degrades.
- Enables `useUnknownInCatchVariables`, enforces `no-explicit-any`, and adds `no-unsafe-type-assertion` for wave-1 paths.

## Changes
- **tsconfig**: `useUnknownInCatchVariables: true`
- **eslint / review:source**: `no-explicit-any` as error; wave-1 paths require `no-unsafe-type-assertion`
- **Hardened**: `SharedStorageService`, `GrimoireSettingsStorage`, `VaultTextIndex`, `HomeFileAdapter`, `McpTester`, `getVaultPath`
- **CONTRIBUTING**: process for Obsidian source warnings and wave-by-wave expansion

## Follow-ups (next PRs)
- Expand `no-unsafe-type-assertion` to chat controllers / rendering / providers (~550 remaining sites repo-wide)
- Re-run Obsidian review on this branch and chase remaining listed files

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run review:source`
- [x] unit tests for path / HomeFileAdapter / VaultTextIndex / McpTester / reviewGate
- [ ] Obsidian community review re-run after merge