### PR TITLE
fix(review): allow community scanner dependency install

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -2,4 +2,3 @@ tag-version-prefix=""
 loglevel=silent
 min-release-age=7
 strict-allow-scripts=true
-engine-strict=true

--- a/tests/unit/scripts/reviewGate.test.ts
+++ b/tests/unit/scripts/reviewGate.test.ts
@@ -57,6 +57,12 @@ describe('Obsidian review gate', () => {
     }
   });
 
+  it('allows the community scanner to install with its npm version', () => {
+    const npmConfig = readFileSync('.npmrc', 'utf8');
+
+    expect(npmConfig).not.toContain('engine-strict=true');
+  });
+
   it('tracks the current Hono, Fast URI, and brace-expansion advisory floors', () => {
     const dependencyGate = readFileSync('scripts/check-review-dependencies.mjs', 'utf8');
 


### PR DESCRIPTION
## Why

The Obsidian community scanner runs `npm ci --ignore-scripts` before its type-aware source review. Grimoire had `engine-strict=true` in the repository `.npmrc`, while `package.json` requires npm `>=12.0.2 <13`.

When the scanner used a different npm version, installation stopped immediately with `EBADENGINE`. Without installed Obsidian and Node types, the source review produced 12,886 cascading `@typescript-eslint/no-unsafe-*` findings.

## What

- Remove `engine-strict=true` so an npm version mismatch remains a warning instead of aborting dependency installation.
- Add a regression test that keeps the repository installable by the community scanner.
- Keep the existing npm 12 pin and exact version checks in CI.

There are no TypeScript or dependency-layout changes in the final diff. The existing TypeScript 6/7 aliases remain, and `obsidian` / `@types/node` stay in `devDependencies`.

## Verification

- Community branch review passed with the exact dependency and TypeScript setup from `main`; all 12,886 cascading findings disappeared.
- `npm ci --ignore-scripts` under npm 10.9.2: 726 packages installed successfully.
- `npm run test -- --selectProjects unit`: 6,903 tests passed across 392 suites.
- `npm run typecheck`
- `npm run lint`
- `npm run review:source`
- `npm run build:release`

All checks passed.

Context: https://github.com/obsidianmd/eslint-plugin/issues/182#issuecomment-5233462015