### PR TITLE
Fix Antigravity model discovery and composer resizing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,6 +95,7 @@ dev
 
 .claude/
 .codex/
+.zcode/
 
 # Agent planning artifacts
 docs/superpowers/

--- a/src/features/chat/ui/inputResizeHandle.ts
+++ b/src/features/chat/ui/inputResizeHandle.ts
@@ -2,6 +2,7 @@ import { t } from '../../../i18n/i18n';
 
 export const INPUT_WRAPPER_MIN_HEIGHT = 106;
 export const INPUT_WRAPPER_MAX_HEIGHT_RATIO = 0.7;
+const INPUT_WRAPPER_HEIGHT_PROPERTY = '--grimoire-input-wrapper-height';
 
 export interface InputResizeHandleOptions {
   inputWrapper: HTMLElement;
@@ -20,6 +21,7 @@ export function createInputResizeHandle({
   let isDragging = false;
   let startY = 0;
   let startHeight = 0;
+  let minimumHeight = INPUT_WRAPPER_MIN_HEIGHT;
 
   const clearDragState = () => {
     isDragging = false;
@@ -30,15 +32,15 @@ export function createInputResizeHandle({
     if (!isDragging) return;
 
     const maxHeight = Math.max(
-      INPUT_WRAPPER_MIN_HEIGHT,
+      minimumHeight,
       viewport.clientHeight * INPUT_WRAPPER_MAX_HEIGHT_RATIO,
     );
     const nextHeight = Math.max(
-      INPUT_WRAPPER_MIN_HEIGHT,
+      minimumHeight,
       Math.min(maxHeight, startHeight + startY - event.clientY),
     );
 
-    inputWrapper.style.setProperty('--grimoire-input-wrapper-height', `${nextHeight}px`);
+    inputWrapper.style.setProperty(INPUT_WRAPPER_HEIGHT_PROPERTY, `${nextHeight}px`);
   };
 
   const onMouseUp = () => {
@@ -52,6 +54,7 @@ export function createInputResizeHandle({
     isDragging = true;
     startY = event.clientY;
     startHeight = inputWrapper.offsetHeight;
+    minimumHeight = measureInputWrapperMinimumHeight(inputWrapper);
     doc.body?.classList.add('grimoire-dragging-ns');
     doc.addEventListener('mousemove', onMouseMove);
     doc.addEventListener('mouseup', onMouseUp);
@@ -66,4 +69,25 @@ export function createInputResizeHandle({
     clearDragState();
     handle.remove();
   };
+}
+
+function measureInputWrapperMinimumHeight(inputWrapper: HTMLElement): number {
+  const explicitHeight = inputWrapper.style.getPropertyValue(INPUT_WRAPPER_HEIGHT_PROPERTY);
+  const explicitHeightPriority = inputWrapper.style.getPropertyPriority(INPUT_WRAPPER_HEIGHT_PROPERTY);
+  inputWrapper.style.removeProperty(INPUT_WRAPPER_HEIGHT_PROPERTY);
+
+  const computedMinHeight = Number.parseFloat(
+    inputWrapper.ownerDocument.defaultView?.getComputedStyle(inputWrapper).minHeight ?? '',
+  );
+  const minimumHeight = Math.max(
+    INPUT_WRAPPER_MIN_HEIGHT,
+    Number.isFinite(computedMinHeight) ? computedMinHeight : 0,
+    inputWrapper.scrollHeight,
+  );
+
+  if (explicitHeight) {
+    inputWrapper.style.setProperty(INPUT_WRAPPER_HEIGHT_PROPERTY, explicitHeight, explicitHeightPriority);
+  }
+
+  return Math.ceil(minimumHeight);
 }

--- a/src/providers/antigravity/models.ts
+++ b/src/providers/antigravity/models.ts
@@ -46,8 +46,16 @@ export const ANTIGRAVITY_FALLBACK_DISCOVERED_MODELS: ReadonlyArray<AntigravityDi
   },
 ]);
 
+export function normalizeAntigravityModelSelector(value: string): string {
+  const columns = value
+    .split('\t')
+    .map((column) => column.trim())
+    .filter(Boolean);
+  return columns.at(-1) ?? '';
+}
+
 export function encodeAntigravityModelId(rawModelId: string): string {
-  const normalized = rawModelId.trim();
+  const normalized = normalizeAntigravityModelSelector(rawModelId);
   return normalized ? `${ANTIGRAVITY_MODEL_PREFIX}${normalized}` : ANTIGRAVITY_SYNTHETIC_MODEL_ID;
 }
 
@@ -56,7 +64,7 @@ export function decodeAntigravityModelId(model: string): string | null {
     return model === ANTIGRAVITY_SYNTHETIC_MODEL_ID ? null : null;
   }
 
-  const rawModelId = model.slice(ANTIGRAVITY_MODEL_PREFIX.length).trim();
+  const rawModelId = normalizeAntigravityModelSelector(model.slice(ANTIGRAVITY_MODEL_PREFIX.length));
   return rawModelId || null;
 }
 

--- a/src/providers/antigravity/runtime/AntigravityModelDiscovery.ts
+++ b/src/providers/antigravity/runtime/AntigravityModelDiscovery.ts
@@ -5,7 +5,10 @@ import path from 'node:path';
 
 import type GrimoirePlugin from '../../../main';
 import { getVaultPath } from '../../../utils/path';
-import { ANTIGRAVITY_FALLBACK_DISCOVERED_MODELS } from '../models';
+import {
+  ANTIGRAVITY_FALLBACK_DISCOVERED_MODELS,
+  normalizeAntigravityModelSelector,
+} from '../models';
 import type { AntigravityDiscoveredModel } from '../settings';
 import { buildAntigravityProcessLaunch } from './AntigravityProcessLaunch';
 import { buildAntigravityRuntimeEnv } from './AntigravityRuntimeEnvironment';
@@ -65,7 +68,7 @@ export function parseAntigravityModels(output: string): AntigravityDiscoveredMod
   const models: AntigravityDiscoveredModel[] = [];
   const seen = new Set<string>();
   for (const line of output.split(/\r?\n/)) {
-    const rawId = line.trim();
+    const rawId = normalizeAntigravityModelSelector(line);
     if (!rawId || seen.has(rawId)) {
       continue;
     }

--- a/src/providers/antigravity/settings.ts
+++ b/src/providers/antigravity/settings.ts
@@ -6,6 +6,7 @@ import {
   getLegacyHostnameKey,
   migrateLegacyHostnameKeyedMap,
 } from '../../utils/env';
+import { normalizeAntigravityModelSelector } from './models';
 
 export interface AntigravityDiscoveredModel {
   description?: string | null;
@@ -65,13 +66,13 @@ export function normalizeAntigravityVisibleModels(value: unknown): string[] {
       continue;
     }
 
-    const trimmed = entry.trim();
-    if (!trimmed || seen.has(trimmed)) {
+    const normalizedEntry = normalizeAntigravityModelSelector(entry);
+    if (!normalizedEntry || seen.has(normalizedEntry)) {
       continue;
     }
 
-    seen.add(trimmed);
-    normalized.push(trimmed);
+    seen.add(normalizedEntry);
+    normalized.push(normalizedEntry);
   }
 
   return normalized;
@@ -103,7 +104,7 @@ export function normalizeAntigravityModelAliases(value: unknown): Record<string,
 
   const normalized: Record<string, string> = {};
   for (const [rawId, alias] of Object.entries(value as Record<string, unknown>)) {
-    const normalizedRawId = rawId.trim();
+    const normalizedRawId = normalizeAntigravityModelSelector(rawId);
     const normalizedAlias = typeof alias === 'string' ? alias.trim() : '';
     if (!normalizedRawId || !normalizedAlias) {
       continue;
@@ -126,8 +127,12 @@ function normalizeAntigravityDiscoveredModels(value: unknown): AntigravityDiscov
     }
 
     const record = entry as Record<string, unknown>;
-    const rawId = typeof record.rawId === 'string' ? record.rawId.trim() : '';
-    const label = typeof record.label === 'string' ? record.label.trim() : rawId;
+    const rawId = typeof record.rawId === 'string'
+      ? normalizeAntigravityModelSelector(record.rawId)
+      : '';
+    const label = typeof record.label === 'string'
+      ? normalizeAntigravityModelSelector(record.label) || rawId
+      : rawId;
     if (!rawId || seen.has(rawId)) {
       continue;
     }

--- a/tests/unit/features/chat/ui/inputResizeHandle.test.ts
+++ b/tests/unit/features/chat/ui/inputResizeHandle.test.ts
@@ -66,6 +66,20 @@ describe('inputResizeHandle', () => {
       .toBe(`${INPUT_WRAPPER_MIN_HEIGHT}px`);
   });
 
+  it('does not shrink below the intrinsic height of a wrapped toolbar', () => {
+    Object.defineProperty(inputWrapper, 'scrollHeight', {
+      configurable: true,
+      value: 138,
+    });
+    cleanup = createInputResizeHandle({ inputWrapper, viewport });
+    const handle = inputWrapper.querySelector('.grimoire-input-resize-handle')!;
+
+    handle.dispatchEvent(new MouseEvent('mousedown', { clientY: 300, bubbles: true }));
+    document.dispatchEvent(new MouseEvent('mousemove', { clientY: 500, bubbles: true }));
+
+    expect(inputWrapper.style.getPropertyValue('--grimoire-input-wrapper-height')).toBe('138px');
+  });
+
   it('toggles the body drag class during drag', () => {
     cleanup = createInputResizeHandle({ inputWrapper, viewport });
     const handle = inputWrapper.querySelector('.grimoire-input-resize-handle')!;

--- a/tests/unit/providers/antigravity/AntigravityChatRuntime.test.ts
+++ b/tests/unit/providers/antigravity/AntigravityChatRuntime.test.ts
@@ -130,6 +130,21 @@ describe('AntigravityChatRuntime', () => {
     }));
   });
 
+  it('repairs a tab-separated model selection saved by older discovery code', async () => {
+    const runtime = new AntigravityChatRuntime(createMockPlugin());
+    const runPrint = jest.spyOn(runtime as any, 'runPrint').mockResolvedValue('Hi\n');
+
+    await collect(runtime.query(
+      runtime.prepareTurn({ text: 'Hello' }),
+      undefined,
+      { model: 'antigravity:gemini-3.6-flash-high\tGemini 3.6 Flash (High)' },
+    ));
+
+    expect(runPrint).toHaveBeenCalledWith(expect.objectContaining({
+      model: 'Gemini 3.6 Flash (High)',
+    }));
+  });
+
   it('emits a startup status before waiting for agy print output', async () => {
     const runtime = new AntigravityChatRuntime(createMockPlugin());
     jest.spyOn(runtime as any, 'runPrint').mockResolvedValue('Hi from Antigravity\n');

--- a/tests/unit/providers/antigravity/AntigravityModelDiscovery.test.ts
+++ b/tests/unit/providers/antigravity/AntigravityModelDiscovery.test.ts
@@ -5,7 +5,10 @@ import os from 'node:os';
 import path from 'node:path';
 import { PassThrough } from 'node:stream';
 
-import { discoverAntigravityModels } from '@/providers/antigravity/runtime/AntigravityModelDiscovery';
+import {
+  discoverAntigravityModels,
+  parseAntigravityModels,
+} from '@/providers/antigravity/runtime/AntigravityModelDiscovery';
 import { updateAntigravityProviderSettings } from '@/providers/antigravity/settings';
 
 jest.mock('node:child_process', () => ({
@@ -54,6 +57,23 @@ describe('AntigravityModelDiscovery', () => {
   afterEach(() => {
     jest.restoreAllMocks();
     mockedSpawn.mockReset();
+  });
+
+  it('uses the CLI display name from tab-separated model output', () => {
+    expect(parseAntigravityModels([
+      'gemini-3.6-flash-high\tGemini 3.6 Flash (High)',
+      'claude-sonnet-4-6\tClaude Sonnet 4.6 (Thinking)',
+      'Gemini 3.6 Flash (High)',
+    ].join('\r\n'))).toEqual([
+      {
+        label: 'Gemini 3.6 Flash (High)',
+        rawId: 'Gemini 3.6 Flash (High)',
+      },
+      {
+        label: 'Claude Sonnet 4.6 (Thinking)',
+        rawId: 'Claude Sonnet 4.6 (Thinking)',
+      },
+    ]);
   });
 
   it('recovers models from Antigravity settings when agy models stdout is empty', async () => {

--- a/tests/unit/providers/antigravity/settings.test.ts
+++ b/tests/unit/providers/antigravity/settings.test.ts
@@ -42,4 +42,40 @@ describe('Antigravity provider settings', () => {
       'Claude Sonnet 4.6 (Thinking)': 'Sonnet Thinking',
     });
   });
+
+  it('repairs tab-separated model values persisted by older discovery code', () => {
+    const root: Record<string, unknown> = {};
+    updateAntigravityProviderSettings(root, {
+      discoveredModels: [
+        {
+          label: 'gemini-3.6-flash-high\tGemini 3.6 Flash (High)',
+          rawId: 'gemini-3.6-flash-high\tGemini 3.6 Flash (High)',
+        },
+        {
+          label: 'Gemini 3.6 Flash (High)',
+          rawId: 'Gemini 3.6 Flash (High)',
+        },
+      ],
+      modelAliases: {
+        'gemini-3.6-flash-high\tGemini 3.6 Flash (High)': 'Flash High',
+      },
+      visibleModels: [
+        'gemini-3.6-flash-high\tGemini 3.6 Flash (High)',
+        'Gemini 3.6 Flash (High)',
+      ],
+    });
+
+    expect(getAntigravityProviderSettings(root)).toEqual(expect.objectContaining({
+      discoveredModels: [
+        {
+          label: 'Gemini 3.6 Flash (High)',
+          rawId: 'Gemini 3.6 Flash (High)',
+        },
+      ],
+      modelAliases: {
+        'Gemini 3.6 Flash (High)': 'Flash High',
+      },
+      visibleModels: ['Gemini 3.6 Flash (High)'],
+    }));
+  });
 });


### PR DESCRIPTION
Closes #44
Closes #45

## What changed
- parse the tab-separated `agy models` output using the CLI display name accepted by `--model`
- repair previously persisted tab-separated Antigravity selections, visibility entries, and aliases
- clamp composer resizing to the measured intrinsic content height so wrapped toolbar controls cannot overflow
- ignore local `.zcode/` artifacts

## Verification
- `npm run test -- --selectProjects unit` (392 suites, 6907 tests)
- `npm run typecheck`
- `npm run lint`
- `npm run build:release`