### PR TITLE
fix(antigravity): show vault skills in slash menu

### DIFF
--- a/src/core/providers/commands/VaultSkillCommandCatalog.ts
+++ b/src/core/providers/commands/VaultSkillCommandCatalog.ts
@@ -1,3 +1,4 @@
+import { extractFirstParagraph } from '../../../utils/slashCommand';
 import { dumpYamlFrontmatter, loadYamlFrontmatter } from '../../../utils/yamlFrontmatter';
 import type { VaultFileAdapter } from '../../storage/VaultFileAdapter';
 import type { SlashCommand } from '../../types';
@@ -29,6 +30,7 @@ export interface VaultSkillRoot {
   path: string;
   editable?: boolean;
   includeFlatFiles?: boolean;
+  allowContentOnlySkills?: boolean;
 }
 
 export interface VaultSkillCommandCatalogOptions {
@@ -125,9 +127,13 @@ function serializeSkill(
 
 function parseSkillMarkdown(
   content: string,
+  allowContentOnlySkills = false,
 ): { frontmatter: Record<string, unknown>; body: string } | null {
   const match = content.match(SKILL_FRONTMATTER_PATTERN);
-  if (!match) return null;
+  if (!match) {
+    if (!allowContentOnlySkills || content.trimStart().startsWith('---')) return null;
+    return { frontmatter: {}, body: content };
+  }
 
   try {
     const parsed: unknown = loadYamlFrontmatter(match[1]);
@@ -285,14 +291,14 @@ export class VaultSkillCommandCatalog implements ProviderCommandCatalog {
     if (!this.adapter) return null;
     try {
       const markdown = await this.adapter.read(this.filePath(root, location));
-      const parsed = parseSkillMarkdown(markdown);
+      const parsed = parseSkillMarkdown(markdown, root.allowContentOnlySkills);
       if (!parsed) return null;
       const frontmatterName = typeof parsed.frontmatter.name === 'string'
         ? parsed.frontmatter.name.trim()
         : '';
       const description = typeof parsed.frontmatter.description === 'string'
         ? parsed.frontmatter.description.trim()
-        : undefined;
+        : extractFirstParagraph(parsed.body);
       const name = frontmatterName || location.name;
       const editable = root.editable !== false;
       return {

--- a/src/core/providers/commands/VaultSkillCommandCatalog.ts
+++ b/src/core/providers/commands/VaultSkillCommandCatalog.ts
@@ -31,6 +31,7 @@ export interface VaultSkillRoot {
   editable?: boolean;
   includeFlatFiles?: boolean;
   allowContentOnlySkills?: boolean;
+  deriveDescriptionFromBody?: boolean;
 }
 
 export interface VaultSkillCommandCatalogOptions {
@@ -131,7 +132,11 @@ function parseSkillMarkdown(
 ): { frontmatter: Record<string, unknown>; body: string } | null {
   const match = content.match(SKILL_FRONTMATTER_PATTERN);
   if (!match) {
-    if (!allowContentOnlySkills || content.trimStart().startsWith('---')) return null;
+    if (
+      !allowContentOnlySkills
+      || !content.trim()
+      || content.trimStart().startsWith('---')
+    ) return null;
     return { frontmatter: {}, body: content };
   }
 
@@ -298,7 +303,9 @@ export class VaultSkillCommandCatalog implements ProviderCommandCatalog {
         : '';
       const description = typeof parsed.frontmatter.description === 'string'
         ? parsed.frontmatter.description.trim()
-        : extractFirstParagraph(parsed.body);
+        : root.deriveDescriptionFromBody
+          ? extractFirstParagraph(parsed.body)
+          : undefined;
       const name = frontmatterName || location.name;
       const editable = root.editable !== false;
       return {

--- a/src/providers/antigravity/AGENTS.md
+++ b/src/providers/antigravity/AGENTS.md
@@ -10,6 +10,7 @@
 - Model discovery comes from `agy models` and is stored in provider settings for the UI.
 - On Windows, observed `agy` 1.0.10 can return exit code 0 with empty stdout for both `agy models` and `agy --print` even when the request succeeds. Preserve the Windows fallback paths that recover print output from Antigravity transcripts and model options from Antigravity settings plus the seeded Pro AI model list.
 - Antigravity settings expose custom model labels so users can add account-specific models when Windows model discovery is incomplete.
+- The AGY slash menu lists read-only vault skills from `.claude/skills` and `.agents/skills` through `VaultSkillCommandCatalog` (content-only SKILL.md files allowed). Because `agy --print` has no slash surface, `AntigravityChatRuntime` expands a leading `/skill-name` invocation client-side through the registered command catalog before launching AGY; keep menu filtering and the expansion grammar in sync.
 - Antigravity CLI 1.0.7 does not expose Gemini CLI's `--acp` flag; do not route it through `src/providers/acp/` unless a real ACP-compatible runtime is confirmed.
 - Auxiliary workflows such as title generation, instruction refinement, and inline edit are unsupported until an Antigravity auxiliary runner exists.
 

--- a/src/providers/antigravity/app/AntigravityWorkspaceServices.ts
+++ b/src/providers/antigravity/app/AntigravityWorkspaceServices.ts
@@ -1,3 +1,4 @@
+import type { ProviderCommandCatalog } from '../../../core/providers/commands/ProviderCommandCatalog';
 import { ProviderWorkspaceRegistry } from '../../../core/providers/ProviderWorkspaceRegistry';
 import type {
   ProviderCliResolver,
@@ -6,7 +7,9 @@ import type {
   ProviderWorkspaceRegistration,
   ProviderWorkspaceServices,
 } from '../../../core/providers/types';
+import type { VaultFileAdapter } from '../../../core/storage/VaultFileAdapter';
 import type GrimoirePlugin from '../../../main';
+import { AntigravityCommandCatalog } from '../commands/AntigravityCommandCatalog';
 import { ANTIGRAVITY_FALLBACK_DISCOVERED_MODELS } from '../models';
 import { AntigravityCliResolver } from '../runtime/AntigravityCliResolver';
 import { discoverAntigravityModels } from '../runtime/AntigravityModelDiscovery';
@@ -16,6 +19,7 @@ import { antigravityPlanUsageStore } from './AntigravityPlanUsageStore';
 
 export interface AntigravityWorkspaceServices extends ProviderWorkspaceServices {
   cliResolver: ProviderCliResolver;
+  commandCatalog: ProviderCommandCatalog;
   modelCatalog: ProviderModelCatalog;
 }
 
@@ -164,9 +168,13 @@ function buildAntigravityModelCatalogCacheKey(settings: ReturnType<typeof getAnt
   });
 }
 
-export async function createAntigravityWorkspaceServices(plugin: GrimoirePlugin): Promise<AntigravityWorkspaceServices> {
+export async function createAntigravityWorkspaceServices(
+  plugin: GrimoirePlugin,
+  vaultAdapter: VaultFileAdapter,
+): Promise<AntigravityWorkspaceServices> {
   return {
     cliResolver: createAntigravityCliResolver(),
+    commandCatalog: new AntigravityCommandCatalog(vaultAdapter),
     modelCatalog: createAntigravityModelCatalog(plugin),
     usageProvider: antigravityPlanUsageStore,
     settingsTabRenderer: antigravitySettingsTabRenderer,
@@ -176,13 +184,13 @@ export async function createAntigravityWorkspaceServices(plugin: GrimoirePlugin)
 
 export const antigravityWorkspaceRegistration: ProviderWorkspaceRegistration<AntigravityWorkspaceServices> = {
   workspaceCapabilities: {
-    skills: { inventory: 'none', manager: 'none' },
+    skills: { inventory: 'readonly', manager: 'none' },
     commands: { inventory: 'none', manager: 'none' },
     agents: { inventory: 'none', manager: 'none' },
     mcp: { inventory: 'none', manager: 'none' },
     environment: { inventory: 'managed', manager: 'managed' },
   },
-  initialize: async ({ plugin }) => createAntigravityWorkspaceServices(plugin),
+  initialize: async ({ plugin, vaultAdapter }) => createAntigravityWorkspaceServices(plugin, vaultAdapter),
 };
 
 export function maybeGetAntigravityWorkspaceServices(): AntigravityWorkspaceServices | null {

--- a/src/providers/antigravity/commands/AntigravityCommandCatalog.ts
+++ b/src/providers/antigravity/commands/AntigravityCommandCatalog.ts
@@ -1,0 +1,41 @@
+import type { ProviderCommandEntry } from '../../../core/providers/commands/ProviderCommandEntry';
+import {
+  VaultSkillCommandCatalog,
+  type VaultSkillStorageAdapter,
+} from '../../../core/providers/commands/VaultSkillCommandCatalog';
+
+/**
+ * AGY does not advertise a slash-command inventory, but Grimoire can still
+ * offer vault skills and expand the selected invocation before launching AGY.
+ */
+export class AntigravityCommandCatalog extends VaultSkillCommandCatalog {
+  constructor(adapter?: VaultSkillStorageAdapter) {
+    super(adapter, {
+      providerId: 'antigravity',
+      roots: [
+        { id: 'claude', path: '.claude/skills', editable: false, allowContentOnlySkills: true },
+        { id: 'agents', path: '.agents/skills', editable: false, allowContentOnlySkills: true },
+      ],
+      dropdown: {
+        triggerChars: ['/'],
+        builtInPrefix: '/',
+        skillPrefix: '/',
+        commandPrefix: '/',
+      },
+    });
+  }
+
+  async listDropdownEntries(_context: { includeBuiltIns: boolean }): Promise<ProviderCommandEntry[]> {
+    return this.listVaultEntries();
+  }
+
+  override async listVaultEntries(): Promise<ProviderCommandEntry[]> {
+    const seenNames = new Set<string>();
+    return (await super.listVaultEntries()).filter((entry) => {
+      const name = entry.name.toLowerCase();
+      if (seenNames.has(name)) return false;
+      seenNames.add(name);
+      return true;
+    });
+  }
+}

--- a/src/providers/antigravity/commands/AntigravityCommandCatalog.ts
+++ b/src/providers/antigravity/commands/AntigravityCommandCatalog.ts
@@ -4,6 +4,10 @@ import {
   type VaultSkillStorageAdapter,
 } from '../../../core/providers/commands/VaultSkillCommandCatalog';
 
+// Must stay in sync with the invocation grammar in
+// expandAntigravityVaultSkillInvocation (/^\/([\p{L}\p{N}_-]+)(?:\s|$)/).
+const INVOCABLE_SKILL_NAME_PATTERN = /^[\p{L}\p{N}_-]+$/u;
+
 /**
  * AGY does not advertise a slash-command inventory, but Grimoire can still
  * offer vault skills and expand the selected invocation before launching AGY.
@@ -13,8 +17,20 @@ export class AntigravityCommandCatalog extends VaultSkillCommandCatalog {
     super(adapter, {
       providerId: 'antigravity',
       roots: [
-        { id: 'claude', path: '.claude/skills', editable: false, allowContentOnlySkills: true },
-        { id: 'agents', path: '.agents/skills', editable: false, allowContentOnlySkills: true },
+        {
+          id: 'claude',
+          path: '.claude/skills',
+          editable: false,
+          allowContentOnlySkills: true,
+          deriveDescriptionFromBody: true,
+        },
+        {
+          id: 'agents',
+          path: '.agents/skills',
+          editable: false,
+          allowContentOnlySkills: true,
+          deriveDescriptionFromBody: true,
+        },
       ],
       dropdown: {
         triggerChars: ['/'],
@@ -32,6 +48,9 @@ export class AntigravityCommandCatalog extends VaultSkillCommandCatalog {
   override async listVaultEntries(): Promise<ProviderCommandEntry[]> {
     const seenNames = new Set<string>();
     return (await super.listVaultEntries()).filter((entry) => {
+      // Only offer skills the runtime can actually expand: the name must fit
+      // the `/name` invocation grammar and the body must be non-empty.
+      if (!INVOCABLE_SKILL_NAME_PATTERN.test(entry.name) || !entry.content?.trim()) return false;
       const name = entry.name.toLowerCase();
       if (seenNames.has(name)) return false;
       seenNames.add(name);

--- a/src/providers/antigravity/runtime/AntigravityChatRuntime.ts
+++ b/src/providers/antigravity/runtime/AntigravityChatRuntime.ts
@@ -40,6 +40,7 @@ import {
   formatCurrentNote,
 } from '../../../utils/context';
 import { appendEditorContext } from '../../../utils/editor';
+import { parseFrontmatter } from '../../../utils/frontmatter';
 import { getVaultPath } from '../../../utils/path';
 import { createUtf8ChunkDecoder, type Utf8ChunkDecoder } from '../../../utils/utf8Stream';
 import { ANTIGRAVITY_PROVIDER_CAPABILITIES } from '../capabilities';
@@ -138,7 +139,10 @@ export class AntigravityChatRuntime implements ChatRuntime {
       return;
     }
 
-    const prompt = buildAntigravityPrintPrompt(turn.prompt, conversationHistory);
+    const prompt = buildAntigravityPrintPrompt(
+      await expandAntigravityVaultSkillInvocation(this.plugin, turn.prompt),
+      conversationHistory,
+    );
 
     try {
       yield { content: 'Starting Antigravity...', type: 'status' };
@@ -524,6 +528,74 @@ export class AntigravityChatRuntime implements ChatRuntime {
       listener(ready);
     }
   }
+}
+
+/**
+ * `agy --print` does not expose Claude-style slash skills.  Preserve the
+ * familiar `/skill-name` workflow by expanding a vault skill before the
+ * prompt is handed to AGY.  Only an invocation at the beginning of a turn is
+ * expanded; ordinary prose containing a slash is left untouched.
+ */
+export async function expandAntigravityVaultSkillInvocation(
+  plugin: GrimoirePlugin,
+  prompt: string,
+): Promise<string> {
+  const match = prompt.match(/^\/([\p{L}\p{N}_-]+)(?:\s|$)([\s\S]*)$/u);
+  if (!match) return prompt;
+
+  const [, skillName, argumentsText] = match;
+  const skill = await findAntigravityVaultSkill(plugin, skillName);
+  if (!skill) return prompt;
+  return [
+    `You are executing the vault skill "${skillName}". Follow its instructions.`,
+    '',
+    skill,
+    argumentsText.trim()
+      ? `\nUser input for this skill:\n${argumentsText.trim()}`
+      : '',
+  ].join('\n');
+}
+
+async function findAntigravityVaultSkill(
+  plugin: GrimoirePlugin,
+  skillName: string,
+): Promise<string | null> {
+  const roots = ['.claude/skills', '.agents/skills'];
+  const adapter = plugin.app.vault.adapter;
+  for (const root of roots) {
+    const direct = await readVaultSkill(adapter, `${root}/${skillName}/SKILL.md`);
+    if (direct) return direct;
+
+    try {
+      const listing = await adapter.list(root);
+      for (const folder of listing.folders) {
+        const candidate = await readVaultSkill(adapter, `${folder}/SKILL.md`);
+        if (candidate && skillNameMatches(candidate, skillName)) return candidate;
+      }
+    } catch {
+      // Missing or unreadable roots do not block the next root.
+    }
+  }
+
+  return null;
+}
+
+async function readVaultSkill(
+  adapter: GrimoirePlugin['app']['vault']['adapter'],
+  path: string,
+): Promise<string | null> {
+  try {
+    const content = await adapter.read(path);
+    return content.trim() ? content : null;
+  } catch {
+    return null;
+  }
+}
+
+function skillNameMatches(content: string, name: string): boolean {
+  const parsed = parseFrontmatter(content);
+  return typeof parsed?.frontmatter.name === 'string'
+    && parsed.frontmatter.name.trim().toLowerCase() === name.toLowerCase();
 }
 
 export function buildAntigravityPrintArgs(spec: AntigravityPrintArgsSpec): string[] {

--- a/src/providers/antigravity/runtime/AntigravityChatRuntime.ts
+++ b/src/providers/antigravity/runtime/AntigravityChatRuntime.ts
@@ -4,6 +4,7 @@ import os from 'node:os';
 import path from 'node:path';
 
 import { ProviderRegistry } from '../../../core/providers/ProviderRegistry';
+import { ProviderWorkspaceRegistry } from '../../../core/providers/ProviderWorkspaceRegistry';
 import type { ProviderCapabilities } from '../../../core/providers/types';
 import type { ChatRuntime } from '../../../core/runtime/ChatRuntime';
 import type {
@@ -38,9 +39,9 @@ import {
   appendProjectWorkspaceContext,
   appendVaultSearchContext,
   formatCurrentNote,
+  XML_CONTEXT_PATTERN,
 } from '../../../utils/context';
 import { appendEditorContext } from '../../../utils/editor';
-import { parseFrontmatter } from '../../../utils/frontmatter';
 import { getVaultPath } from '../../../utils/path';
 import { createUtf8ChunkDecoder, type Utf8ChunkDecoder } from '../../../utils/utf8Stream';
 import { ANTIGRAVITY_PROVIDER_CAPABILITIES } from '../capabilities';
@@ -140,7 +141,7 @@ export class AntigravityChatRuntime implements ChatRuntime {
     }
 
     const prompt = buildAntigravityPrintPrompt(
-      await expandAntigravityVaultSkillInvocation(this.plugin, turn.prompt),
+      await expandAntigravityVaultSkillInvocation(turn.prompt),
       conversationHistory,
     );
 
@@ -534,68 +535,53 @@ export class AntigravityChatRuntime implements ChatRuntime {
  * `agy --print` does not expose Claude-style slash skills.  Preserve the
  * familiar `/skill-name` workflow by expanding a vault skill before the
  * prompt is handed to AGY.  Only an invocation at the beginning of a turn is
- * expanded; ordinary prose containing a slash is left untouched.
+ * expanded; ordinary prose containing a slash is left untouched.  Skills are
+ * resolved through the registered command catalog so the slash menu and the
+ * expansion always refer to the same skill, and appended XML context blocks
+ * stay outside the wrapper instead of being labeled as skill input.
  */
-export async function expandAntigravityVaultSkillInvocation(
-  plugin: GrimoirePlugin,
-  prompt: string,
-): Promise<string> {
-  const match = prompt.match(/^\/([\p{L}\p{N}_-]+)(?:\s|$)([\s\S]*)$/u);
+export async function expandAntigravityVaultSkillInvocation(prompt: string): Promise<string> {
+  const { userText, contextTail } = splitPromptXmlContext(prompt);
+  const match = userText.match(/^\/([\p{L}\p{N}_-]+)(?:\s|$)([\s\S]*)$/u);
   if (!match) return prompt;
 
   const [, skillName, argumentsText] = match;
-  const skill = await findAntigravityVaultSkill(plugin, skillName);
+  const skill = await findAntigravityVaultSkill(skillName);
   if (!skill) return prompt;
-  return [
+  const expanded = [
     `You are executing the vault skill "${skillName}". Follow its instructions.`,
     '',
     skill,
     argumentsText.trim()
       ? `\nUser input for this skill:\n${argumentsText.trim()}`
       : '',
-  ].join('\n');
+  ].join('\n').trimEnd();
+  return contextTail ? `${expanded}${contextTail}` : expanded;
 }
 
-async function findAntigravityVaultSkill(
-  plugin: GrimoirePlugin,
-  skillName: string,
-): Promise<string | null> {
-  const roots = ['.claude/skills', '.agents/skills'];
-  const adapter = plugin.app.vault.adapter;
-  for (const root of roots) {
-    const direct = await readVaultSkill(adapter, `${root}/${skillName}/SKILL.md`);
-    if (direct) return direct;
-
-    try {
-      const listing = await adapter.list(root);
-      for (const folder of listing.folders) {
-        const candidate = await readVaultSkill(adapter, `${folder}/SKILL.md`);
-        if (candidate && skillNameMatches(candidate, skillName)) return candidate;
-      }
-    } catch {
-      // Missing or unreadable roots do not block the next root.
-    }
+function splitPromptXmlContext(prompt: string): { userText: string; contextTail: string } {
+  const xmlMatch = prompt.match(XML_CONTEXT_PATTERN);
+  if (xmlMatch?.index === undefined) {
+    return { userText: prompt, contextTail: '' };
   }
-
-  return null;
+  return {
+    userText: prompt.substring(0, xmlMatch.index),
+    contextTail: prompt.substring(xmlMatch.index),
+  };
 }
 
-async function readVaultSkill(
-  adapter: GrimoirePlugin['app']['vault']['adapter'],
-  path: string,
-): Promise<string | null> {
+async function findAntigravityVaultSkill(skillName: string): Promise<string | null> {
+  const catalog = ProviderWorkspaceRegistry.getCommandCatalog('antigravity');
+  if (!catalog) return null;
   try {
-    const content = await adapter.read(path);
-    return content.trim() ? content : null;
+    const entries = await catalog.listVaultEntries();
+    const entry = entries.find(
+      (candidate) => candidate.name.toLowerCase() === skillName.toLowerCase(),
+    );
+    return entry?.content?.trim() ? entry.content : null;
   } catch {
     return null;
   }
-}
-
-function skillNameMatches(content: string, name: string): boolean {
-  const parsed = parseFrontmatter(content);
-  return typeof parsed?.frontmatter.name === 'string'
-    && parsed.frontmatter.name.trim().toLowerCase() === name.toLowerCase();
 }
 
 export function buildAntigravityPrintArgs(spec: AntigravityPrintArgsSpec): string[] {

--- a/tests/unit/core/providers/commands/VaultSkillCommandCatalog.test.ts
+++ b/tests/unit/core/providers/commands/VaultSkillCommandCatalog.test.ts
@@ -61,6 +61,27 @@ function createCatalog(adapter: ReturnType<typeof createAdapter>) {
   });
 }
 
+function createContentOnlyCatalog(adapter: ReturnType<typeof createAdapter>) {
+  return new VaultSkillCommandCatalog(adapter, {
+    providerId: 'kimicode',
+    roots: [
+      {
+        id: 'agents',
+        path: '.agents/skills',
+        editable: false,
+        allowContentOnlySkills: true,
+        deriveDescriptionFromBody: true,
+      },
+    ],
+    dropdown: {
+      triggerChars: ['/'],
+      builtInPrefix: '/',
+      commandPrefix: '/',
+      skillPrefix: '/',
+    },
+  });
+}
+
 describe('VaultSkillCommandCatalog', () => {
   it('lists directory and flat project skills with their real source paths', async () => {
     const adapter = createAdapter({
@@ -309,5 +330,51 @@ describe('VaultSkillCommandCatalog', () => {
 
     expect(adapter.write).not.toHaveBeenCalled();
     expect(adapter.files.get('.kimi-code/skills/review/SKILL.md')).toContain('Original body.');
+  });
+
+  it('lists content-only skills with a derived description when the root allows them', async () => {
+    const adapter = createAdapter({
+      '.agents/skills/review/SKILL.md': 'Review the current changes\nbefore merging.',
+    });
+
+    const entries = await createContentOnlyCatalog(adapter).listVaultEntries();
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({
+      name: 'review',
+      description: 'Review the current changes before merging.',
+    });
+  });
+
+  it('rejects content-only skills on roots that do not allow them', async () => {
+    const adapter = createAdapter({
+      '.kimi-code/skills/review/SKILL.md': 'Review the current changes.',
+    });
+
+    const entries = await createCatalog(adapter).listVaultEntries();
+
+    expect(entries).toEqual([]);
+  });
+
+  it('rejects content-only skills that look like frontmatter or are empty', async () => {
+    const adapter = createAdapter({
+      '.agents/skills/broken/SKILL.md': '---\nname: broken\nmetadata: [one\n---\n\nBroken.',
+      '.agents/skills/empty/SKILL.md': '   ',
+    });
+
+    const entries = await createContentOnlyCatalog(adapter).listVaultEntries();
+
+    expect(entries).toEqual([]);
+  });
+
+  it('keeps the description undefined without frontmatter unless the root derives it', async () => {
+    const adapter = createAdapter({
+      '.kimi-code/skills/review/SKILL.md': '---\nname: review\n---\n\nReview it.',
+    });
+
+    const entries = await createCatalog(adapter).listVaultEntries();
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0]?.description).toBeUndefined();
   });
 });

--- a/tests/unit/providers/antigravity/AntigravityChatRuntime.test.ts
+++ b/tests/unit/providers/antigravity/AntigravityChatRuntime.test.ts
@@ -7,8 +7,10 @@ import os from 'node:os';
 import path from 'node:path';
 import { PassThrough } from 'node:stream';
 
+import { ProviderWorkspaceRegistry } from '@/core/providers/ProviderWorkspaceRegistry';
 import type { StreamChunk } from '@/core/types';
 import { setLocale } from '@/i18n/i18n';
+import { AntigravityCommandCatalog } from '@/providers/antigravity/commands/AntigravityCommandCatalog';
 import {
   AntigravityChatRuntime,
   buildAntigravityPrintArgs,
@@ -75,6 +77,7 @@ describe('AntigravityChatRuntime', () => {
     setLocale('en');
     jest.restoreAllMocks();
     mockedSpawn.mockReset();
+    ProviderWorkspaceRegistry.setServices('antigravity', undefined);
   });
 
   it('does not start when the provider is disabled', async () => {
@@ -114,42 +117,102 @@ describe('AntigravityChatRuntime', () => {
     expect(chunks[chunks.length - 1]).toEqual({ type: 'done' });
   });
 
+  function registerSkillCatalog(files: Record<string, string>): void {
+    const catalog = new AntigravityCommandCatalog({
+      listFiles: jest.fn(async () => []),
+      listFolders: jest.fn(async (root: string) => [
+        ...new Set(Object.keys(files)
+          .filter((file) => file.startsWith(`${root}/`))
+          .map((file) => file.slice(0, file.lastIndexOf('/')))),
+      ]),
+      read: jest.fn(async (path: string) => {
+        const content = files[path];
+        if (content === undefined) throw new Error(`Missing ${path}`);
+        return content;
+      }),
+    } as any);
+    ProviderWorkspaceRegistry.setServices('antigravity', { commandCatalog: catalog });
+  }
+
   it('expands a shared content-only skill and passes its arguments to AGY', async () => {
-    const plugin = createMockPlugin({
-      app: {
-        vault: {
-          adapter: {
-            list: jest.fn(async (root: string) => root === '.claude/skills'
-              ? { folders: [], files: [] }
-              : { folders: ['.agents/skills/start-my-day'], files: [] }),
-            read: jest.fn(async (path: string) => path === '.agents/skills/start-my-day/SKILL.md'
-              ? 'Prepare a focused daily plan.'
-              : Promise.reject(new Error('Missing skill'))),
-          },
-        },
-      },
+    registerSkillCatalog({
+      '.agents/skills/start-my-day/SKILL.md': 'Prepare a focused daily plan.',
     });
 
-    await expect(expandAntigravityVaultSkillInvocation(plugin, '/start-my-day prioritize health'))
+    await expect(expandAntigravityVaultSkillInvocation('/start-my-day prioritize health'))
       .resolves.toContain('Prepare a focused daily plan.');
-    await expect(expandAntigravityVaultSkillInvocation(plugin, '/start-my-day prioritize health'))
+    await expect(expandAntigravityVaultSkillInvocation('/start-my-day prioritize health'))
       .resolves.toContain('User input for this skill:\nprioritize health');
   });
 
-  it('expands a skill selected by its frontmatter name', async () => {
-    const plugin = createMockPlugin({
-      app: {
-        vault: {
-          adapter: {
-            list: jest.fn(async () => ({ folders: ['.claude/skills/daily-routine'], files: [] })),
-            read: jest.fn(async () => '---\nname: start-my-day\n---\n\nStart calmly.'),
-          },
-        },
-      },
+  it('expands a skill selected by its frontmatter name without the frontmatter block', async () => {
+    registerSkillCatalog({
+      '.claude/skills/daily-routine/SKILL.md': '---\nname: start-my-day\n---\n\nStart calmly.',
     });
 
-    await expect(expandAntigravityVaultSkillInvocation(plugin, '/start-my-day'))
+    const expanded = await expandAntigravityVaultSkillInvocation('/start-my-day');
+    expect(expanded).toContain('Start calmly.');
+    expect(expanded).not.toContain('name: start-my-day');
+    await expect(expandAntigravityVaultSkillInvocation('/Start-My-Day'))
       .resolves.toContain('Start calmly.');
+  });
+
+  it('resolves duplicate names with the same root priority as the slash menu', async () => {
+    registerSkillCatalog({
+      '.claude/skills/shared/SKILL.md': 'Claude copy wins.',
+      '.agents/skills/shared/SKILL.md': 'Agents copy must not be used.',
+    });
+
+    await expect(expandAntigravityVaultSkillInvocation('/shared'))
+      .resolves.toContain('Claude copy wins.');
+    await expect(expandAntigravityVaultSkillInvocation('/shared'))
+      .resolves.not.toContain('Agents copy must not be used.');
+  });
+
+  it('passes an unknown skill invocation through unchanged', async () => {
+    registerSkillCatalog({
+      '.agents/skills/start-my-day/SKILL.md': 'Prepare a focused daily plan.',
+    });
+
+    await expect(expandAntigravityVaultSkillInvocation('/other-skill do things'))
+      .resolves.toBe('/other-skill do things');
+  });
+
+  it('keeps appended XML context outside the skill instructions', async () => {
+    registerSkillCatalog({
+      '.agents/skills/start-my-day/SKILL.md': 'Prepare a focused daily plan.',
+    });
+    const prompt = '/start-my-day prioritize health\n\n<current_note>\ndaily.md\n</current_note>';
+
+    await expect(expandAntigravityVaultSkillInvocation(prompt)).resolves.toBe([
+      'You are executing the vault skill "start-my-day". Follow its instructions.',
+      '',
+      'Prepare a focused daily plan.',
+      '',
+      'User input for this skill:',
+      'prioritize health',
+      '',
+      '<current_note>',
+      'daily.md',
+      '</current_note>',
+    ].join('\n'));
+  });
+
+  it('keeps appended XML context after a skill invoked without arguments', async () => {
+    registerSkillCatalog({
+      '.agents/skills/start-my-day/SKILL.md': 'Prepare a focused daily plan.',
+    });
+    const prompt = '/start-my-day\n\n<current_note>\ndaily.md\n</current_note>';
+
+    await expect(expandAntigravityVaultSkillInvocation(prompt)).resolves.toBe([
+      'You are executing the vault skill "start-my-day". Follow its instructions.',
+      '',
+      'Prepare a focused daily plan.',
+      '',
+      '<current_note>',
+      'daily.md',
+      '</current_note>',
+    ].join('\n'));
   });
 
   it('keeps a multibyte character that agy split across two stdout chunks intact', async () => {

--- a/tests/unit/providers/antigravity/AntigravityChatRuntime.test.ts
+++ b/tests/unit/providers/antigravity/AntigravityChatRuntime.test.ts
@@ -12,6 +12,7 @@ import { setLocale } from '@/i18n/i18n';
 import {
   AntigravityChatRuntime,
   buildAntigravityPrintArgs,
+  expandAntigravityVaultSkillInvocation,
 } from '@/providers/antigravity/runtime/AntigravityChatRuntime';
 import { updateAntigravityProviderSettings } from '@/providers/antigravity/settings';
 
@@ -111,6 +112,44 @@ describe('AntigravityChatRuntime', () => {
     }));
     expect(chunks).toContainEqual({ content: 'Hi from Antigravity', type: 'text' });
     expect(chunks[chunks.length - 1]).toEqual({ type: 'done' });
+  });
+
+  it('expands a shared content-only skill and passes its arguments to AGY', async () => {
+    const plugin = createMockPlugin({
+      app: {
+        vault: {
+          adapter: {
+            list: jest.fn(async (root: string) => root === '.claude/skills'
+              ? { folders: [], files: [] }
+              : { folders: ['.agents/skills/start-my-day'], files: [] }),
+            read: jest.fn(async (path: string) => path === '.agents/skills/start-my-day/SKILL.md'
+              ? 'Prepare a focused daily plan.'
+              : Promise.reject(new Error('Missing skill'))),
+          },
+        },
+      },
+    });
+
+    await expect(expandAntigravityVaultSkillInvocation(plugin, '/start-my-day prioritize health'))
+      .resolves.toContain('Prepare a focused daily plan.');
+    await expect(expandAntigravityVaultSkillInvocation(plugin, '/start-my-day prioritize health'))
+      .resolves.toContain('User input for this skill:\nprioritize health');
+  });
+
+  it('expands a skill selected by its frontmatter name', async () => {
+    const plugin = createMockPlugin({
+      app: {
+        vault: {
+          adapter: {
+            list: jest.fn(async () => ({ folders: ['.claude/skills/daily-routine'], files: [] })),
+            read: jest.fn(async () => '---\nname: start-my-day\n---\n\nStart calmly.'),
+          },
+        },
+      },
+    });
+
+    await expect(expandAntigravityVaultSkillInvocation(plugin, '/start-my-day'))
+      .resolves.toContain('Start calmly.');
   });
 
   it('keeps a multibyte character that agy split across two stdout chunks intact', async () => {

--- a/tests/unit/providers/antigravity/registration.test.ts
+++ b/tests/unit/providers/antigravity/registration.test.ts
@@ -58,12 +58,14 @@ describe('Antigravity provider registration', () => {
       ['.claude/skills/shared/SKILL.md', '---\nname: shared\ndescription: Claude copy\n---\n\nUse Claude copy.'],
       ['.agents/skills/review/SKILL.md', 'Review the current changes before merging.'],
       ['.agents/skills/shared/SKILL.md', 'Shared copy that must be hidden.'],
+      ['.agents/skills/deep-work/SKILL.md', '---\nname: "Deep Work"\ndescription: Uninvocable name\n---\n\nCannot be typed as /Deep Work.'],
+      ['.agents/skills/empty/SKILL.md', '   '],
     ]);
     const vaultAdapter = {
       listFiles: jest.fn().mockResolvedValue([]),
       listFolders: jest.fn(async (root: string) => root === '.claude/skills'
         ? ['.claude/skills/start-my-day', '.claude/skills/shared']
-        : ['.agents/skills/review', '.agents/skills/shared']),
+        : ['.agents/skills/review', '.agents/skills/shared', '.agents/skills/deep-work', '.agents/skills/empty']),
       read: jest.fn(async (path: string) => files.get(path) ?? Promise.reject(new Error('Missing skill'))),
     };
     const services = await antigravityWorkspaceRegistration.initialize({
@@ -75,10 +77,12 @@ describe('Antigravity provider registration', () => {
 
     const entries = await services.commandCatalog.listDropdownEntries({ includeBuiltIns: false });
 
-    expect(entries.map(({ name, displayPrefix, insertPrefix }) => ({ name, displayPrefix, insertPrefix }))).toEqual([
-      { name: 'start-my-day', displayPrefix: '/', insertPrefix: '/' },
-      { name: 'shared', displayPrefix: '/', insertPrefix: '/' },
-      { name: 'review', displayPrefix: '/', insertPrefix: '/' },
+    expect(entries.map(({ name, description, displayPrefix, insertPrefix }) => (
+      { name, description, displayPrefix, insertPrefix }
+    ))).toEqual([
+      { name: 'start-my-day', description: 'Plan today', displayPrefix: '/', insertPrefix: '/' },
+      { name: 'shared', description: 'Claude copy', displayPrefix: '/', insertPrefix: '/' },
+      { name: 'review', description: 'Review the current changes before merging.', displayPrefix: '/', insertPrefix: '/' },
     ]);
   });
 

--- a/tests/unit/providers/antigravity/registration.test.ts
+++ b/tests/unit/providers/antigravity/registration.test.ts
@@ -47,8 +47,39 @@ describe('Antigravity provider registration', () => {
     });
 
     expect(services.cliResolver).toBeDefined();
+    expect(services.commandCatalog).toBeDefined();
     expect(services.modelCatalog).toBeDefined();
     expect(services.usageProvider).toBeDefined();
+  });
+
+  it('lists frontmatter and content-only skills in the AGY slash menu', async () => {
+    const files = new Map([
+      ['.claude/skills/start-my-day/SKILL.md', '---\nname: start-my-day\ndescription: Plan today\n---\n\nStart the day.'],
+      ['.claude/skills/shared/SKILL.md', '---\nname: shared\ndescription: Claude copy\n---\n\nUse Claude copy.'],
+      ['.agents/skills/review/SKILL.md', 'Review the current changes before merging.'],
+      ['.agents/skills/shared/SKILL.md', 'Shared copy that must be hidden.'],
+    ]);
+    const vaultAdapter = {
+      listFiles: jest.fn().mockResolvedValue([]),
+      listFolders: jest.fn(async (root: string) => root === '.claude/skills'
+        ? ['.claude/skills/start-my-day', '.claude/skills/shared']
+        : ['.agents/skills/review', '.agents/skills/shared']),
+      read: jest.fn(async (path: string) => files.get(path) ?? Promise.reject(new Error('Missing skill'))),
+    };
+    const services = await antigravityWorkspaceRegistration.initialize({
+      homeAdapter: {} as any,
+      plugin: {} as any,
+      storage: {} as any,
+      vaultAdapter: vaultAdapter as any,
+    });
+
+    const entries = await services.commandCatalog.listDropdownEntries({ includeBuiltIns: false });
+
+    expect(entries.map(({ name, displayPrefix, insertPrefix }) => ({ name, displayPrefix, insertPrefix }))).toEqual([
+      { name: 'start-my-day', displayPrefix: '/', insertPrefix: '/' },
+      { name: 'shared', displayPrefix: '/', insertPrefix: '/' },
+      { name: 'review', displayPrefix: '/', insertPrefix: '/' },
+    ]);
   });
 
   it('replaces the synthetic fallback with discovered agy models on refresh', async () => {


### PR DESCRIPTION
## Summary\n- register a Vault skill catalog for Antigravity's slash menu\n- list .claude/skills and .agents/skills, including content-only SKILL.md files\n- expand selected Vault skills before passing the prompt to AGY\n\n## Verification\n- 52 focused unit tests passed\n- TypeScript and lint checks passed\n- production build completed