### PR TITLE
fix(antigravity): quote Windows cmd.exe launch arguments

### DIFF
--- a/src/providers/antigravity/AGENTS.md
+++ b/src/providers/antigravity/AGENTS.md
@@ -12,6 +12,7 @@
 - Antigravity settings expose custom model labels so users can add account-specific models when Windows model discovery is incomplete.
 - The AGY slash menu lists read-only vault skills from `.claude/skills` and `.agents/skills` through `VaultSkillCommandCatalog` (content-only SKILL.md files allowed). Because `agy --print` has no slash surface, `AntigravityChatRuntime` expands a leading `/skill-name` invocation client-side through the registered command catalog before launching AGY; keep menu filtering and the expansion grammar in sync.
 - Antigravity CLI 1.0.7 does not expose Gemini CLI's `--acp` flag; do not route it through `src/providers/acp/` unless a real ACP-compatible runtime is confirmed.
+- On Windows, resolved `.exe` commands launch directly; `.cmd`/`.bat` launchers and bare command names go through an explicit `cmd.exe /d /s /c` invocation with per-argument quoting in `AntigravityProcessLaunch` — never Node's `shell: true`, which concatenates the command line without quoting arguments (#59).
 - Auxiliary workflows such as title generation, instruction refinement, and inline edit are unsupported until an Antigravity auxiliary runner exists.
 
 ## Boundaries

--- a/src/providers/antigravity/runtime/AntigravityProcessLaunch.ts
+++ b/src/providers/antigravity/runtime/AntigravityProcessLaunch.ts
@@ -1,7 +1,7 @@
 export interface AntigravityProcessLaunch {
   args: string[];
   command: string;
-  launchMode: 'direct' | 'shellLogin';
+  launchMode: 'direct' | 'shellLogin' | 'cmdShell';
   shell: boolean;
 }
 
@@ -9,8 +9,9 @@ export function buildAntigravityProcessLaunch(
   command: string,
   args: string[],
   runtimeEnv: NodeJS.ProcessEnv,
+  platform: NodeJS.Platform = process.platform,
 ): AntigravityProcessLaunch {
-  if (process.platform === 'win32') {
+  if (platform === 'win32') {
     if (canLaunchDirectlyOnWindows(command)) {
       return {
         args,
@@ -20,11 +21,15 @@ export function buildAntigravityProcessLaunch(
       };
     }
 
+    // .cmd/.bat launchers and bare command names must be interpreted by
+    // cmd.exe, but Node's `shell: true` concatenates the command line without
+    // per-argument quoting, letting prompt content break out of its argument
+    // (#59). Quote everything ourselves and spawn cmd.exe directly instead.
     return {
-      args,
-      command,
-      launchMode: 'direct',
-      shell: true,
+      args: ['/d', '/s', '/c', buildWindowsShellCommandLine(command, args)],
+      command: 'cmd.exe',
+      launchMode: 'cmdShell',
+      shell: false,
     };
   }
 
@@ -44,6 +49,26 @@ export function buildAntigravityProcessLaunch(
     launchMode: 'shellLogin',
     shell: false,
   };
+}
+
+/**
+ * Build the command line passed to `cmd.exe /d /s /c` for non-`.exe`
+ * launchers. Each element is quoted so cmd.exe treats metacharacters
+ * (`& | < > ^`) as literals and never re-parses argument boundaries.
+ */
+export function buildWindowsShellCommandLine(command: string, args: string[]): string {
+  return [command, ...args].map(quoteWindowsArgument).join(' ');
+}
+
+function quoteWindowsArgument(value: string): string {
+  // Double backslashes that precede a quote or the closing quote so the
+  // child's argv parser keeps them, and double internal quotes so cmd.exe's
+  // quote state stays balanced while the child receives a literal quote.
+  // `%` expansion remains a cmd.exe limitation and cannot be escaped here.
+  const prepared = value
+    .replace(/(\\*)"/g, '$1$1""')
+    .replace(/(\\+)$/, '$1$1');
+  return `"${prepared}"`;
 }
 
 function canLaunchDirectlyOnWindows(command: string): boolean {

--- a/tests/unit/providers/antigravity/AntigravityProcessLaunch.test.ts
+++ b/tests/unit/providers/antigravity/AntigravityProcessLaunch.test.ts
@@ -1,4 +1,7 @@
-import { buildAntigravityProcessLaunch } from '@/providers/antigravity/runtime/AntigravityProcessLaunch';
+import {
+  buildAntigravityProcessLaunch,
+  buildWindowsShellCommandLine,
+} from '@/providers/antigravity/runtime/AntigravityProcessLaunch';
 
 describe('buildAntigravityProcessLaunch', () => {
   it('wraps Antigravity launches in the user shell without shell-escaping arguments', () => {
@@ -9,13 +12,7 @@ describe('buildAntigravityProcessLaunch', () => {
       'hello && rm -rf nope',
     ], {
       SHELL: '/bin/zsh',
-    });
-
-    if (process.platform === 'win32') {
-      // eslint-disable-next-line jest/no-conditional-expect -- launch behavior is platform-specific.
-      expect(launch.launchMode).toBe('direct');
-      return;
-    }
+    }, 'darwin');
 
     expect(launch).toEqual({
       args: [
@@ -34,14 +31,10 @@ describe('buildAntigravityProcessLaunch', () => {
   });
 
   it('launches a resolved Windows agy.exe directly instead of through cmd.exe', () => {
-    if (process.platform !== 'win32') {
-      return;
-    }
-
     const launch = buildAntigravityProcessLaunch('C:\\Users\\test\\AppData\\Local\\agy\\bin\\agy.exe', [
       '--print',
       'hello',
-    ], {});
+    ], {}, 'win32');
 
     expect(launch).toEqual({
       args: [
@@ -52,5 +45,69 @@ describe('buildAntigravityProcessLaunch', () => {
       launchMode: 'direct',
       shell: false,
     });
+  });
+
+  it('routes Windows .cmd launchers through an explicitly quoted cmd.exe invocation', () => {
+    const launch = buildAntigravityProcessLaunch('C:\\Users\\test\\AppData\\agy.cmd', [
+      '--print',
+      'summarize this & echo injected',
+    ], {}, 'win32');
+
+    expect(launch).toEqual({
+      args: [
+        '/d',
+        '/s',
+        '/c',
+        '"C:\\Users\\test\\AppData\\agy.cmd" "--print" "summarize this & echo injected"',
+      ],
+      command: 'cmd.exe',
+      launchMode: 'cmdShell',
+      shell: false,
+    });
+  });
+
+  it('resolves bare Windows command names through cmd.exe with quoted arguments', () => {
+    const launch = buildAntigravityProcessLaunch('agy', [
+      '--print',
+      'hello',
+    ], {}, 'win32');
+
+    expect(launch).toEqual({
+      args: ['/d', '/s', '/c', '"agy" "--print" "hello"'],
+      command: 'cmd.exe',
+      launchMode: 'cmdShell',
+      shell: false,
+    });
+  });
+});
+
+describe('buildWindowsShellCommandLine', () => {
+  it('keeps cmd.exe metacharacters inert inside quoted arguments', () => {
+    expect(buildWindowsShellCommandLine('agy.cmd', ['--print', 'a & b | c < d > e ^ f']))
+      .toBe('"agy.cmd" "--print" "a & b | c < d > e ^ f"');
+  });
+
+  it('doubles internal quotes so the child receives them as literals', () => {
+    expect(buildWindowsShellCommandLine('agy.cmd', ['--print', 'say "hi" now']))
+      .toBe('"agy.cmd" "--print" "say ""hi"" now"');
+  });
+
+  it('doubles backslashes that precede a quote or the closing quote', () => {
+    expect(buildWindowsShellCommandLine('agy.cmd', ['--print', 'path C:\\dir\\ "name"']))
+      .toBe('"agy.cmd" "--print" "path C:\\dir\\ ""name"""');
+    expect(buildWindowsShellCommandLine('agy.cmd', ['--print', 'before\\"after']))
+      .toBe('"agy.cmd" "--print" "before\\\\""after"');
+    expect(buildWindowsShellCommandLine('agy.cmd', ['--print', 'trailing\\']))
+      .toBe('"agy.cmd" "--print" "trailing\\\\"');
+  });
+
+  it('keeps paths with spaces as a single command token', () => {
+    expect(buildWindowsShellCommandLine('C:\\Program Files\\agy\\agy.cmd', ['models']))
+      .toBe('"C:\\Program Files\\agy\\agy.cmd" "models"');
+  });
+
+  it('preserves multibyte prompt content unchanged', () => {
+    expect(buildWindowsShellCommandLine('agy.cmd', ['--print', 'привет 世界 🌍']))
+      .toBe('"agy.cmd" "--print" "привет 世界 🌍"');
   });
 });


### PR DESCRIPTION
Fixes #59.

## Summary

- Replace Node's `shell: true` for non-`.exe` Windows launches (`.cmd`/`.bat` launchers and bare command names) with an explicit `cmd.exe /d /s /c` invocation whose command line we quote ourselves.
- `shell: true` concatenates the command and arguments into one `cmd.exe` string **without per-argument quoting**, so the prompt after `--print` was parsed by cmd.exe and metacharacters (`& | < > ^`, quotes) could break out of the argument. With per-argument quoting, metacharacters stay inert inside quoted spans and the child's argv parser receives the original text.
- Quoting rules: internal quotes are doubled (`""`), which keeps cmd.exe's quote state balanced while the child receives a literal quote; backslashes that precede a quote or the closing quote are doubled for the argv parser. `%variable%` expansion remains a cmd.exe limitation that cannot be escaped on a `/c` command line (documented in code).
- Side repair: the temp `--log-file` path (which contains spaces on typical Windows profiles) was previously passed unquoted through `shell: true` in `AntigravityModelDiscovery`, splitting the argument; it is now quoted like every other argument.
- `buildAntigravityProcessLaunch` gained an optional `platform` parameter so the win32 branches are unit-testable on any OS, and a `cmdShell` launch mode value for accurate debug logging.
- Documented the Windows launch rule in `src/providers/antigravity/AGENTS.md`.

## Testing

- 9 launcher unit tests covering: POSIX shell-login passthrough, direct `.exe` launch, `.cmd` and bare-name `cmd.exe` routing, metacharacter/quoting/backslash/path-with-spaces/multibyte cases — all runnable on any platform via the `platform` parameter.
- Full local gate: 403 suites / 7013 unit tests, typecheck, lint, and `build:release` pass.
