### PR TITLE
fix(grok): serialize concurrent ensureReady restarts

### DIFF
--- a/src/providers/grok/runtime/GrokChatRuntime.ts
+++ b/src/providers/grok/runtime/GrokChatRuntime.ts
@@ -217,6 +217,7 @@ export class GrokChatRuntime implements ChatRuntime {
   private currentSessionModeId: string | null = null;
   private currentTurnSawAcpCost = false;
   private currentTurnMetadata: ChatTurnMetadata = {};
+  private ensureReadyChain: Promise<unknown> = Promise.resolve(true);
   private loadedSessionId: string | null = null;
   private process: AcpSubprocess | null = null;
   private promptUsage: AcpUsage | null = null;
@@ -342,6 +343,20 @@ export class GrokChatRuntime implements ChatRuntime {
   }
 
   async ensureReady(options?: ChatRuntimeEnsureReadyOptions): Promise<boolean> {
+    // Serialize readiness checks: concurrent callers (the send path and the
+    // slash-menu command catalog) each evaluate restart reasons against shared
+    // process/transport state. Without serialization, a caller that evaluates
+    // mid-restart sees partial state, shuts the fresh process down, and races
+    // its own start — the first turn then fails with a start error.
+    const run = this.ensureReadyChain.then(
+      () => this.runEnsureReady(options),
+      () => this.runEnsureReady(options),
+    );
+    this.ensureReadyChain = run.then(() => undefined, () => undefined);
+    return run;
+  }
+
+  private async runEnsureReady(options?: ChatRuntimeEnsureReadyOptions): Promise<boolean> {
     const settings = getGrokProviderSettings(this.plugin.settings);
     if (!settings.enabled) {
       logGrokDebug(this.plugin, 'ensureReady.skipped', {

--- a/tests/unit/providers/grok/GrokChatRuntime.test.ts
+++ b/tests/unit/providers/grok/GrokChatRuntime.test.ts
@@ -490,6 +490,53 @@ describe('GrokChatRuntime', () => {
     expect(startProcess).toHaveBeenCalled();
   });
 
+  it('serializes concurrent ensureReady calls into a single process restart', async () => {
+    const plugin = createMockPlugin({
+      settings: {
+        providerConfigs: {
+          grok: {
+            enabled: true,
+          },
+        },
+      },
+    });
+    const runtime = new GrokChatRuntime(plugin);
+
+    jest.spyOn(launchArtifacts, 'prepareGrokLaunchArtifacts').mockResolvedValue({
+      configContent: '# managed\n',
+      grokHomePath: '/tmp/grimoire-grok-home',
+      launchKey: 'launch-key',
+      managedConfigPath: '/tmp/grimoire-grok-home/managed_config.toml',
+      systemPromptPath: '/tmp/grimoire-grok-home/system.md',
+    });
+    // A slow start reproduces the real race: without serialization the second
+    // caller evaluates restart reasons while the first restart is mid-flight,
+    // shuts the fresh process down, and starts its own.
+    const startProcess = jest.spyOn(runtime as any, 'startProcess').mockImplementation(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      (runtime as any).process = { isAlive: () => true };
+      (runtime as any).transport = { isClosed: false };
+      (runtime as any).connection = {};
+      (runtime as any).ready = true;
+    });
+    const shutdownProcess = jest.spyOn(runtime as any, 'shutdownProcess').mockResolvedValue(undefined);
+    (runtime as any).createSession = jest.fn().mockImplementation(async () => {
+      (runtime as any).sessionId = 'session-1';
+      return 'session-1';
+    });
+    (runtime as any).loadSession = jest.fn().mockResolvedValue(true);
+
+    const [fromSend, fromCommandCatalog] = await Promise.all([
+      runtime.ensureReady({ allowSessionCreation: true }),
+      runtime.ensureReady({ allowSessionCreation: false }),
+    ]);
+
+    expect(fromSend).toBe(true);
+    expect(fromCommandCatalog).toBe(true);
+    expect(startProcess).toHaveBeenCalledTimes(1);
+    expect(shutdownProcess).toHaveBeenCalledTimes(1);
+  });
+
   it('builds launch artifacts from the Grok-projected permission mode', async () => {
     const plugin = createMockPlugin({
       settings: {


### PR DESCRIPTION
## Summary

Fixes a first-turn launch failure observed with Grok Build in debug logs:

- `ensureReady` had no mutual exclusion. When the send path (`query()`) and the slash-menu command catalog (`getSupportedCommands()`) called it within milliseconds of each other, each caller independently evaluated restart reasons against shared process/transport/connection state.
- A caller evaluating mid-restart saw partial state (spawned process without a connection yet — exactly "1 restart reason" in the logs), ran its own `shutdownProcess()` — killing the process the other caller had just spawned — and raced its own `startProcess()`.
- The interleaved start failed instantly with an empty stderr, and the first turn surfaced `Failed to start Grok Build. Check the CLI path and login state` even though the CLI path and login were fine. The racing caller's process came up ~0.5s later, which is why the second message worked.

Log evidence (test vault, 2026-08-20):

```
55.337 ensureReady.started  {allowSessionCreation: true}  → restart (4 reasons)
55.339 ensureReady.started  {allowSessionCreation: false} → restart (1 reason: missing_connection)
55.339 runtime.start.failed {stderrPreview: ""}
55.339 query.ensureReady.failed → user-facing start error
55.876 runtime.ready (the other caller's process)
```

## Fix

Serialize `ensureReady` through a promise chain: concurrent callers queue behind the in-flight readiness check and re-evaluate restart reasons against the settled post-restart state. Exactly one shutdown/start cycle runs per readiness wave; caller-specific options (`allowSessionCreation`, `force`) are still honored per call since each queued caller runs its own evaluation.

## Testing

- New unit test `serializes concurrent ensureReady calls into a single process restart`: two concurrent `ensureReady` calls (send-style `allowSessionCreation: true` + catalog-style `false`) with a deliberately slow start must resolve with exactly one `startProcess` and one `shutdownProcess`. Verified it fails on the pre-fix code and passes with the fix.
- Full local gate: 403 suites / 7014 unit tests, typecheck, lint, `build:release`.
