### PR TITLE
fix(antigravity): pass vault to agy --print via probed --add-dir

### DIFF
--- a/src/providers/antigravity/AGENTS.md
+++ b/src/providers/antigravity/AGENTS.md
@@ -13,6 +13,7 @@
 - The AGY slash menu lists read-only vault skills from `.claude/skills` and `.agents/skills` through `VaultSkillCommandCatalog` (content-only SKILL.md files allowed). Because `agy --print` has no slash surface, `AntigravityChatRuntime` expands a leading `/skill-name` invocation client-side through the registered command catalog before launching AGY; keep menu filtering and the expansion grammar in sync.
 - Antigravity CLI 1.0.7 does not expose Gemini CLI's `--acp` flag; do not route it through `src/providers/acp/` unless a real ACP-compatible runtime is confirmed.
 - On Windows, resolved `.exe` commands launch directly; `.cmd`/`.bat` launchers and bare command names go through an explicit `cmd.exe /d /s /c` invocation with per-argument quoting in `AntigravityProcessLaunch` — never Node's `shell: true`, which concatenates the command line without quoting arguments (#59).
+- Grimoire probes `agy --help` once per CLI command for `--add-dir` support (`AntigravityAddDirSupport`) and prepends `--add-dir <vault>` to `agy --print` when advertised, so the agent workspace includes the vault root without wrapper scripts (#67). The probe fails closed: spawn errors, timeouts, or the Windows empty-help quirk launch without the flag.
 - Auxiliary workflows such as title generation, instruction refinement, and inline edit are unsupported until an Antigravity auxiliary runner exists.
 
 ## Boundaries

--- a/src/providers/antigravity/runtime/AntigravityAddDirSupport.ts
+++ b/src/providers/antigravity/runtime/AntigravityAddDirSupport.ts
@@ -1,0 +1,82 @@
+import { type ChildProcess, spawn } from 'node:child_process';
+
+import { buildAntigravityProcessLaunch } from './AntigravityProcessLaunch';
+
+const ADD_DIR_HELP_PROBE_TIMEOUT_MS = 10_000;
+
+const addDirSupportByCommand = new Map<string, Promise<boolean>>();
+
+/**
+ * Older `agy` builds predate `--add-dir`, and Windows builds can return exit
+ * code 0 with empty stdout (#67), so support is probed from `agy --help`
+ * instead of assumed. The result is cached per CLI command; callers that find
+ * no support simply launch without the flag, preserving existing behavior.
+ */
+export function probeAntigravityAddDirSupport(
+  command: string,
+  runtimeEnv: NodeJS.ProcessEnv,
+): Promise<boolean> {
+  const cached = addDirSupportByCommand.get(command);
+  if (cached) {
+    return cached;
+  }
+  const probe = detectAddDirSupport(command, runtimeEnv).catch(() => false);
+  addDirSupportByCommand.set(command, probe);
+  return probe;
+}
+
+export function resetAntigravityAddDirSupportCache(): void {
+  addDirSupportByCommand.clear();
+}
+
+async function detectAddDirSupport(
+  command: string,
+  runtimeEnv: NodeJS.ProcessEnv,
+): Promise<boolean> {
+  const launch = buildAntigravityProcessLaunch(command, ['--help'], runtimeEnv);
+  return new Promise<boolean>((resolve) => {
+    let child: ChildProcess;
+    try {
+      child = spawn(launch.command, launch.args, {
+        env: runtimeEnv,
+        shell: launch.shell,
+        stdio: ['ignore', 'pipe', 'pipe'],
+        windowsHide: true,
+      });
+    } catch {
+      resolve(false);
+      return;
+    }
+
+    let output = '';
+    let settled = false;
+    let timer: number | undefined;
+    const settle = (supported: boolean): void => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      if (timer) {
+        window.clearTimeout(timer);
+      }
+      try {
+        child.kill();
+      } catch {
+        // The child already exited between the event and this call.
+      }
+      resolve(supported);
+    };
+    const collect = (chunk: Buffer | string): void => {
+      output += chunk.toString();
+      if (output.includes('--add-dir')) {
+        settle(true);
+      }
+    };
+
+    child.stdout?.on('data', collect);
+    child.stderr?.on('data', collect);
+    child.on('error', () => settle(output.includes('--add-dir')));
+    child.on('close', () => settle(output.includes('--add-dir')));
+    timer = window.setTimeout(() => settle(false), ADD_DIR_HELP_PROBE_TIMEOUT_MS);
+  });
+}

--- a/src/providers/antigravity/runtime/AntigravityAddDirSupport.ts
+++ b/src/providers/antigravity/runtime/AntigravityAddDirSupport.ts
@@ -3,6 +3,12 @@ import { type ChildProcess, spawn } from 'node:child_process';
 import { buildAntigravityProcessLaunch } from './AntigravityProcessLaunch';
 
 const ADD_DIR_HELP_PROBE_TIMEOUT_MS = 10_000;
+const PROBE_OUTPUT_LIMIT = 64_000;
+
+// Anchored so sibling flags like a hypothetical `--add-directory` do not
+// register as support; `--no-add-dir` cannot match because its only `--`
+// precedes `no`.
+const ADD_DIR_FLAG_PATTERN = /--add-dir\b/;
 
 const addDirSupportByCommand = new Map<string, Promise<boolean>>();
 
@@ -15,12 +21,13 @@ const addDirSupportByCommand = new Map<string, Promise<boolean>>();
 export function probeAntigravityAddDirSupport(
   command: string,
   runtimeEnv: NodeJS.ProcessEnv,
+  onSpawn?: (child: ChildProcess) => void,
 ): Promise<boolean> {
   const cached = addDirSupportByCommand.get(command);
   if (cached) {
     return cached;
   }
-  const probe = detectAddDirSupport(command, runtimeEnv).catch(() => false);
+  const probe = detectAddDirSupport(command, runtimeEnv, onSpawn).catch(() => false);
   addDirSupportByCommand.set(command, probe);
   return probe;
 }
@@ -32,6 +39,7 @@ export function resetAntigravityAddDirSupportCache(): void {
 async function detectAddDirSupport(
   command: string,
   runtimeEnv: NodeJS.ProcessEnv,
+  onSpawn?: (child: ChildProcess) => void,
 ): Promise<boolean> {
   const launch = buildAntigravityProcessLaunch(command, ['--help'], runtimeEnv);
   return new Promise<boolean>((resolve) => {
@@ -47,6 +55,7 @@ async function detectAddDirSupport(
       resolve(false);
       return;
     }
+    onSpawn?.(child);
 
     let output = '';
     let settled = false;
@@ -64,19 +73,27 @@ async function detectAddDirSupport(
       } catch {
         // The child already exited between the event and this call.
       }
+      // Destroying the read ends stops accumulation and closes the pipe so an
+      // orphaned writer (e.g. agy under a killed cmd.exe wrapper) gets EPIPE
+      // instead of keeping a broken CLI streaming into memory.
+      child.stdout?.destroy();
+      child.stderr?.destroy();
       resolve(supported);
     };
     const collect = (chunk: Buffer | string): void => {
+      if (settled || output.length >= PROBE_OUTPUT_LIMIT) {
+        return;
+      }
       output += chunk.toString();
-      if (output.includes('--add-dir')) {
+      if (ADD_DIR_FLAG_PATTERN.test(output)) {
         settle(true);
       }
     };
 
     child.stdout?.on('data', collect);
     child.stderr?.on('data', collect);
-    child.on('error', () => settle(output.includes('--add-dir')));
-    child.on('close', () => settle(output.includes('--add-dir')));
+    child.on('error', () => settle(ADD_DIR_FLAG_PATTERN.test(output)));
+    child.on('close', () => settle(ADD_DIR_FLAG_PATTERN.test(output)));
     timer = window.setTimeout(() => settle(false), ADD_DIR_HELP_PROBE_TIMEOUT_MS);
   });
 }

--- a/src/providers/antigravity/runtime/AntigravityChatRuntime.ts
+++ b/src/providers/antigravity/runtime/AntigravityChatRuntime.ts
@@ -77,6 +77,8 @@ export class AntigravityChatRuntime implements ChatRuntime {
 
   private activeProcess: ChildProcess | null = null;
   private currentTurnMetadata: ChatTurnMetadata = {};
+  private cancelRequested = false;
+  private probeProcess: ChildProcess | null = null;
   private readonly readyListeners: Array<(ready: boolean) => void> = [];
   private ready = false;
 
@@ -130,6 +132,7 @@ export class AntigravityChatRuntime implements ChatRuntime {
       yield { type: 'done' };
       return;
     }
+    this.cancelRequested = false;
 
     const vaultPath = getVaultPath(this.plugin.app);
     const cwd = vaultPath ?? process.cwd();
@@ -152,7 +155,16 @@ export class AntigravityChatRuntime implements ChatRuntime {
 
     try {
       yield { content: 'Starting Antigravity...', type: 'status' };
-      const addDirSupported = await probeAntigravityAddDirSupport(command, runtimeEnv);
+      const addDirSupported = await probeAntigravityAddDirSupport(command, runtimeEnv, (child) => {
+        this.probeProcess = child;
+      });
+      this.probeProcess = null;
+      if (this.cancelRequested) {
+        // The consumer discards chunks once cancelRequested is set, so a bare
+        // done ends the turn without launching a print run the user stopped.
+        yield { type: 'done' };
+        return;
+      }
       this.plugin.recordDebugLog?.({
         data: {
           command,
@@ -194,11 +206,16 @@ export class AntigravityChatRuntime implements ChatRuntime {
       yield { type: 'done' };
     } finally {
       this.activeProcess = null;
+      this.probeProcess = null;
     }
   }
 
   cancel(): void {
+    this.cancelRequested = true;
     this.activeProcess?.kill('SIGTERM');
+    // Kill the in-flight help probe too so cancel does not wait out its
+    // timeout before the generator can observe the flag.
+    this.probeProcess?.kill('SIGTERM');
   }
 
   resetSession(): void {}
@@ -782,11 +799,16 @@ function getCwdLabel(plugin: GrimoirePlugin, cwd: string): string {
 
 function summarizeAntigravityPrintArgs(args: string[]): string {
   return args.map((arg, index) => {
-    if (arg === '--print') {
+    if (arg === '--print' || arg === '--add-dir') {
       return arg;
     }
     if (index > 0 && args[index - 1] === '--print') {
       return '<prompt>';
+    }
+    // Keep the absolute vault path out of debug logs; the shared sanitizer's
+    // path redaction does not cover every platform's home prefixes.
+    if (index > 0 && args[index - 1] === '--add-dir') {
+      return '<vault-path>';
     }
     return arg;
   }).join(' ');

--- a/src/providers/antigravity/runtime/AntigravityChatRuntime.ts
+++ b/src/providers/antigravity/runtime/AntigravityChatRuntime.ts
@@ -47,6 +47,7 @@ import { createUtf8ChunkDecoder, type Utf8ChunkDecoder } from '../../../utils/ut
 import { ANTIGRAVITY_PROVIDER_CAPABILITIES } from '../capabilities';
 import { decodeAntigravityModelId } from '../models';
 import { getAntigravityProviderSettings } from '../settings';
+import { probeAntigravityAddDirSupport } from './AntigravityAddDirSupport';
 import { buildAntigravityProcessLaunch } from './AntigravityProcessLaunch';
 import { buildAntigravityRuntimeEnv } from './AntigravityRuntimeEnvironment';
 
@@ -54,6 +55,7 @@ const OUTPUT_BUFFER_LIMIT = 64_000;
 const PRINT_TIMEOUT_MS = 5 * 60 * 1000;
 
 interface AntigravityPrintSpec {
+  addDirPath: string | null;
   command: string;
   cwd: string;
   model: string | null;
@@ -63,6 +65,7 @@ interface AntigravityPrintSpec {
 }
 
 export interface AntigravityPrintArgsSpec {
+  addDirPath?: string | null;
   logFilePath?: string;
   model: string | null;
   permissionMode: string;
@@ -128,8 +131,10 @@ export class AntigravityChatRuntime implements ChatRuntime {
       return;
     }
 
-    const cwd = getVaultPath(this.plugin.app) ?? process.cwd();
+    const vaultPath = getVaultPath(this.plugin.app);
+    const cwd = vaultPath ?? process.cwd();
     const command = this.plugin.getResolvedProviderCliPath('antigravity') ?? 'agy';
+    const runtimeEnv = buildAntigravityRuntimeEnv(this.plugin.settings, command);
     const permissionMode = this.getPermissionMode();
     if (permissionMode !== 'full_access') {
       yield {
@@ -147,13 +152,25 @@ export class AntigravityChatRuntime implements ChatRuntime {
 
     try {
       yield { content: 'Starting Antigravity...', type: 'status' };
+      const addDirSupported = await probeAntigravityAddDirSupport(command, runtimeEnv);
+      this.plugin.recordDebugLog?.({
+        data: {
+          command,
+          providerId: this.providerId,
+          supported: addDirSupported,
+        },
+        event: 'print.addDirProbe',
+        level: 'debug',
+        scope: 'provider.antigravity',
+      });
       const output = await this.runPrint({
+        addDirPath: addDirSupported ? vaultPath : null,
         command,
         cwd,
         model: this.getSelectedRawModel(queryOptions),
         permissionMode,
         prompt,
-        runtimeEnv: buildAntigravityRuntimeEnv(this.plugin.settings, command),
+        runtimeEnv,
       });
       const trimmed = output.trim();
       if (trimmed) {
@@ -586,6 +603,9 @@ async function findAntigravityVaultSkill(skillName: string): Promise<string | nu
 
 export function buildAntigravityPrintArgs(spec: AntigravityPrintArgsSpec): string[] {
   const args: string[] = [];
+  if (spec.addDirPath) {
+    args.push('--add-dir', spec.addDirPath);
+  }
   if (spec.permissionMode === 'full_access') {
     args.push('--dangerously-skip-permissions');
   } else {

--- a/tests/unit/providers/antigravity/AntigravityAddDirSupport.test.ts
+++ b/tests/unit/providers/antigravity/AntigravityAddDirSupport.test.ts
@@ -17,6 +17,9 @@ function createMockChildProcess(): any {
   const proc = new EventEmitter() as any;
   proc.stdout = new PassThrough();
   proc.stderr = new PassThrough();
+  // Probe teardown destroys the pipes; tolerate writes that arrive after it.
+  proc.stdout.on('error', () => {});
+  proc.stderr.on('error', () => {});
   proc.stdin = null;
   proc.kill = jest.fn();
   proc.pid = 4321;
@@ -98,6 +101,81 @@ describe('probeAntigravityAddDirSupport', () => {
 
     await expect(probeAntigravityAddDirSupport('/usr/local/bin/agy', {})).resolves.toBe(true);
     expect(mockedSpawn).toHaveBeenCalledTimes(1);
+  });
+
+  it('also caches negative results so failed probes do not respawn every turn', async () => {
+    const proc = createMockChildProcess();
+    mockedSpawn.mockReturnValue(proc);
+
+    const first = probeAntigravityAddDirSupport('agy', {});
+    emitHelpAndExit(proc, '  --print');
+    await expect(first).resolves.toBe(false);
+
+    await expect(probeAntigravityAddDirSupport('agy', {})).resolves.toBe(false);
+    expect(mockedSpawn).toHaveBeenCalledTimes(1);
+  });
+
+  it('fail-closes when agy --help never finishes, and stays settled once', async () => {
+    jest.useFakeTimers();
+    try {
+      const proc = createMockChildProcess();
+      mockedSpawn.mockReturnValue(proc);
+
+      const promise = probeAntigravityAddDirSupport('agy', {});
+      jest.advanceTimersByTime(10_000);
+
+      await expect(promise).resolves.toBe(false);
+      expect(proc.kill).toHaveBeenCalledTimes(1);
+
+      // Late help output after the timeout must not flip the cached result.
+      proc.stdout.write('  --add-dir <dir>');
+      proc.emit('close', 0, null);
+      await expect(probeAntigravityAddDirSupport('agy', {})).resolves.toBe(false);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('does not match sibling flags that merely contain the substring', async () => {
+    const directoryProc = createMockChildProcess();
+    mockedSpawn.mockReturnValue(directoryProc);
+    const directoryPromise = probeAntigravityAddDirSupport('agy', {});
+    emitHelpAndExit(directoryProc, '  --add-directory <dir>   Add many directories\n  --print');
+    await expect(directoryPromise).resolves.toBe(false);
+
+    resetAntigravityAddDirSupportCache();
+    const negationProc = createMockChildProcess();
+    mockedSpawn.mockReturnValue(negationProc);
+    const negationPromise = probeAntigravityAddDirSupport('agy', {});
+    emitHelpAndExit(negationProc, '  --no-add-dir            Disable extra directories\n  --print');
+    await expect(negationPromise).resolves.toBe(false);
+  });
+
+  it('fail-closes past the output cap even when --add-dir arrives later', async () => {
+    const proc = createMockChildProcess();
+    mockedSpawn.mockReturnValue(proc);
+
+    const promise = probeAntigravityAddDirSupport('agy', {});
+    const filler = `${'x'.repeat(1024)}\n`;
+    for (let i = 0; i < 80; i += 1) {
+      proc.stdout.write(filler);
+    }
+    proc.stdout.write('  --add-dir <dir>');
+    proc.emit('close', 0, null);
+
+    await expect(promise).resolves.toBe(false);
+  });
+
+  it('reports the spawned probe child so callers can cancel it', async () => {
+    const proc = createMockChildProcess();
+    mockedSpawn.mockReturnValue(proc);
+    const onSpawn = jest.fn();
+
+    const promise = probeAntigravityAddDirSupport('agy', {}, onSpawn);
+    expect(onSpawn).toHaveBeenCalledWith(proc);
+    emitHelpAndExit(proc, '  --add-dir <dir>');
+
+    await expect(promise).resolves.toBe(true);
   });
 
   it('probes different CLI commands separately', async () => {

--- a/tests/unit/providers/antigravity/AntigravityAddDirSupport.test.ts
+++ b/tests/unit/providers/antigravity/AntigravityAddDirSupport.test.ts
@@ -1,0 +1,130 @@
+import { spawn } from 'node:child_process';
+import { EventEmitter } from 'node:events';
+import { PassThrough } from 'node:stream';
+
+import {
+  probeAntigravityAddDirSupport,
+  resetAntigravityAddDirSupportCache,
+} from '@/providers/antigravity/runtime/AntigravityAddDirSupport';
+
+jest.mock('node:child_process', () => ({
+  spawn: jest.fn(),
+}));
+
+const mockedSpawn = spawn as jest.Mock;
+
+function createMockChildProcess(): any {
+  const proc = new EventEmitter() as any;
+  proc.stdout = new PassThrough();
+  proc.stderr = new PassThrough();
+  proc.stdin = null;
+  proc.kill = jest.fn();
+  proc.pid = 4321;
+  return proc;
+}
+
+function emitHelpAndExit(proc: any, helpText: string): void {
+  proc.stdout.write(helpText);
+  proc.emit('close', 0, null);
+}
+
+describe('probeAntigravityAddDirSupport', () => {
+  beforeEach(() => {
+    resetAntigravityAddDirSupportCache();
+    mockedSpawn.mockReset();
+  });
+
+  it('detects --add-dir in agy --help output', async () => {
+    const proc = createMockChildProcess();
+    mockedSpawn.mockReturnValue(proc);
+
+    const promise = probeAntigravityAddDirSupport('/usr/local/bin/agy', { SHELL: '/bin/zsh' });
+    emitHelpAndExit(proc, 'Usage: agy [flags]\n  --add-dir <dir>   Add a workspace directory\n  --print');
+
+    await expect(promise).resolves.toBe(true);
+    expect(mockedSpawn).toHaveBeenCalledWith(
+      '/bin/zsh',
+      ['-lc', 'exec "$0" "$@"', '/usr/local/bin/agy', '--help'],
+      expect.objectContaining({ shell: false }),
+    );
+  });
+
+  it('reports no support when help output lacks --add-dir', async () => {
+    const proc = createMockChildProcess();
+    mockedSpawn.mockReturnValue(proc);
+
+    const promise = probeAntigravityAddDirSupport('agy', {});
+    emitHelpAndExit(proc, 'Usage: agy [flags]\n  --print');
+
+    await expect(promise).resolves.toBe(false);
+  });
+
+  it('fail-closes when the probe child cannot be spawned', async () => {
+    const proc = createMockChildProcess();
+    mockedSpawn.mockReturnValue(proc);
+
+    const promise = probeAntigravityAddDirSupport('agy', {});
+    proc.emit('error', new Error('ENOENT'));
+
+    await expect(promise).resolves.toBe(false);
+  });
+
+  it('fail-closes when spawn throws', async () => {
+    mockedSpawn.mockImplementation(() => {
+      throw new Error('spawn refused');
+    });
+
+    await expect(probeAntigravityAddDirSupport('agy', {})).resolves.toBe(false);
+  });
+
+  it('scans stderr because some CLIs print help there', async () => {
+    const proc = createMockChildProcess();
+    mockedSpawn.mockReturnValue(proc);
+
+    const promise = probeAntigravityAddDirSupport('agy', {});
+    proc.stderr.write('  --add-dir <dir>   Additional workspace\n');
+    proc.emit('close', 1, null);
+
+    await expect(promise).resolves.toBe(true);
+  });
+
+  it('caches the probe result per CLI command', async () => {
+    const proc = createMockChildProcess();
+    mockedSpawn.mockReturnValue(proc);
+
+    const first = probeAntigravityAddDirSupport('/usr/local/bin/agy', {});
+    emitHelpAndExit(proc, '  --add-dir <dir>');
+    await expect(first).resolves.toBe(true);
+
+    await expect(probeAntigravityAddDirSupport('/usr/local/bin/agy', {})).resolves.toBe(true);
+    expect(mockedSpawn).toHaveBeenCalledTimes(1);
+  });
+
+  it('probes different CLI commands separately', async () => {
+    const proc = createMockChildProcess();
+    mockedSpawn.mockReturnValue(proc);
+
+    const first = probeAntigravityAddDirSupport('agy', {});
+    emitHelpAndExit(proc, '  --add-dir <dir>');
+    await expect(first).resolves.toBe(true);
+
+    const other = createMockChildProcess();
+    mockedSpawn.mockReturnValue(other);
+    const second = probeAntigravityAddDirSupport('/opt/other/agy', {});
+    emitHelpAndExit(other, '  --print');
+    await expect(second).resolves.toBe(false);
+  });
+
+  it('shares a single in-flight probe between concurrent callers', async () => {
+    const proc = createMockChildProcess();
+    mockedSpawn.mockReturnValue(proc);
+
+    const first = probeAntigravityAddDirSupport('agy', {});
+    const second = probeAntigravityAddDirSupport('agy', {});
+    emitHelpAndExit(proc, '  --add-dir <dir>');
+
+    await expect(first).resolves.toBe(true);
+    await expect(second).resolves.toBe(true);
+    expect(mockedSpawn).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/unit/providers/antigravity/AntigravityChatRuntime.test.ts
+++ b/tests/unit/providers/antigravity/AntigravityChatRuntime.test.ts
@@ -11,6 +11,7 @@ import { ProviderWorkspaceRegistry } from '@/core/providers/ProviderWorkspaceReg
 import type { StreamChunk } from '@/core/types';
 import { setLocale } from '@/i18n/i18n';
 import { AntigravityCommandCatalog } from '@/providers/antigravity/commands/AntigravityCommandCatalog';
+import { resetAntigravityAddDirSupportCache } from '@/providers/antigravity/runtime/AntigravityAddDirSupport';
 import {
   AntigravityChatRuntime,
   buildAntigravityPrintArgs,
@@ -65,11 +66,13 @@ function createMockChildProcess(): any {
 }
 
 function getSpawnedAgyArgs(): string[] {
-  const [, args] = mockedSpawn.mock.calls[0] as [string, string[]];
-  if (args[0] === '-lc' && args[1] === 'exec "$0" "$@"') {
-    return args.slice(3);
-  }
-  return args;
+  const printCall = mockedSpawn.mock.calls
+    .map(([, args]: [string, string[]]) => {
+      const flagArgs = args[0] === '-lc' && args[1] === 'exec "$0" "$@"' ? args.slice(3) : args;
+      return { args: flagArgs, isPrint: flagArgs.includes('--print') };
+    })
+    .find((entry: { isPrint: boolean }) => entry.isPrint);
+  return printCall ? printCall.args : [];
 }
 
 describe('AntigravityChatRuntime', () => {
@@ -77,6 +80,7 @@ describe('AntigravityChatRuntime', () => {
     setLocale('en');
     jest.restoreAllMocks();
     mockedSpawn.mockReset();
+    resetAntigravityAddDirSupportCache();
     ProviderWorkspaceRegistry.setServices('antigravity', undefined);
   });
 
@@ -485,5 +489,78 @@ describe('AntigravityChatRuntime', () => {
       '--print',
       'Hello',
     ]);
+  });
+
+  it('prepends --add-dir for the vault when the CLI probed as supporting it', () => {
+    expect(buildAntigravityPrintArgs({
+      addDirPath: '/tmp/grimoire-antigravity-test-vault',
+      model: null,
+      permissionMode: 'full_access',
+      prompt: 'Hello',
+    })).toEqual([
+      '--add-dir',
+      '/tmp/grimoire-antigravity-test-vault',
+      '--dangerously-skip-permissions',
+      '--print',
+      'Hello',
+    ]);
+
+    expect(buildAntigravityPrintArgs({
+      addDirPath: null,
+      model: null,
+      permissionMode: 'full_access',
+      prompt: 'Hello',
+    })).not.toContain('--add-dir');
+  });
+
+  it('passes the vault to agy via --add-dir after probing agy --help', async () => {
+    const runtime = new AntigravityChatRuntime(createMockPlugin());
+    const probeProc = createMockChildProcess();
+    const printProc = createMockChildProcess();
+    mockedSpawn.mockImplementation((command: string, args: string[]) => {
+      if (args.includes('--help')) return probeProc;
+      return printProc;
+    });
+
+    const chunksPromise = collect(runtime.query(runtime.prepareTurn({ text: 'List vault files' })));
+    await new Promise((resolve) => setImmediate(resolve));
+    probeProc.stdout.write('Usage: agy\n  --add-dir <dir>\n');
+    probeProc.emit('close', 0, null);
+    await new Promise((resolve) => setImmediate(resolve));
+    printProc.stdout.write('Vault listed\n');
+    printProc.emit('exit', 0, null);
+
+    const chunks = await chunksPromise;
+    expect(chunks).toContainEqual({ content: 'Vault listed', type: 'text' });
+    const agyArgs = getSpawnedAgyArgs();
+    expect(agyArgs.indexOf('--add-dir')).toBe(0);
+    expect(agyArgs).toEqual(expect.arrayContaining([
+      '--add-dir',
+      '/tmp/grimoire-antigravity-test-vault',
+      '--dangerously-skip-permissions',
+      '--print',
+      'List vault files',
+    ]));
+  });
+
+  it('omits --add-dir when the probed agy --help does not advertise it', async () => {
+    const runtime = new AntigravityChatRuntime(createMockPlugin());
+    const probeProc = createMockChildProcess();
+    const printProc = createMockChildProcess();
+    mockedSpawn.mockImplementation((command: string, args: string[]) => {
+      if (args.includes('--help')) return probeProc;
+      return printProc;
+    });
+
+    const chunksPromise = collect(runtime.query(runtime.prepareTurn({ text: 'Hello' })));
+    await new Promise((resolve) => setImmediate(resolve));
+    probeProc.stdout.write('Usage: agy\n  --print\n');
+    probeProc.emit('close', 0, null);
+    await new Promise((resolve) => setImmediate(resolve));
+    printProc.stdout.write('Hi\n');
+    printProc.emit('exit', 0, null);
+
+    await chunksPromise;
+    expect(getSpawnedAgyArgs()).not.toContain('--add-dir');
   });
 });

--- a/tests/unit/providers/antigravity/AntigravityChatRuntime.test.ts
+++ b/tests/unit/providers/antigravity/AntigravityChatRuntime.test.ts
@@ -563,4 +563,51 @@ describe('AntigravityChatRuntime', () => {
     await chunksPromise;
     expect(getSpawnedAgyArgs()).not.toContain('--add-dir');
   });
+
+  it('drops the print run when cancelled while the add-dir probe is in flight', async () => {
+    const runtime = new AntigravityChatRuntime(createMockPlugin());
+    const probeProc = createMockChildProcess();
+    const printProc = createMockChildProcess();
+    mockedSpawn.mockImplementation((command: string, args: string[]) => {
+      if (args.includes('--help')) return probeProc;
+      return printProc;
+    });
+
+    const chunksPromise = collect(runtime.query(runtime.prepareTurn({ text: 'Hello' })));
+    await new Promise((resolve) => setImmediate(resolve));
+    runtime.cancel();
+    probeProc.emit('close', 0, null);
+    await new Promise((resolve) => setImmediate(resolve));
+
+    const chunks = await chunksPromise;
+    expect(mockedSpawn).toHaveBeenCalledTimes(1);
+    expect(chunks).not.toContainEqual(expect.objectContaining({ type: 'text' }));
+    expect(chunks[chunks.length - 1]).toEqual({ type: 'done' });
+  });
+
+  it('masks the vault path in the print.spawn args summary', async () => {
+    const recordDebugLog = jest.fn();
+    const runtime = new AntigravityChatRuntime(createMockPlugin({ recordDebugLog }));
+    const probeProc = createMockChildProcess();
+    const printProc = createMockChildProcess();
+    mockedSpawn.mockImplementation((command: string, args: string[]) => {
+      if (args.includes('--help')) return probeProc;
+      return printProc;
+    });
+
+    const chunksPromise = collect(runtime.query(runtime.prepareTurn({ text: 'Hello' })));
+    await new Promise((resolve) => setImmediate(resolve));
+    probeProc.stdout.write('Usage: agy\n  --add-dir <dir>\n');
+    probeProc.emit('close', 0, null);
+    await new Promise((resolve) => setImmediate(resolve));
+    printProc.stdout.write('Hi\n');
+    printProc.emit('exit', 0, null);
+    await chunksPromise;
+
+    const spawnLog = recordDebugLog.mock.calls
+      .map(([entry]) => entry)
+      .find((entry: any) => entry.event === 'print.spawn');
+    expect(spawnLog?.data?.argsSummary).toContain('--add-dir <vault-path>');
+    expect(spawnLog?.data?.argsSummary).not.toContain('/tmp/grimoire-antigravity-test-vault');
+  });
 });


### PR DESCRIPTION
## Summary
- Probe `agy --help` once per CLI command for `--add-dir` support (`AntigravityAddDirSupport`) and prepend `--add-dir <vault>` to `agy --print` args when advertised, so the agent workspace includes the vault root without wrapper scripts.
- The probe fails closed: spawn errors, timeouts, and the Windows empty-help quirk (agy 1.0.10 can exit 0 with empty stdout) launch without the flag, preserving current behavior on older CLIs.
- Concurrent queries share one in-flight probe; the result is cached per CLI command.

## Context
Fixes the `--add-dir` half of #67. The cmd.exe quoting half was already fixed for #59 in c119141 and ships in the next release.

## Test plan
- [x] Unit: probe detects `--add-dir` in help (stdout and stderr), fail-closes on spawn error/throw, caches per command, shares in-flight probes.
- [x] Unit: `buildAntigravityPrintArgs` prepends `--add-dir` first when requested and omits it when null.
- [x] Runtime: `query()` spawns the probe then the print run with `--add-dir <vault>`; omits the flag when help lacks it.
- [x] `npm run test -- --selectProjects unit`, `npm run typecheck`, `npm run lint`, `npm run build:release` all green.

Closes #67