### PR TITLE
fix(opencode): launch acp with config content only

### DIFF
--- a/src/providers/kimicode/runtime/KimicodeAuxQueryRunner.ts
+++ b/src/providers/kimicode/runtime/KimicodeAuxQueryRunner.ts
@@ -203,7 +203,6 @@ export class KimicodeAuxQueryRunner implements AuxQueryRunner {
     this.reset();
     await this.startProcess({
       command: resolvedCliPath,
-      configPath: artifacts.configPath,
       configContent: artifacts.configContent,
       cwd,
       runtimeEnv,
@@ -241,7 +240,6 @@ export class KimicodeAuxQueryRunner implements AuxQueryRunner {
 
   private async startProcess(params: {
     command: string;
-    configPath: string;
     configContent: string;
     cwd: string;
     runtimeEnv: NodeJS.ProcessEnv;
@@ -249,10 +247,14 @@ export class KimicodeAuxQueryRunner implements AuxQueryRunner {
     const processEnv: NodeJS.ProcessEnv = {
       ...process.env,
       ...params.runtimeEnv,
-      KIMICODE_CONFIG: params.configPath,
       KIMICODE_CONFIG_CONTENT: params.configContent,
       PATH: params.runtimeEnv.PATH,
     };
+    // A file-based KIMICODE_CONFIG makes the acp mode hang or crash outright
+    // on Windows (Kimi Code mirrors the OpenCode CLI); the merged config must
+    // only travel as KIMICODE_CONFIG_CONTENT. Delete it explicitly so a
+    // user-configured value cannot leak through.
+    delete processEnv.KIMICODE_CONFIG;
 
     this.process = new AcpSubprocess({
       args: ['acp'],

--- a/src/providers/kimicode/runtime/KimicodeChatRuntime.ts
+++ b/src/providers/kimicode/runtime/KimicodeChatRuntime.ts
@@ -349,7 +349,7 @@ export class KimicodeChatRuntime implements ChatRuntime {
       }
       await this.startProcess({
         command: resolvedCliPath,
-        configPath: artifacts.configPath,
+        configContent: artifacts.configContent,
         cwd,
         runtimeEnv,
       });
@@ -674,19 +674,24 @@ export class KimicodeChatRuntime implements ChatRuntime {
 
   private async startProcess(params: {
     command: string;
-    configPath: string;
+    configContent: string;
     cwd: string;
     runtimeEnv: NodeJS.ProcessEnv;
   }): Promise<void> {
     const processEnv: NodeJS.ProcessEnv = {
       ...process.env,
       ...params.runtimeEnv,
-      KIMICODE_CONFIG: params.configPath,
+      KIMICODE_CONFIG_CONTENT: params.configContent,
       PATH: getEnhancedPath(
         params.runtimeEnv.PATH,
         path.isAbsolute(params.command) ? params.command : undefined,
       ),
     };
+    // A file-based KIMICODE_CONFIG makes the acp mode hang or crash outright
+    // on Windows (Kimi Code mirrors the OpenCode CLI); the merged config must
+    // only travel as KIMICODE_CONFIG_CONTENT. Delete it explicitly so a
+    // user-configured value cannot leak through.
+    delete processEnv.KIMICODE_CONFIG;
 
     this.process = new AcpSubprocess({
       args: ['acp'],

--- a/src/providers/kimicode/runtime/KimicodeLaunchArtifacts.ts
+++ b/src/providers/kimicode/runtime/KimicodeLaunchArtifacts.ts
@@ -93,7 +93,7 @@ export async function prepareKimicodeLaunchArtifacts(
   const configContent = `${JSON.stringify(
     buildKimicodeManagedConfig(
       baseConfig,
-      systemPromptPath,
+      systemPrompt,
       params.userName ?? params.settings?.userName,
       params.managedAgents,
       params.defaultAgentId,
@@ -132,7 +132,7 @@ async function ensureKimicodeDatabaseDirectory(databasePath: string | null): Pro
 
 export function buildKimicodeManagedConfig(
   baseConfig: Record<string, unknown>,
-  systemPromptPath: string,
+  systemPrompt: string,
   userName?: string,
   managedAgents: readonly KimicodeManagedAgentConfig[] = DEFAULT_KIMICODE_MANAGED_AGENT_CONFIGS,
   defaultAgentId?: string,
@@ -159,7 +159,10 @@ export function buildKimicodeManagedConfig(
     nextAgents[agentConfig.id] = {
       ...existingAgent,
       ...(isPlainObject(agentConfig.definition) ? agentConfig.definition : {}),
-      prompt: `{file:${systemPromptPath}}`,
+      // The prompt is inlined rather than referenced via `{file:...}`: file
+      // references resolve relative to the config file, which does not exist
+      // when the config travels as KIMICODE_CONFIG_CONTENT.
+      prompt: systemPrompt,
     };
   }
 

--- a/src/providers/mimocode/runtime/MimocodeAuxQueryRunner.ts
+++ b/src/providers/mimocode/runtime/MimocodeAuxQueryRunner.ts
@@ -203,7 +203,6 @@ export class MimocodeAuxQueryRunner implements AuxQueryRunner {
     this.reset();
     await this.startProcess({
       command: resolvedCliPath,
-      configPath: artifacts.configPath,
       configContent: artifacts.configContent,
       cwd,
       runtimeEnv,
@@ -241,7 +240,6 @@ export class MimocodeAuxQueryRunner implements AuxQueryRunner {
 
   private async startProcess(params: {
     command: string;
-    configPath: string;
     configContent: string;
     cwd: string;
     runtimeEnv: NodeJS.ProcessEnv;
@@ -249,10 +247,14 @@ export class MimocodeAuxQueryRunner implements AuxQueryRunner {
     const processEnv: NodeJS.ProcessEnv = {
       ...process.env,
       ...params.runtimeEnv,
-      MIMOCODE_CONFIG: params.configPath,
       MIMOCODE_CONFIG_CONTENT: params.configContent,
       PATH: params.runtimeEnv.PATH,
     };
+    // A file-based MIMOCODE_CONFIG makes the acp mode hang or crash outright on
+    // Windows (MiMoCode mirrors the OpenCode CLI); the merged config must only
+    // travel as MIMOCODE_CONFIG_CONTENT. Delete it explicitly so a
+    // user-configured value cannot leak through.
+    delete processEnv.MIMOCODE_CONFIG;
 
     this.process = new AcpSubprocess({
       args: ['acp'],

--- a/src/providers/mimocode/runtime/MimocodeChatRuntime.ts
+++ b/src/providers/mimocode/runtime/MimocodeChatRuntime.ts
@@ -354,7 +354,7 @@ export class MimocodeChatRuntime implements ChatRuntime {
       }
       await this.startProcess({
         command: resolvedCliPath,
-        configPath: artifacts.configPath,
+        configContent: artifacts.configContent,
         cwd,
         runtimeEnv,
       });
@@ -704,19 +704,24 @@ export class MimocodeChatRuntime implements ChatRuntime {
 
   private async startProcess(params: {
     command: string;
-    configPath: string;
+    configContent: string;
     cwd: string;
     runtimeEnv: NodeJS.ProcessEnv;
   }): Promise<void> {
     const processEnv: NodeJS.ProcessEnv = {
       ...process.env,
       ...params.runtimeEnv,
-      MIMOCODE_CONFIG: params.configPath,
+      MIMOCODE_CONFIG_CONTENT: params.configContent,
       PATH: getEnhancedPath(
         params.runtimeEnv.PATH,
         path.isAbsolute(params.command) ? params.command : undefined,
       ),
     };
+    // A file-based MIMOCODE_CONFIG makes the acp mode hang or crash outright on
+    // Windows (MiMoCode mirrors the OpenCode CLI); the merged config must only
+    // travel as MIMOCODE_CONFIG_CONTENT. Delete it explicitly so a
+    // user-configured value cannot leak through.
+    delete processEnv.MIMOCODE_CONFIG;
 
     this.process = new AcpSubprocess({
       args: ['acp'],

--- a/src/providers/mimocode/runtime/MimocodeLaunchArtifacts.ts
+++ b/src/providers/mimocode/runtime/MimocodeLaunchArtifacts.ts
@@ -93,7 +93,7 @@ export async function prepareMimocodeLaunchArtifacts(
   const configContent = `${JSON.stringify(
     buildMimocodeManagedConfig(
       baseConfig,
-      systemPromptPath,
+      systemPrompt,
       params.userName ?? params.settings?.userName,
       params.managedAgents,
       params.defaultAgentId,
@@ -132,7 +132,7 @@ async function ensureMimocodeDatabaseDirectory(databasePath: string | null): Pro
 
 export function buildMimocodeManagedConfig(
   baseConfig: Record<string, unknown>,
-  systemPromptPath: string,
+  systemPrompt: string,
   userName?: string,
   managedAgents: readonly MimocodeManagedAgentConfig[] = DEFAULT_MIMOCODE_MANAGED_AGENT_CONFIGS,
   defaultAgentId?: string,
@@ -159,7 +159,10 @@ export function buildMimocodeManagedConfig(
     nextAgents[agentConfig.id] = {
       ...existingAgent,
       ...(isPlainObject(agentConfig.definition) ? agentConfig.definition : {}),
-      prompt: `{file:${systemPromptPath}}`,
+      // The prompt is inlined rather than referenced via `{file:...}`: file
+      // references resolve relative to the config file, which does not exist
+      // when the config travels as MIMOCODE_CONFIG_CONTENT.
+      prompt: systemPrompt,
     };
   }
 

--- a/src/providers/opencode/runtime/OpencodeAuxQueryRunner.ts
+++ b/src/providers/opencode/runtime/OpencodeAuxQueryRunner.ts
@@ -203,7 +203,6 @@ export class OpencodeAuxQueryRunner implements AuxQueryRunner {
     this.reset();
     await this.startProcess({
       command: resolvedCliPath,
-      configPath: artifacts.configPath,
       configContent: artifacts.configContent,
       cwd,
       runtimeEnv,
@@ -241,7 +240,6 @@ export class OpencodeAuxQueryRunner implements AuxQueryRunner {
 
   private async startProcess(params: {
     command: string;
-    configPath: string;
     configContent: string;
     cwd: string;
     runtimeEnv: NodeJS.ProcessEnv;
@@ -249,10 +247,13 @@ export class OpencodeAuxQueryRunner implements AuxQueryRunner {
     const processEnv: NodeJS.ProcessEnv = {
       ...process.env,
       ...params.runtimeEnv,
-      OPENCODE_CONFIG: params.configPath,
       OPENCODE_CONFIG_CONTENT: params.configContent,
       PATH: params.runtimeEnv.PATH,
     };
+    // A file-based OPENCODE_CONFIG makes `opencode acp` hang or crash outright
+    // on Windows; the merged config must only travel as OPENCODE_CONFIG_CONTENT.
+    // Delete it explicitly so a user-configured value cannot leak through.
+    delete processEnv.OPENCODE_CONFIG;
 
     this.process = new AcpSubprocess({
       args: ['acp'],

--- a/src/providers/opencode/runtime/OpencodeChatRuntime.ts
+++ b/src/providers/opencode/runtime/OpencodeChatRuntime.ts
@@ -349,7 +349,7 @@ export class OpencodeChatRuntime implements ChatRuntime {
       }
       await this.startProcess({
         command: resolvedCliPath,
-        configPath: artifacts.configPath,
+        configContent: artifacts.configContent,
         cwd,
         runtimeEnv,
       });
@@ -674,19 +674,23 @@ export class OpencodeChatRuntime implements ChatRuntime {
 
   private async startProcess(params: {
     command: string;
-    configPath: string;
+    configContent: string;
     cwd: string;
     runtimeEnv: NodeJS.ProcessEnv;
   }): Promise<void> {
     const processEnv: NodeJS.ProcessEnv = {
       ...process.env,
       ...params.runtimeEnv,
-      OPENCODE_CONFIG: params.configPath,
+      OPENCODE_CONFIG_CONTENT: params.configContent,
       PATH: getEnhancedPath(
         params.runtimeEnv.PATH,
         path.isAbsolute(params.command) ? params.command : undefined,
       ),
     };
+    // A file-based OPENCODE_CONFIG makes `opencode acp` hang or crash outright
+    // on Windows; the merged config must only travel as OPENCODE_CONFIG_CONTENT.
+    // Delete it explicitly so a user-configured value cannot leak through.
+    delete processEnv.OPENCODE_CONFIG;
 
     this.process = new AcpSubprocess({
       args: ['acp'],

--- a/src/providers/opencode/runtime/OpencodeLaunchArtifacts.ts
+++ b/src/providers/opencode/runtime/OpencodeLaunchArtifacts.ts
@@ -93,7 +93,7 @@ export async function prepareOpencodeLaunchArtifacts(
   const configContent = `${JSON.stringify(
     buildOpencodeManagedConfig(
       baseConfig,
-      systemPromptPath,
+      systemPrompt,
       params.userName ?? params.settings?.userName,
       params.managedAgents,
       params.defaultAgentId,
@@ -132,7 +132,7 @@ async function ensureOpencodeDatabaseDirectory(databasePath: string | null): Pro
 
 export function buildOpencodeManagedConfig(
   baseConfig: Record<string, unknown>,
-  systemPromptPath: string,
+  systemPrompt: string,
   userName?: string,
   managedAgents: readonly OpencodeManagedAgentConfig[] = DEFAULT_OPENCODE_MANAGED_AGENT_CONFIGS,
   defaultAgentId?: string,
@@ -159,7 +159,10 @@ export function buildOpencodeManagedConfig(
     nextAgents[agentConfig.id] = {
       ...existingAgent,
       ...(isPlainObject(agentConfig.definition) ? agentConfig.definition : {}),
-      prompt: `{file:${systemPromptPath}}`,
+      // The prompt is inlined rather than referenced via `{file:...}`: file
+      // references resolve relative to the config file, which does not exist
+      // when the config travels as OPENCODE_CONFIG_CONTENT.
+      prompt: systemPrompt,
     };
   }
 

--- a/tests/helpers/acpLaunchMocks.ts
+++ b/tests/helpers/acpLaunchMocks.ts
@@ -38,7 +38,7 @@ export type AcpLaunchMockTransport = {
 
 export interface AcpLaunchMockPluginParams {
   cliPath: string;
-  providerId: 'opencode' | 'mimocode';
+  providerId: 'opencode' | 'mimocode' | 'kimicode';
   vaultPath?: string;
 }
 

--- a/tests/unit/providers/kimicode/KimicodeAcpLaunch.test.ts
+++ b/tests/unit/providers/kimicode/KimicodeAcpLaunch.test.ts
@@ -1,0 +1,104 @@
+import '@/providers';
+
+import {
+  type AcpLaunchMockConnection,
+  type AcpLaunchMockProcess,
+  type AcpLaunchMockTransport,
+  createAcpLaunchMockPlugin,
+  createAcpMockConnection,
+  createAcpMockProcess,
+  createAcpMockTransport,
+  WINDOWS_UNICODE_VAULT,
+  wireAcpMocks,
+} from '@test/helpers/acpLaunchMocks';
+
+import { KimicodeChatRuntime } from '@/providers/kimicode/runtime/KimicodeChatRuntime';
+import { prepareKimicodeLaunchArtifacts } from '@/providers/kimicode/runtime/KimicodeLaunchArtifacts';
+
+import { AcpClientConnection, AcpJsonRpcTransport, AcpSubprocess } from '../../../../src/providers/acp';
+
+jest.mock('../../../../src/providers/acp', () => {
+  const actual = jest.requireActual('../../../../src/providers/acp');
+  return {
+    ...actual,
+    AcpClientConnection: jest.fn(),
+    AcpJsonRpcTransport: jest.fn(),
+    AcpSubprocess: jest.fn(),
+  };
+});
+
+jest.mock('@/providers/kimicode/runtime/KimicodeLaunchArtifacts', () => {
+  const actual = jest.requireActual('@/providers/kimicode/runtime/KimicodeLaunchArtifacts');
+  return {
+    ...actual,
+    prepareKimicodeLaunchArtifacts: jest.fn(),
+  };
+});
+
+const MockAcpClientConnection = AcpClientConnection as jest.MockedClass<typeof AcpClientConnection>;
+const MockAcpJsonRpcTransport = AcpJsonRpcTransport as jest.MockedClass<typeof AcpJsonRpcTransport>;
+const MockAcpSubprocess = AcpSubprocess as jest.MockedClass<typeof AcpSubprocess>;
+const mockPrepareKimicodeLaunchArtifacts = prepareKimicodeLaunchArtifacts as jest.MockedFunction<typeof prepareKimicodeLaunchArtifacts>;
+
+describe('Kimi Code ACP launch', () => {
+  let mockConnection: AcpLaunchMockConnection;
+  let mockProcess: AcpLaunchMockProcess;
+  let mockTransport: AcpLaunchMockTransport;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockConnection = createAcpMockConnection();
+    mockProcess = createAcpMockProcess();
+    mockTransport = createAcpMockTransport();
+
+    wireAcpMocks({
+      connection: mockConnection,
+      connectionCtor: MockAcpClientConnection,
+      process: mockProcess,
+      subprocessCtor: MockAcpSubprocess,
+      transport: mockTransport,
+      transportCtor: MockAcpJsonRpcTransport,
+    });
+    mockPrepareKimicodeLaunchArtifacts.mockResolvedValue({
+      configPath: 'C:\\tmp\\grimoire-kimicode\\config.json',
+      configContent: '{}\n',
+      databasePath: null,
+      launchKey: 'launch-key',
+      systemPromptPath: 'C:\\tmp\\grimoire-kimicode\\system.md',
+    });
+  });
+
+  it('does not pass the workspace path through Kimi Code CLI arguments', async () => {
+    const runtime = new KimicodeChatRuntime(createAcpLaunchMockPlugin({
+      cliPath: 'C:\\Tools\\kimi.exe',
+      providerId: 'kimicode',
+    }));
+
+    await expect(runtime.ensureReady()).resolves.toBe(true);
+
+    expect(MockAcpSubprocess).toHaveBeenCalledWith(expect.objectContaining({
+      args: ['acp'],
+      command: 'C:\\Tools\\kimi.exe',
+      cwd: WINDOWS_UNICODE_VAULT,
+    }));
+    expect(mockConnection.newSession).toHaveBeenCalledWith({
+      cwd: WINDOWS_UNICODE_VAULT,
+      mcpServers: [],
+    });
+  });
+
+  it('passes the managed config as KIMICODE_CONFIG_CONTENT and never KIMICODE_CONFIG', async () => {
+    const plugin = createAcpLaunchMockPlugin({
+      cliPath: 'C:\\Tools\\kimi.exe',
+      providerId: 'kimicode',
+    });
+    plugin.settings.providerConfigs.kimicode.environmentVariables = 'KIMICODE_CONFIG=C:\\tmp\\user-kimicode.json';
+
+    const runtime = new KimicodeChatRuntime(plugin);
+    await expect(runtime.ensureReady()).resolves.toBe(true);
+
+    const launchEnv: NodeJS.ProcessEnv = MockAcpSubprocess.mock.calls[0][0].env;
+    expect(launchEnv.KIMICODE_CONFIG_CONTENT).toBe('{}\n');
+    expect(launchEnv.KIMICODE_CONFIG).toBeUndefined();
+  });
+});

--- a/tests/unit/providers/kimicode/KimicodeAuxQueryRunner.test.ts
+++ b/tests/unit/providers/kimicode/KimicodeAuxQueryRunner.test.ts
@@ -181,6 +181,23 @@ describe('KimicodeAuxQueryRunner', () => {
     expect(onTextChunk).toHaveBeenNthCalledWith(2, 'Fix title now');
   });
 
+  it('passes the managed config as KIMICODE_CONFIG_CONTENT and never KIMICODE_CONFIG', async () => {
+    const plugin = createMockPlugin();
+    plugin.settings.providerConfigs.kimicode.environmentVariables = 'KIMICODE_CONFIG=C:/tmp/user-kimicode.json';
+    const runner = new KimicodeAuxQueryRunner(plugin, {
+      agentProfile: 'passive',
+      artifactPurpose: 'title-gen',
+    });
+
+    await expect(runner.query({
+      systemPrompt: 'Use this custom system prompt.',
+    }, 'Generate a title')).resolves.toBe('Fix title now');
+
+    const launchEnv: NodeJS.ProcessEnv = MockAcpSubprocess.mock.calls[0][0].env;
+    expect(launchEnv.KIMICODE_CONFIG_CONTENT).toBe('{"default_agent":"grimoire-aux-passive"}\n');
+    expect(launchEnv.KIMICODE_CONFIG).toBeUndefined();
+  });
+
   it('falls back to kimi from PATH when no CLI path is configured', async () => {
     const plugin = createMockPlugin();
     plugin.getResolvedProviderCliPath.mockReturnValue(null);

--- a/tests/unit/providers/kimicode/KimicodeLaunchArtifacts.test.ts
+++ b/tests/unit/providers/kimicode/KimicodeLaunchArtifacts.test.ts
@@ -12,12 +12,12 @@ import {
 } from '../../../../src/providers/kimicode/runtime/KimicodeLaunchArtifacts';
 
 describe('buildKimicodeManagedConfig', () => {
-  it('pins Kimi Code build, Auto-approve, safe, and plan prompts to the managed prompt file', () => {
-    expect(buildKimicodeManagedConfig({}, '/vault/.grimoire/kimicode/system.md', 'Test User')).toEqual({
+  it('pins Kimi Code build, Auto-approve, safe, and plan prompts to the managed prompt text', () => {
+    expect(buildKimicodeManagedConfig({}, 'Managed system prompt.', 'Test User')).toEqual({
       $schema: 'https://kimicode.ai/config.json',
       agent: {
         build: {
-          prompt: '{file:/vault/.grimoire/kimicode/system.md}',
+          prompt: 'Managed system prompt.',
         },
         [KIMICODE_FULL_ACCESS_MODE_ID]: {
           mode: 'primary',
@@ -25,7 +25,7 @@ describe('buildKimicodeManagedConfig', () => {
             plan_enter: 'allow',
             question: 'allow',
           },
-          prompt: '{file:/vault/.grimoire/kimicode/system.md}',
+          prompt: 'Managed system prompt.',
         },
         [KIMICODE_SAFE_MODE_ID]: {
           mode: 'primary',
@@ -36,10 +36,10 @@ describe('buildKimicodeManagedConfig', () => {
             question: 'allow',
             write: 'ask',
           },
-          prompt: '{file:/vault/.grimoire/kimicode/system.md}',
+          prompt: 'Managed system prompt.',
         },
         plan: {
-          prompt: '{file:/vault/.grimoire/kimicode/system.md}',
+          prompt: 'Managed system prompt.',
         },
       },
       username: 'Test User',
@@ -49,7 +49,7 @@ describe('buildKimicodeManagedConfig', () => {
   it('can create a dedicated aux agent and default it for the process', () => {
     expect(buildKimicodeManagedConfig(
       {},
-      '/vault/.grimoire/kimicode/auxiliary/system.md',
+      'Aux system prompt.',
       undefined,
       [{
         definition: {
@@ -71,7 +71,7 @@ describe('buildKimicodeManagedConfig', () => {
             '*': 'deny',
             read: 'allow',
           },
-          prompt: '{file:/vault/.grimoire/kimicode/auxiliary/system.md}',
+          prompt: 'Aux system prompt.',
         },
       },
       default_agent: 'grimoire-aux-readonly',
@@ -96,7 +96,7 @@ describe('buildKimicodeManagedConfig', () => {
         },
       },
       username: 'Existing',
-    }, '/vault/.grimoire/kimicode/system.md')).toEqual({
+    }, 'Managed system prompt.')).toEqual({
       $schema: 'https://kimicode.ai/config.json',
       agent: {
         build: {
@@ -105,7 +105,7 @@ describe('buildKimicodeManagedConfig', () => {
             bash: 'ask',
             edit: 'ask',
           },
-          prompt: '{file:/vault/.grimoire/kimicode/system.md}',
+          prompt: 'Managed system prompt.',
         },
         [KIMICODE_FULL_ACCESS_MODE_ID]: {
           mode: 'primary',
@@ -113,7 +113,7 @@ describe('buildKimicodeManagedConfig', () => {
             plan_enter: 'allow',
             question: 'allow',
           },
-          prompt: '{file:/vault/.grimoire/kimicode/system.md}',
+          prompt: 'Managed system prompt.',
         },
         [KIMICODE_SAFE_MODE_ID]: {
           mode: 'primary',
@@ -124,10 +124,10 @@ describe('buildKimicodeManagedConfig', () => {
             question: 'allow',
             write: 'ask',
           },
-          prompt: '{file:/vault/.grimoire/kimicode/system.md}',
+          prompt: 'Managed system prompt.',
         },
         plan: {
-          prompt: '{file:/vault/.grimoire/kimicode/system.md}',
+          prompt: 'Managed system prompt.',
         },
       },
       default_agent: 'build',
@@ -175,8 +175,9 @@ describe('prepareKimicodeLaunchArtifacts', () => {
 
     expect(result.configPath).toBe(path.join(tmpRoot, '.grimoire', 'kimicode', 'config.json'));
     expect(result.systemPromptPath).toBe(path.join(tmpRoot, '.grimoire', 'kimicode', 'system.md'));
-    expect(result.configContent).toContain(`"prompt": "{file:${result.systemPromptPath}}"`);
-    const generatedConfig = JSON.parse(await fs.readFile(result.configPath, 'utf8'));
+    expect(result.configContent).not.toContain('{file:');
+    const generatedConfig = JSON.parse(result.configContent);
+    const systemPromptFile = await fs.readFile(result.systemPromptPath, 'utf8');
     expect(generatedConfig).toMatchObject({
       default_agent: 'build',
       providers: {
@@ -189,7 +190,7 @@ describe('prepareKimicodeLaunchArtifacts', () => {
     expect(generatedConfig.agent).toMatchObject({
       build: {
         model: 'openai/gpt-5',
-        prompt: `{file:${result.systemPromptPath}}`,
+        prompt: systemPromptFile,
       },
       [KIMICODE_FULL_ACCESS_MODE_ID]: {
         mode: 'primary',
@@ -197,7 +198,7 @@ describe('prepareKimicodeLaunchArtifacts', () => {
           plan_enter: 'allow',
           question: 'allow',
         },
-        prompt: `{file:${result.systemPromptPath}}`,
+        prompt: systemPromptFile,
       },
       [KIMICODE_SAFE_MODE_ID]: {
         mode: 'primary',
@@ -207,10 +208,10 @@ describe('prepareKimicodeLaunchArtifacts', () => {
           plan_enter: 'allow',
           question: 'allow',
         },
-        prompt: `{file:${result.systemPromptPath}}`,
+        prompt: systemPromptFile,
       },
       plan: {
-        prompt: `{file:${result.systemPromptPath}}`,
+        prompt: systemPromptFile,
       },
     });
   });

--- a/tests/unit/providers/mimocode/MimocodeAcpLaunch.test.ts
+++ b/tests/unit/providers/mimocode/MimocodeAcpLaunch.test.ts
@@ -86,4 +86,19 @@ describe('MiMoCode ACP launch', () => {
       mcpServers: [],
     });
   });
+
+  it('passes the managed config as MIMOCODE_CONFIG_CONTENT and never MIMOCODE_CONFIG', async () => {
+    const plugin = createAcpLaunchMockPlugin({
+      cliPath: 'C:\\Tools\\mimo.exe',
+      providerId: 'mimocode',
+    });
+    plugin.settings.providerConfigs.mimocode.environmentVariables = 'MIMOCODE_CONFIG=C:\\tmp\\user-mimocode.json';
+
+    const runtime = new MimocodeChatRuntime(plugin);
+    await expect(runtime.ensureReady()).resolves.toBe(true);
+
+    const launchEnv: NodeJS.ProcessEnv = MockAcpSubprocess.mock.calls[0][0].env;
+    expect(launchEnv.MIMOCODE_CONFIG_CONTENT).toBe('{}\n');
+    expect(launchEnv.MIMOCODE_CONFIG).toBeUndefined();
+  });
 });

--- a/tests/unit/providers/mimocode/MimocodeAuxQueryRunner.test.ts
+++ b/tests/unit/providers/mimocode/MimocodeAuxQueryRunner.test.ts
@@ -177,6 +177,23 @@ describe('MimocodeAuxQueryRunner', () => {
     expect(onTextChunk).toHaveBeenNthCalledWith(2, 'Fix title now');
   });
 
+  it('passes the managed config as MIMOCODE_CONFIG_CONTENT and never MIMOCODE_CONFIG', async () => {
+    const plugin = createMockPlugin();
+    plugin.settings.providerConfigs.mimocode.environmentVariables = 'MIMOCODE_CONFIG=C:/tmp/user-mimocode.json';
+    const runner = new MimocodeAuxQueryRunner(plugin, {
+      agentProfile: 'passive',
+      artifactPurpose: 'title-gen',
+    });
+
+    await expect(runner.query({
+      systemPrompt: 'Use this custom system prompt.',
+    }, 'Generate a title')).resolves.toBe('Fix title now');
+
+    const launchEnv: NodeJS.ProcessEnv = MockAcpSubprocess.mock.calls[0][0].env;
+    expect(launchEnv.MIMOCODE_CONFIG_CONTENT).toBe('{"default_agent":"grimoire-aux-passive"}\n');
+    expect(launchEnv.MIMOCODE_CONFIG).toBeUndefined();
+  });
+
   it('falls back to mimo from PATH when no CLI path is configured', async () => {
     const plugin = createMockPlugin();
     plugin.getResolvedProviderCliPath.mockReturnValue(null);

--- a/tests/unit/providers/mimocode/MimocodeLaunchArtifacts.test.ts
+++ b/tests/unit/providers/mimocode/MimocodeLaunchArtifacts.test.ts
@@ -176,7 +176,7 @@ describe('prepareMimocodeLaunchArtifacts', () => {
     expect(result.configPath).toBe(path.join(tmpRoot, '.grimoire', 'mimocode', 'config.json'));
     expect(result.systemPromptPath).toBe(path.join(tmpRoot, '.grimoire', 'mimocode', 'system.md'));
     expect(result.configContent).not.toContain('{file:');
-    const generatedConfig = JSON.parse(await fs.readFile(result.configPath, 'utf8'));
+    const generatedConfig = JSON.parse(result.configContent);
     expect(generatedConfig).toMatchObject({
       default_agent: 'build',
       providers: {

--- a/tests/unit/providers/mimocode/MimocodeLaunchArtifacts.test.ts
+++ b/tests/unit/providers/mimocode/MimocodeLaunchArtifacts.test.ts
@@ -12,12 +12,12 @@ import {
 } from '../../../../src/providers/mimocode/runtime/MimocodeLaunchArtifacts';
 
 describe('buildMimocodeManagedConfig', () => {
-  it('pins MiMoCode build, Auto-approve, safe, and plan prompts to the managed prompt file', () => {
-    expect(buildMimocodeManagedConfig({}, '/vault/.grimoire/mimocode/system.md', 'Test User')).toEqual({
+  it('pins MiMoCode build, Auto-approve, safe, and plan prompts to the managed prompt text', () => {
+    expect(buildMimocodeManagedConfig({}, 'Managed system prompt.', 'Test User')).toEqual({
       $schema: 'https://mimocode.ai/config.json',
       agent: {
         build: {
-          prompt: '{file:/vault/.grimoire/mimocode/system.md}',
+          prompt: 'Managed system prompt.',
         },
         [MIMOCODE_FULL_ACCESS_MODE_ID]: {
           mode: 'primary',
@@ -25,7 +25,7 @@ describe('buildMimocodeManagedConfig', () => {
             plan_enter: 'allow',
             question: 'allow',
           },
-          prompt: '{file:/vault/.grimoire/mimocode/system.md}',
+          prompt: 'Managed system prompt.',
         },
         [MIMOCODE_SAFE_MODE_ID]: {
           mode: 'primary',
@@ -36,10 +36,10 @@ describe('buildMimocodeManagedConfig', () => {
             question: 'allow',
             write: 'ask',
           },
-          prompt: '{file:/vault/.grimoire/mimocode/system.md}',
+          prompt: 'Managed system prompt.',
         },
         plan: {
-          prompt: '{file:/vault/.grimoire/mimocode/system.md}',
+          prompt: 'Managed system prompt.',
         },
       },
       username: 'Test User',
@@ -49,7 +49,7 @@ describe('buildMimocodeManagedConfig', () => {
   it('can create a dedicated aux agent and default it for the process', () => {
     expect(buildMimocodeManagedConfig(
       {},
-      '/vault/.grimoire/mimocode/auxiliary/system.md',
+      'Aux system prompt.',
       undefined,
       [{
         definition: {
@@ -71,7 +71,7 @@ describe('buildMimocodeManagedConfig', () => {
             '*': 'deny',
             read: 'allow',
           },
-          prompt: '{file:/vault/.grimoire/mimocode/auxiliary/system.md}',
+          prompt: 'Aux system prompt.',
         },
       },
       default_agent: 'grimoire-aux-readonly',
@@ -96,7 +96,7 @@ describe('buildMimocodeManagedConfig', () => {
         },
       },
       username: 'Existing',
-    }, '/vault/.grimoire/mimocode/system.md')).toEqual({
+    }, 'Managed system prompt.')).toEqual({
       $schema: 'https://mimocode.ai/config.json',
       agent: {
         build: {
@@ -105,7 +105,7 @@ describe('buildMimocodeManagedConfig', () => {
             bash: 'ask',
             edit: 'ask',
           },
-          prompt: '{file:/vault/.grimoire/mimocode/system.md}',
+          prompt: 'Managed system prompt.',
         },
         [MIMOCODE_FULL_ACCESS_MODE_ID]: {
           mode: 'primary',
@@ -113,7 +113,7 @@ describe('buildMimocodeManagedConfig', () => {
             plan_enter: 'allow',
             question: 'allow',
           },
-          prompt: '{file:/vault/.grimoire/mimocode/system.md}',
+          prompt: 'Managed system prompt.',
         },
         [MIMOCODE_SAFE_MODE_ID]: {
           mode: 'primary',
@@ -124,10 +124,10 @@ describe('buildMimocodeManagedConfig', () => {
             question: 'allow',
             write: 'ask',
           },
-          prompt: '{file:/vault/.grimoire/mimocode/system.md}',
+          prompt: 'Managed system prompt.',
         },
         plan: {
-          prompt: '{file:/vault/.grimoire/mimocode/system.md}',
+          prompt: 'Managed system prompt.',
         },
       },
       default_agent: 'build',
@@ -175,7 +175,7 @@ describe('prepareMimocodeLaunchArtifacts', () => {
 
     expect(result.configPath).toBe(path.join(tmpRoot, '.grimoire', 'mimocode', 'config.json'));
     expect(result.systemPromptPath).toBe(path.join(tmpRoot, '.grimoire', 'mimocode', 'system.md'));
-    expect(result.configContent).toContain(`"prompt": "{file:${result.systemPromptPath}}"`);
+    expect(result.configContent).not.toContain('{file:');
     const generatedConfig = JSON.parse(await fs.readFile(result.configPath, 'utf8'));
     expect(generatedConfig).toMatchObject({
       default_agent: 'build',
@@ -186,10 +186,11 @@ describe('prepareMimocodeLaunchArtifacts', () => {
       },
       username: 'Test User',
     });
+    const systemPromptFile = await fs.readFile(result.systemPromptPath, 'utf8');
     expect(generatedConfig.agent).toMatchObject({
       build: {
         model: 'openai/gpt-5',
-        prompt: `{file:${result.systemPromptPath}}`,
+        prompt: systemPromptFile,
       },
       [MIMOCODE_FULL_ACCESS_MODE_ID]: {
         mode: 'primary',
@@ -197,7 +198,7 @@ describe('prepareMimocodeLaunchArtifacts', () => {
           plan_enter: 'allow',
           question: 'allow',
         },
-        prompt: `{file:${result.systemPromptPath}}`,
+        prompt: systemPromptFile,
       },
       [MIMOCODE_SAFE_MODE_ID]: {
         mode: 'primary',
@@ -207,10 +208,10 @@ describe('prepareMimocodeLaunchArtifacts', () => {
           plan_enter: 'allow',
           question: 'allow',
         },
-        prompt: `{file:${result.systemPromptPath}}`,
+        prompt: systemPromptFile,
       },
       plan: {
-        prompt: `{file:${result.systemPromptPath}}`,
+        prompt: systemPromptFile,
       },
     });
   });

--- a/tests/unit/providers/opencode/OpencodeAcpLaunch.test.ts
+++ b/tests/unit/providers/opencode/OpencodeAcpLaunch.test.ts
@@ -86,4 +86,19 @@ describe('OpenCode ACP launch', () => {
       mcpServers: [],
     });
   });
+
+  it('passes the managed config as OPENCODE_CONFIG_CONTENT and never OPENCODE_CONFIG', async () => {
+    const plugin = createAcpLaunchMockPlugin({
+      cliPath: 'C:\\Tools\\opencode.exe',
+      providerId: 'opencode',
+    });
+    plugin.settings.providerConfigs.opencode.environmentVariables = 'OPENCODE_CONFIG=C:\\tmp\\user-opencode.json';
+
+    const runtime = new OpencodeChatRuntime(plugin);
+    await expect(runtime.ensureReady()).resolves.toBe(true);
+
+    const launchEnv: NodeJS.ProcessEnv = MockAcpSubprocess.mock.calls[0][0].env;
+    expect(launchEnv.OPENCODE_CONFIG_CONTENT).toBe('{}\n');
+    expect(launchEnv.OPENCODE_CONFIG).toBeUndefined();
+  });
 });

--- a/tests/unit/providers/opencode/OpencodeAuxQueryRunner.test.ts
+++ b/tests/unit/providers/opencode/OpencodeAuxQueryRunner.test.ts
@@ -177,6 +177,23 @@ describe('OpencodeAuxQueryRunner', () => {
     expect(onTextChunk).toHaveBeenNthCalledWith(2, 'Fix title now');
   });
 
+  it('passes the managed config as OPENCODE_CONFIG_CONTENT and never OPENCODE_CONFIG', async () => {
+    const plugin = createMockPlugin();
+    plugin.settings.providerConfigs.opencode.environmentVariables = 'OPENCODE_CONFIG=C:/tmp/user-opencode.json';
+    const runner = new OpencodeAuxQueryRunner(plugin, {
+      agentProfile: 'passive',
+      artifactPurpose: 'title-gen',
+    });
+
+    await expect(runner.query({
+      systemPrompt: 'Use this custom system prompt.',
+    }, 'Generate a title')).resolves.toBe('Fix title now');
+
+    const launchEnv: NodeJS.ProcessEnv = MockAcpSubprocess.mock.calls[0][0].env;
+    expect(launchEnv.OPENCODE_CONFIG_CONTENT).toBe('{"default_agent":"grimoire-aux-passive"}\n');
+    expect(launchEnv.OPENCODE_CONFIG).toBeUndefined();
+  });
+
   it('falls back to opencode from PATH when no CLI path is configured', async () => {
     const plugin = createMockPlugin();
     plugin.getResolvedProviderCliPath.mockReturnValue(null);

--- a/tests/unit/providers/opencode/OpencodeLaunchArtifacts.test.ts
+++ b/tests/unit/providers/opencode/OpencodeLaunchArtifacts.test.ts
@@ -176,7 +176,7 @@ describe('prepareOpencodeLaunchArtifacts', () => {
     expect(result.configPath).toBe(path.join(tmpRoot, '.grimoire', 'opencode', 'config.json'));
     expect(result.systemPromptPath).toBe(path.join(tmpRoot, '.grimoire', 'opencode', 'system.md'));
     expect(result.configContent).not.toContain('{file:');
-    const generatedConfig = JSON.parse(await fs.readFile(result.configPath, 'utf8'));
+    const generatedConfig = JSON.parse(result.configContent);
     expect(generatedConfig).toMatchObject({
       default_agent: 'build',
       providers: {

--- a/tests/unit/providers/opencode/OpencodeLaunchArtifacts.test.ts
+++ b/tests/unit/providers/opencode/OpencodeLaunchArtifacts.test.ts
@@ -12,12 +12,12 @@ import {
 } from '../../../../src/providers/opencode/runtime/OpencodeLaunchArtifacts';
 
 describe('buildOpencodeManagedConfig', () => {
-  it('pins OpenCode build, Auto-approve, safe, and plan prompts to the managed prompt file', () => {
-    expect(buildOpencodeManagedConfig({}, '/vault/.grimoire/opencode/system.md', 'Test User')).toEqual({
+  it('pins OpenCode build, Auto-approve, safe, and plan prompts to the managed prompt text', () => {
+    expect(buildOpencodeManagedConfig({}, 'Managed system prompt.', 'Test User')).toEqual({
       $schema: 'https://opencode.ai/config.json',
       agent: {
         build: {
-          prompt: '{file:/vault/.grimoire/opencode/system.md}',
+          prompt: 'Managed system prompt.',
         },
         [OPENCODE_FULL_ACCESS_MODE_ID]: {
           mode: 'primary',
@@ -25,7 +25,7 @@ describe('buildOpencodeManagedConfig', () => {
             plan_enter: 'allow',
             question: 'allow',
           },
-          prompt: '{file:/vault/.grimoire/opencode/system.md}',
+          prompt: 'Managed system prompt.',
         },
         [OPENCODE_SAFE_MODE_ID]: {
           mode: 'primary',
@@ -36,10 +36,10 @@ describe('buildOpencodeManagedConfig', () => {
             question: 'allow',
             write: 'ask',
           },
-          prompt: '{file:/vault/.grimoire/opencode/system.md}',
+          prompt: 'Managed system prompt.',
         },
         plan: {
-          prompt: '{file:/vault/.grimoire/opencode/system.md}',
+          prompt: 'Managed system prompt.',
         },
       },
       username: 'Test User',
@@ -49,7 +49,7 @@ describe('buildOpencodeManagedConfig', () => {
   it('can create a dedicated aux agent and default it for the process', () => {
     expect(buildOpencodeManagedConfig(
       {},
-      '/vault/.grimoire/opencode/auxiliary/system.md',
+      'Aux system prompt.',
       undefined,
       [{
         definition: {
@@ -71,7 +71,7 @@ describe('buildOpencodeManagedConfig', () => {
             '*': 'deny',
             read: 'allow',
           },
-          prompt: '{file:/vault/.grimoire/opencode/auxiliary/system.md}',
+          prompt: 'Aux system prompt.',
         },
       },
       default_agent: 'grimoire-aux-readonly',
@@ -96,7 +96,7 @@ describe('buildOpencodeManagedConfig', () => {
         },
       },
       username: 'Existing',
-    }, '/vault/.grimoire/opencode/system.md')).toEqual({
+    }, 'Managed system prompt.')).toEqual({
       $schema: 'https://opencode.ai/config.json',
       agent: {
         build: {
@@ -105,7 +105,7 @@ describe('buildOpencodeManagedConfig', () => {
             bash: 'ask',
             edit: 'ask',
           },
-          prompt: '{file:/vault/.grimoire/opencode/system.md}',
+          prompt: 'Managed system prompt.',
         },
         [OPENCODE_FULL_ACCESS_MODE_ID]: {
           mode: 'primary',
@@ -113,7 +113,7 @@ describe('buildOpencodeManagedConfig', () => {
             plan_enter: 'allow',
             question: 'allow',
           },
-          prompt: '{file:/vault/.grimoire/opencode/system.md}',
+          prompt: 'Managed system prompt.',
         },
         [OPENCODE_SAFE_MODE_ID]: {
           mode: 'primary',
@@ -124,10 +124,10 @@ describe('buildOpencodeManagedConfig', () => {
             question: 'allow',
             write: 'ask',
           },
-          prompt: '{file:/vault/.grimoire/opencode/system.md}',
+          prompt: 'Managed system prompt.',
         },
         plan: {
-          prompt: '{file:/vault/.grimoire/opencode/system.md}',
+          prompt: 'Managed system prompt.',
         },
       },
       default_agent: 'build',
@@ -175,7 +175,7 @@ describe('prepareOpencodeLaunchArtifacts', () => {
 
     expect(result.configPath).toBe(path.join(tmpRoot, '.grimoire', 'opencode', 'config.json'));
     expect(result.systemPromptPath).toBe(path.join(tmpRoot, '.grimoire', 'opencode', 'system.md'));
-    expect(result.configContent).toContain(`"prompt": "{file:${result.systemPromptPath}}"`);
+    expect(result.configContent).not.toContain('{file:');
     const generatedConfig = JSON.parse(await fs.readFile(result.configPath, 'utf8'));
     expect(generatedConfig).toMatchObject({
       default_agent: 'build',
@@ -186,10 +186,11 @@ describe('prepareOpencodeLaunchArtifacts', () => {
       },
       username: 'Test User',
     });
+    const systemPromptFile = await fs.readFile(result.systemPromptPath, 'utf8');
     expect(generatedConfig.agent).toMatchObject({
       build: {
         model: 'openai/gpt-5',
-        prompt: `{file:${result.systemPromptPath}}`,
+        prompt: systemPromptFile,
       },
       [OPENCODE_FULL_ACCESS_MODE_ID]: {
         mode: 'primary',
@@ -197,7 +198,7 @@ describe('prepareOpencodeLaunchArtifacts', () => {
           plan_enter: 'allow',
           question: 'allow',
         },
-        prompt: `{file:${result.systemPromptPath}}`,
+        prompt: systemPromptFile,
       },
       [OPENCODE_SAFE_MODE_ID]: {
         mode: 'primary',
@@ -207,10 +208,10 @@ describe('prepareOpencodeLaunchArtifacts', () => {
           plan_enter: 'allow',
           question: 'allow',
         },
-        prompt: `{file:${result.systemPromptPath}}`,
+        prompt: systemPromptFile,
       },
       plan: {
-        prompt: `{file:${result.systemPromptPath}}`,
+        prompt: systemPromptFile,
       },
     });
   });


### PR DESCRIPTION
## Summary

On Windows, `opencode acp` never completes `initialize` (and sometimes crashes with `0xC0000005`) whenever a file-based `OPENCODE_CONFIG` is present — even a trivial `{}` file, with either path separator style. Verified live against opencode 1.18.21 on Windows 11 ARM64. Since both the chat runtime and the aux query runners passed `OPENCODE_CONFIG`, the OpenCode provider was fully broken on Windows: no model list, no turns.

- The managed config now travels exclusively as `OPENCODE_CONFIG_CONTENT`. It is already complete: the user's `OPENCODE_CONFIG` base (if configured in Grimoire env settings) is read and merged during artifact preparation, so nothing is lost.
- `OPENCODE_CONFIG` is explicitly deleted from the child env so a user-configured value (from Grimoire environment settings or the parent process) cannot leak through and reintroduce the hang.
- `{file:...}` prompt references resolve relative to a config file that no longer reaches the CLI, so the managed system prompt is now inlined into the agent `prompt` fields. `system.md` is still written next to the config for inspection and stays byte-identical to the inlined prompt.
- **Kimi Code** (`src/providers/kimicode/`, the same OpenCode-CLI family) received the identical `KIMICODE_CONFIG` → `KIMICODE_CONFIG_CONTENT` treatment — it kept the exact Windows-hang launch shape this PR removes.
- MiMoCode mirrors the OpenCode CLI launch contract and gets the same `MIMOCODE_CONFIG` → `MIMOCODE_CONFIG_CONTENT` treatment per the provider-mirroring rule.

## Live verification (Windows 11 ARM64, opencode 1.18.21)

- `OPENCODE_CONFIG` set (any content, any path style) → `initialize` never answers; sometimes exit `0xC0000005`.
- `OPENCODE_CONFIG_CONTENT` only → `initialize` + `session/new` work; the `model` config option returns 12 models; a custom managed agent registers; a turn completes.
- With the session mode switched to the managed agent (`session/set_config_option`), a marker word embedded in the inlined system prompt is repeated by the model — the inlined prompt is genuinely loaded.

## Multi-review round

Two independent review agents (correctness/regressions + tests/contract) found no blockers; their findings are addressed in 20f894b:

- Aux query runners had zero child-env coverage — added env-contract tests for all three providers (a reverted `delete` now fails the suite at every launch site).
- Prepare tests parsed the on-disk config file; they now assert on `result.configContent` (the string the CLI actually consumes) and cross-check the inlined prompt against `system.md`.
- Kimi Code carried the same broken launch shape — fixed in this PR (see above).
- Known notes, deliberately not code: the 4-agent chat config inlines the prompt four times (~17.5 KB baseline, ~54% of the conservative 32,767-char Windows env-var budget; a custom system prompt over ~4 KB per agent could exceed it, though CreateProcessW/libuv measured delivering 200 KB fine); a user-set `OPENCODE_CONFIG_CONTENT`/`MIMOCODE_CONFIG_CONTENT`/`KIMICODE_CONFIG_CONTENT` in Grimoire env settings is intentionally overridden by the managed value (which already contains the user's base config).

## Testing

- Launch tests per provider (chat runtime + aux runner): child env carries `*_CONFIG_CONTENT` and never the file-based `*_CONFIG`, even when user env vars set it.
- Managed-config tests updated from `{file:...}` expectations to the inlined prompt text, asserted byte-identical to `system.md` via `configContent`.
- Local gate on Windows: unit suites for opencode/mimocode/kimicode — 49 failing vs 50 on `main` (all pre-existing Windows-only mock failures) with 5 new tests passing; full unit, integration, `typecheck`, `lint`, `build:release` including Obsidian community-review gates all pass. (MiMoCode and Kimi Code CLIs were not available locally for live checks; both changes are symmetric mirrors covered by mirrored unit tests.)