### PR TITLE
test(antigravity): make runtime and capabilities fixtures independent of the launch platform

### DIFF
--- a/tests/unit/providers/antigravity/AntigravityChatRuntime.test.ts
+++ b/tests/unit/providers/antigravity/AntigravityChatRuntime.test.ts
@@ -114,10 +114,70 @@ function writeStreamJsonResult(
   writeStreamJsonFrame(proc, { event: 'result', result });
 }
 
+/**
+ * Undo the quoting `buildWindowsShellCommandLine` applies, so assertions can
+ * read the agy flags out of a `cmd.exe /d /s /c "<line>"` launch the same way
+ * they read them out of a POSIX one. Doubled trailing backslashes are left as
+ * written; no fixture path ends in one.
+ */
+function parseWindowsShellCommandLine(line: string): string[] {
+  const parsed: string[] = [];
+  let current = '';
+  let quoted = false;
+  let started = false;
+  for (let index = 0; index < line.length; index += 1) {
+    const char = line[index];
+    if (char === '"') {
+      if (quoted && line[index + 1] === '"') {
+        current += '"';
+        index += 1;
+      } else {
+        quoted = !quoted;
+        started = true;
+      }
+      continue;
+    }
+    if (char === ' ' && !quoted) {
+      if (started) {
+        parsed.push(current);
+        current = '';
+        started = false;
+      }
+      continue;
+    }
+    current += char;
+    started = true;
+  }
+  if (started) {
+    parsed.push(current);
+  }
+  return parsed;
+}
+
+/**
+ * Normalizes every launch shape `buildAntigravityProcessLaunch` can produce
+ * (POSIX login shell, Windows cmd.exe wrapper, direct exec) back to the agy
+ * arguments themselves, so the fixtures assert behavior instead of the host
+ * platform's process-launch convention.
+ */
+function toAgyArgs(spawnArgs: string[]): string[] {
+  if (spawnArgs[0] === '-lc' && spawnArgs[1] === 'exec "$0" "$@"') {
+    return spawnArgs.slice(3);
+  }
+  if (spawnArgs[0] === '/d' && spawnArgs[1] === '/s' && spawnArgs[2] === '/c') {
+    return parseWindowsShellCommandLine(spawnArgs[3] ?? '').slice(1);
+  }
+  return spawnArgs;
+}
+
+function isHelpProbeArgs(spawnArgs: string[]): boolean {
+  return toAgyArgs(spawnArgs).includes('--help');
+}
+
 function getSpawnedAgyArgs(): string[] {
   const printCall = mockedSpawn.mock.calls
     .map(([, args]: [string, string[]]) => {
-      const flagArgs = args[0] === '-lc' && args[1] === 'exec "$0" "$@"' ? args.slice(3) : args;
+      const flagArgs = toAgyArgs(args);
       const isPrint = flagArgs.includes('--print') || flagArgs.includes('--input-format');
       return { args: flagArgs, isPrint };
     })
@@ -127,7 +187,8 @@ function getSpawnedAgyArgs(): string[] {
 
 function getPrintLogFilePath(): string {
   const [, args] = mockedSpawn.mock.calls[mockedSpawn.mock.calls.length - 1] as [string, string[]];
-  return args[args.indexOf('--log-file') + 1];
+  const agyArgs = toAgyArgs(args);
+  return agyArgs[agyArgs.indexOf('--log-file') + 1];
 }
 
 // FIFOs exist on POSIX only; the drain-race test parks transcript recovery
@@ -491,7 +552,7 @@ describe('AntigravityChatRuntime', () => {
         prompt: 'Hello from transcript',
         runtimeEnv: process.env,
       });
-      const spawnArgs = mockedSpawn.mock.calls[0][1] as string[];
+      const spawnArgs = toAgyArgs(mockedSpawn.mock.calls[0][1] as string[]);
       const logFileArgIndex = spawnArgs.indexOf('--log-file');
       expect(logFileArgIndex).toBeGreaterThanOrEqual(0);
       const logFilePath = spawnArgs[logFileArgIndex + 1];
@@ -584,7 +645,7 @@ describe('AntigravityChatRuntime', () => {
     const probeProc = createMockChildProcess();
     const printProc = createMockChildProcess();
     mockedSpawn.mockImplementation((command: string, args: string[]) => {
-      if (args.includes('--help')) return probeProc;
+      if (isHelpProbeArgs(args)) return probeProc;
       return printProc;
     });
 
@@ -614,7 +675,7 @@ describe('AntigravityChatRuntime', () => {
     const probeProc = createMockChildProcess();
     const printProc = createMockChildProcess();
     mockedSpawn.mockImplementation((command: string, args: string[]) => {
-      if (args.includes('--help')) return probeProc;
+      if (isHelpProbeArgs(args)) return probeProc;
       return printProc;
     });
 
@@ -637,7 +698,7 @@ describe('AntigravityChatRuntime', () => {
     const printProc = createMockChildProcess({ stdin: true });
     const stdin = trackStdin(printProc);
     mockedSpawn.mockImplementation((command: string, args: string[]) => {
-      if (args.includes('--help')) return probeProc;
+      if (isHelpProbeArgs(args)) return probeProc;
       return printProc;
     });
 
@@ -654,7 +715,7 @@ describe('AntigravityChatRuntime', () => {
     await new Promise((resolve) => setImmediate(resolve));
 
     const spawnOptions = mockedSpawn.mock.calls
-      .filter(([, args]: [string, string[]]) => !args.includes('--help'))
+      .filter(([, args]: [string, string[]]) => !isHelpProbeArgs(args))
       .map(([, , options]: [string, string[], Record<string, unknown>]) => options)[0];
     expect(spawnOptions).toEqual(expect.objectContaining({
       stdio: ['pipe', 'pipe', 'pipe'],
@@ -695,7 +756,7 @@ describe('AntigravityChatRuntime', () => {
     const probeProc = createMockChildProcess();
     const printProc = createMockChildProcess({ stdin: true });
     mockedSpawn.mockImplementation((command: string, args: string[]) => {
-      if (args.includes('--help')) return probeProc;
+      if (isHelpProbeArgs(args)) return probeProc;
       return printProc;
     });
 
@@ -724,7 +785,7 @@ describe('AntigravityChatRuntime', () => {
     const probeProc = createMockChildProcess();
     const printProc = createMockChildProcess({ stdin: true });
     mockedSpawn.mockImplementation((command: string, args: string[]) => {
-      if (args.includes('--help')) return probeProc;
+      if (isHelpProbeArgs(args)) return probeProc;
       return printProc;
     });
 
@@ -794,7 +855,7 @@ describe('AntigravityChatRuntime', () => {
         prompt: 'Hello from transcript',
         runtimeEnv: process.env,
       });
-      const spawnArgs = mockedSpawn.mock.calls[0][1] as string[];
+      const spawnArgs = toAgyArgs(mockedSpawn.mock.calls[0][1] as string[]);
       const logFilePath = spawnArgs[spawnArgs.indexOf('--log-file') + 1];
       await fs.mkdir(transcriptDir, { recursive: true });
       await fs.writeFile(logFilePath, [
@@ -1020,7 +1081,7 @@ describe('AntigravityChatRuntime', () => {
       const probeProc = createMockChildProcess();
       const printProc = createMockChildProcess({ stdin: true });
       mockedSpawn.mockImplementation((command: string, args: string[]) => {
-        if (args.includes('--help')) return probeProc;
+        if (isHelpProbeArgs(args)) return probeProc;
         return printProc;
       });
 
@@ -1052,7 +1113,7 @@ describe('AntigravityChatRuntime', () => {
     const printProc = createMockChildProcess({ stdin: true });
     const helpProbes = [firstProbeProc, secondProbeProc];
     mockedSpawn.mockImplementation((command: string, args: string[]) => {
-      if (args.includes('--help')) return helpProbes.shift();
+      if (isHelpProbeArgs(args)) return helpProbes.shift();
       return printProc;
     });
 
@@ -1088,7 +1149,7 @@ describe('AntigravityChatRuntime', () => {
     const secondProc = createMockChildProcess();
     const printProcs = [firstProc, secondProc];
     mockedSpawn.mockImplementation((command: string, args: string[]) => {
-      if (args.includes('--help')) return probeProc;
+      if (isHelpProbeArgs(args)) return probeProc;
       return printProcs.shift();
     });
 
@@ -1143,7 +1204,7 @@ describe('AntigravityChatRuntime', () => {
     const probeProc = createMockChildProcess();
     const printProc = createMockChildProcess();
     mockedSpawn.mockImplementation((command: string, args: string[]) => {
-      if (args.includes('--help')) return probeProc;
+      if (isHelpProbeArgs(args)) return probeProc;
       return printProc;
     });
 
@@ -1386,7 +1447,7 @@ describe('AntigravityChatRuntime', () => {
     const probeProc = createMockChildProcess();
     const printProc = createMockChildProcess();
     mockedSpawn.mockImplementation((command: string, args: string[]) => {
-      if (args.includes('--help')) return probeProc;
+      if (isHelpProbeArgs(args)) return probeProc;
       return printProc;
     });
 
@@ -1408,7 +1469,7 @@ describe('AntigravityChatRuntime', () => {
     const probeProc = createMockChildProcess();
     const printProc = createMockChildProcess();
     mockedSpawn.mockImplementation((command: string, args: string[]) => {
-      if (args.includes('--help')) return probeProc;
+      if (isHelpProbeArgs(args)) return probeProc;
       return printProc;
     });
 

--- a/tests/unit/providers/antigravity/AntigravityChatRuntime.test.ts
+++ b/tests/unit/providers/antigravity/AntigravityChatRuntime.test.ts
@@ -17,6 +17,10 @@ import {
   expandAntigravityVaultSkillInvocation,
 } from '@/providers/antigravity/runtime/AntigravityChatRuntime';
 import { resetAntigravityCliCapabilitiesCache } from '@/providers/antigravity/runtime/AntigravityCliCapabilities';
+import {
+  buildAntigravityProcessLaunch,
+  buildWindowsShellCommandLine,
+} from '@/providers/antigravity/runtime/AntigravityProcessLaunch';
 import { updateAntigravityProviderSettings } from '@/providers/antigravity/settings';
 
 jest.mock('node:child_process', () => ({
@@ -115,26 +119,42 @@ function writeStreamJsonResult(
 }
 
 /**
- * Undo the quoting `buildWindowsShellCommandLine` applies, so assertions can
+ * Invert the quoting `buildWindowsShellCommandLine` applies, so assertions can
  * read the agy flags out of a `cmd.exe /d /s /c "<line>"` launch the same way
- * they read them out of a POSIX one. Doubled trailing backslashes are left as
- * written; no fixture path ends in one.
+ * they read them out of a POSIX one. Kept lossless for every argument shape
+ * the launch builder can emit; `launch-shape normalization helpers` pins that
+ * against the producer.
  */
 function parseWindowsShellCommandLine(line: string): string[] {
   const parsed: string[] = [];
   let current = '';
   let quoted = false;
   let started = false;
-  for (let index = 0; index < line.length; index += 1) {
+  let index = 0;
+  while (index < line.length) {
     const char = line[index];
+    if (char === '\\') {
+      let backslashes = 0;
+      while (line[index] === '\\') {
+        backslashes += 1;
+        index += 1;
+      }
+      // quoteWindowsArgument doubles the run that precedes a quote or the
+      // closing quote; every other run reaches the child verbatim.
+      const wasDoubled = line[index] === '"';
+      current += '\\'.repeat(wasDoubled ? Math.floor(backslashes / 2) : backslashes);
+      started = true;
+      continue;
+    }
+    index += 1;
     if (char === '"') {
-      if (quoted && line[index + 1] === '"') {
+      if (quoted && line[index] === '"') {
         current += '"';
         index += 1;
       } else {
         quoted = !quoted;
-        started = true;
       }
+      started = true;
       continue;
     }
     if (char === ' ' && !quoted) {
@@ -1489,5 +1509,105 @@ describe('AntigravityChatRuntime', () => {
     expect(spawnLog?.data?.argsSummary).not.toContain('/tmp/grimoire-antigravity-test-vault');
     expect(spawnLog?.data?.argsSummary).toContain('--log-file <log-path>');
     expect(spawnLog?.data?.argsSummary).not.toMatch(/grimoire-antigravity-print-/);
+  });
+});
+
+describe('launch-shape normalization helpers', () => {
+  // Every argument shape buildAntigravityProcessLaunch can hand to cmd.exe,
+  // including the quoting edge cases quoteWindowsArgument exists for. Without
+  // this, a fixture that grew a path ending in a backslash would read back a
+  // different value on Windows only, and fail for a reason unrelated to it.
+  const LAUNCH_CASES: Array<{ args: string[]; command: string; name: string }> = [
+    {
+      args: ['--print', '--output-format', 'stream-json'],
+      command: 'agy',
+      name: 'plain flags',
+    },
+    {
+      args: ['--help'],
+      command: 'agy',
+      name: 'the capability probe',
+    },
+    {
+      args: ['--log-file', 'C:\\Users\\test\\AppData\\Local\\Temp\\grimoire-print\\agy.jsonl'],
+      command: 'C:\\Users\\test\\AppData\\agy.cmd',
+      name: 'a Windows log-file path',
+    },
+    {
+      args: ['--add-dir', 'C:\\Users\\test\\My Vault\\notes'],
+      command: 'C:\\Program Files\\agy\\agy.cmd',
+      name: 'paths containing spaces',
+    },
+    {
+      args: ['--print', 'a & b | c < d > e ^ f'],
+      command: 'agy.cmd',
+      name: 'cmd.exe metacharacters',
+    },
+    {
+      args: ['--print', 'привет 世界 🌍'],
+      command: 'agy.cmd',
+      name: 'multibyte prompt content',
+    },
+    {
+      args: ['--print', 'say "hi" now'],
+      command: 'agy.cmd',
+      name: 'quoted prompt content',
+    },
+    {
+      args: ['--add-dir', 'C:\\Users\\test\\vault\\'],
+      command: 'agy.cmd',
+      name: 'a trailing backslash',
+    },
+    {
+      args: ['--print', 'before\\"after'],
+      command: 'agy.cmd',
+      name: 'a backslash before a quote',
+    },
+    {
+      args: ['--print', ''],
+      command: 'agy.cmd',
+      name: 'an empty argument',
+    },
+  ];
+
+  it.each(LAUNCH_CASES)('parses $name back out of the cmd.exe command line', ({ args, command }) => {
+    expect(parseWindowsShellCommandLine(buildWindowsShellCommandLine(command, args)))
+      .toEqual([command, ...args]);
+  });
+
+  it.each(LAUNCH_CASES)('recovers $name from a Windows cmd.exe launch', ({ args, command }) => {
+    const launch = buildAntigravityProcessLaunch(command, args, {}, 'win32');
+
+    expect(launch.launchMode).toBe('cmdShell');
+    expect(toAgyArgs(launch.args)).toEqual(args);
+  });
+
+  it.each(LAUNCH_CASES)('recovers $name from a POSIX login-shell launch', ({ args, command }) => {
+    const launch = buildAntigravityProcessLaunch(command, args, { SHELL: '/bin/zsh' }, 'darwin');
+
+    expect(launch.launchMode).toBe('shellLogin');
+    expect(toAgyArgs(launch.args)).toEqual(args);
+  });
+
+  it('recovers arguments from a direct agy.exe launch', () => {
+    const launch = buildAntigravityProcessLaunch(
+      'C:\\Users\\test\\agy\\agy.exe',
+      ['--print', 'hello'],
+      {},
+      'win32',
+    );
+
+    expect(launch.launchMode).toBe('direct');
+    expect(toAgyArgs(launch.args)).toEqual(['--print', 'hello']);
+  });
+
+  it('detects the capability probe through every launch shape', () => {
+    const cmdShell = buildAntigravityProcessLaunch('agy', ['--help'], {}, 'win32');
+    const loginShell = buildAntigravityProcessLaunch('agy', ['--help'], { SHELL: '/bin/zsh' }, 'darwin');
+    const printLaunch = buildAntigravityProcessLaunch('agy', ['--print', 'hello'], {}, 'win32');
+
+    expect(isHelpProbeArgs(cmdShell.args)).toBe(true);
+    expect(isHelpProbeArgs(loginShell.args)).toBe(true);
+    expect(isHelpProbeArgs(printLaunch.args)).toBe(false);
   });
 });

--- a/tests/unit/providers/antigravity/AntigravityCliCapabilities.test.ts
+++ b/tests/unit/providers/antigravity/AntigravityCliCapabilities.test.ts
@@ -6,6 +6,7 @@ import {
   probeAntigravityCliCapabilities,
   resetAntigravityCliCapabilitiesCache,
 } from '@/providers/antigravity/runtime/AntigravityCliCapabilities';
+import { buildAntigravityProcessLaunch } from '@/providers/antigravity/runtime/AntigravityProcessLaunch';
 
 jest.mock('node:child_process', () => ({
   spawn: jest.fn(),
@@ -52,8 +53,9 @@ describe('probeAntigravityCliCapabilities', () => {
   it('detects every capability in agy --help output', async () => {
     const proc = createMockChildProcess();
     mockedSpawn.mockReturnValue(proc);
+    const runtimeEnv = { SHELL: '/bin/zsh' };
 
-    const promise = probeAntigravityCliCapabilities('/usr/local/bin/agy', { SHELL: '/bin/zsh' });
+    const promise = probeAntigravityCliCapabilities('/usr/local/bin/agy', runtimeEnv);
     emitHelpAndExit(proc, [
       'Usage: agy [flags]',
       '  --add-dir <dir>          Add a workspace directory',
@@ -68,10 +70,15 @@ describe('probeAntigravityCliCapabilities', () => {
       printTimeout: true,
       streamJson: true,
     });
+    // The launch shape (POSIX login shell, Windows cmd.exe wrapper, or a
+    // direct exec) is buildAntigravityProcessLaunch's decision, not this
+    // probe's; asserting through it keeps the expectation correct on every
+    // platform the suite runs on instead of hardcoding the POSIX shape.
+    const launch = buildAntigravityProcessLaunch('/usr/local/bin/agy', ['--help'], runtimeEnv);
     expect(mockedSpawn).toHaveBeenCalledWith(
-      '/bin/zsh',
-      ['-lc', 'exec "$0" "$@"', '/usr/local/bin/agy', '--help'],
-      expect.objectContaining({ shell: false }),
+      launch.command,
+      launch.args,
+      expect.objectContaining({ shell: launch.shell }),
     );
   });
 


### PR DESCRIPTION
## Problem

On Windows, the `antigravity` provider's unit tests fail broadly — not
from a behavior regression, but because several fixtures hardcode a
POSIX process-launch shape. Flagged during review of #71 (7 failed on
`main`/1.1.8 vs 16 on that PR's branch) and requested explicitly:

> **Point 3 — please do send that PR.** Making the runtime and
> capabilities fixtures platform-aware (following the
> `AntigravityCliResolver.test.ts` pattern) is the right split: it is
> mechanical, it is pre-existing debt rather than this branch's
> regression, and it gives the provider real CI coverage on the
> platform it exists for.
> — https://github.com/sandsaber/Grimoire/pull/71#issuecomment-5370169369

No issue number was opened for this; it's tracked only in that review
thread.

## Root Cause

`buildAntigravityProcessLaunch` wraps non-`.exe` commands on Windows in
`cmd.exe /d /s /c "<quoted line>"` instead of spawning `agy` directly.
The fixtures were written for the POSIX login-shell shape only:

- `AntigravityChatRuntime.test.ts` matched the print/probe child
  processes via `args.includes('--help')`, which is `false` once the
  flag is nested inside one quoted cmd.exe argument string — the probe
  then received the wrong child, never resolved, and every downstream
  stream-json assertion failed for a reason unrelated to the behavior
  under test.
- `AntigravityCliCapabilities.test.ts` asserted the exact spawn call
  (`'/bin/zsh', ['-lc', ...]`) instead of deriving it from the
  platform, so the one launch-shape assertion failed outright.

`AntigravityCliResolver.test.ts` already handles this correctly by
branching fixtures on `process.platform`.

## Approach

Rather than branching each assertion on `process.platform` (the
`AntigravityCliResolver.test.ts` pattern), this normalizes both
directions:

- `AntigravityChatRuntime.test.ts`: added `toAgyArgs()` /
  `parseWindowsShellCommandLine()`, which undo whichever launch
  wrapping was actually applied (POSIX login shell, Windows cmd.exe, or
  direct exec) and recover the logical `agy` arguments. Existing
  `args.includes('--help')` call sites, the `--log-file` path lookups,
  and the print-args filter now all go through this.
- `AntigravityCliCapabilities.test.ts`: the one launch-shape assertion
  now computes its expectation by calling `buildAntigravityProcessLaunch`
  directly instead of hardcoding a POSIX shape, so it can't drift from
  what the launch builder actually decides.

I chose normalization over per-assertion platform branching because
most of the affected assertions only care about the logical `agy`
flags, not the wrapping — normalizing once keeps the test bodies free
of `if (process.platform === 'win32')` noise. Happy to switch to the
branching style instead if you'd prefer consistency with
`AntigravityCliResolver.test.ts`.

Test-only change; no production code touched.

## Architecture

- [x] Provider-native behavior remains inside `src/providers/antigravity/`
      — N/A, no `src/` change at all, tests directory only.
- [x] N/A — no shared contract touched.
- [x] N/A — no sibling providers affected (Antigravity-only fixtures).

## Security And Privacy

No security boundary change — test-only, no production code paths
altered.

## Verification

Automated commands run (Windows 11, Node 22.22.2, npm 12.0.2 — matching
CI's pinned toolchain, run through an isolated portable install so the
system Node/npm were not touched):

```text
npm run typecheck
npm run lint
npm run review:source
npm run test -- --selectProjects unit
npm run build:release
```

On Windows, `tests/unit/providers/antigravity` goes from 18 failing to
3. The remaining 3 are pre-existing and unrelated to process launch
(two involve a log-file unlink timing difference, one is
model-discovery ordering — separate root causes, out of scope here).
On the full unit suite: 83 → 70 failures (13 repaired), and no suite
enters the failing set — verified against a `main` baseline run with
the same toolchain immediately before and after.

Manual verification: Not run (test-only change; no runtime behavior to
exercise manually).

## Generated Artifacts

- [x] `npm run build:release` recreates `dist/grimoire/main.js`,
      `manifest.json`, and `styles.css` from the submitted source
      (verified locally; not included in this diff).
- [x] N/A — no dependency changes.
- [x] Generated root bundles, `dist/grimoire`, and local-only artifacts
      are not included.

## Review Checklist

- [x] The PR is focused on one coherent problem (platform-dependent
      test fixtures).
- [x] N/A — test-only change, no behavior change requiring new
      regression tests.
- [ ] N/A — no protocol payloads or error codes involved; this is a
      process-launch fixture, not provider protocol handling.
- [x] Documentation and user-facing copy are in English.
- [x] The description distinguishes automated tests (above) from
      manual verification (not run).