### PR TITLE
ci: report the Windows unit suite without gating merges on it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,3 +56,87 @@ jobs:
 
       - name: Build release artifacts
         run: npm run build:release
+
+  windows-unit:
+    # Only the test step is non-blocking. The unit suite still has known
+    # Windows-only failures, so this job records the current count rather than
+    # gating merges on it: the step summary shows the gap on every run and the
+    # uploaded log names the failing tests to work from. Setup still fails the
+    # job outright — a Windows install that stops working is a real break, not
+    # a known gap. Drop `continue-on-error` and make the check required once
+    # the count reaches zero. Linux owns the lockfile, audit, and
+    # release-artifact gates; this job covers only what is platform-dependent.
+    name: windows-unit (non-blocking)
+    runs-on: windows-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Setup Node 22
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: 22.22.2
+          cache: 'npm'
+
+      # .npmrc relies on npm 12 behavior (`min-release-age`,
+      # `strict-allow-scripts`), so the pin is not optional here either. On
+      # Windows `--prefix` puts npm.cmd in the prefix directory itself rather
+      # than in a bin/ subdirectory.
+      - name: Install isolated npm 12.0.2
+        shell: bash
+        run: |
+          npm install --global --prefix "${RUNNER_TEMP}/npm-12.0.2" npm@12.0.2 --ignore-scripts --no-audit --no-fund
+          echo "${RUNNER_TEMP}/npm-12.0.2" >> "${GITHUB_PATH}"
+
+      - name: Verify npm version
+        shell: bash
+        run: test "$(npm --version)" = "12.0.2"
+
+      - name: Install dependencies
+        shell: bash
+        run: npm ci
+
+      - name: Unit tests
+        id: unit
+        continue-on-error: true
+        shell: bash
+        run: npm run test -- --selectProjects unit 2>&1 | tee windows-unit.log
+
+      - name: Summarize Windows results
+        if: always()
+        shell: bash
+        run: |
+          suites="$(grep -E '^Test Suites:' windows-unit.log | tail -1 || true)"
+          tests="$(grep -E '^Tests:' windows-unit.log | tail -1 || true)"
+          {
+            echo "## Windows unit suite"
+            echo
+            echo "Outcome: \`${{ steps.unit.outcome }}\` (non-blocking)"
+            echo
+            if [ -n "${tests}" ]; then
+              echo "- ${suites}"
+              echo "- ${tests}"
+            else
+              echo "Jest printed no summary line. The run likely failed before"
+              echo "the suite started — see the \`windows-unit-log\` artifact."
+            fi
+            failures="$(grep -E '^[[:space:]]+● ' windows-unit.log | sort -u || true)"
+            if [ -n "${failures}" ]; then
+              echo
+              echo "<details><summary>Failing tests</summary>"
+              echo
+              echo '```text'
+              echo "${failures}" | head -200
+              echo '```'
+              echo
+              echo "</details>"
+            fi
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+      - name: Upload Windows unit log
+        if: always()
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
+        with:
+          name: windows-unit-log
+          path: windows-unit.log
+          if-no-files-found: warn


### PR DESCRIPTION
## Problem

Grimoire ships to Obsidian on Windows, but CI has only ever run on `ubuntu-latest`. The platform with the most divergent process-launch, path, and file-locking behavior has no coverage at all, so Windows-only breakage reaches us through contributors instead of through CI.

#74 is the current example: a set of Antigravity fixtures had silently assumed a POSIX launch shape, and the numbers in that PR put the remaining Windows unit failures at roughly seventy. Nobody on the project can see that number without a Windows machine, and nothing stops it from growing.

No issue number — this follows from the review discussion on #71 and #74.

## Root Cause

`.github/workflows/ci.yml` has a single `validate` job pinned to `ubuntu-latest`. Every platform-dependent code path — `buildAntigravityProcessLaunch`'s `cmd.exe` wrapper, path separators in fixtures, POSIX-only syscalls, deleting a file another process holds open — is exercised on exactly one platform, and it is not the one where those paths differ.

## Approach

Add a second job rather than a matrix entry on `validate`.

A matrix would have forced one of two bad outcomes: either Windows becomes a merge gate immediately and CI goes red against ~70 known failures, or the whole `validate` job goes non-blocking and Linux loses its gate too. A separate job lets Windows be reported without being enforced, while Linux stays exactly as strict as it is today.

What the job runs:

- `npm ci` and `npm run test -- --selectProjects unit` — the genuinely platform-dependent parts.
- Not the lockfile-age, audit, signature, or `build:release` gates. Those are platform-independent and Linux already owns them; duplicating them here would add runtime and a second place to keep in sync.

What blocks and what does not:

- `continue-on-error` is on the **test step only**. Known Windows failures do not paint CI red.
- Setup steps stay blocking. A Windows install that stops working is a regression, not a known gap, and should fail loudly.
- Once the failure count reaches zero, drop `continue-on-error` and make the check required. The comment on the job says so, so the temporary state does not quietly become permanent.

How the result stays visible — a silently-green job would be worse than no job:

- A summary step writes the suite/test counts and a collapsible list of failing test names into the run's step summary, so the gap is one click from the checks list.
- The full log uploads as the `windows-unit-log` artifact, which is the triage list for the follow-up work.

Two Windows-specific details worth flagging for review:

- **The npm pin is not optional here.** `.npmrc` uses npm 12 features (`min-release-age`, `strict-allow-scripts`) and `engines.npm` requires `>=12.0.2`, but Node 22.22.2 ships npm 10. The pin is reproduced from `validate` with one difference: on Windows `npm install --global --prefix DIR` puts `npm.cmd` in `DIR` itself rather than in `DIR/bin`, so that is what goes on `GITHUB_PATH`. The `Verify npm version` step fails the job if that resolution is ever wrong, instead of silently running npm 10.
- **`shell: bash` on every scripted step.** The default shell on Windows runners is PowerShell, which would not interpret `${RUNNER_TEMP}` or `>> "${GITHUB_PATH}"` the way the Linux job does.

## Architecture

- [x] N/A — no `src/` change; CI configuration only.
- [x] N/A — no shared contract touched.
- [x] N/A — no provider behavior changed.

Architecture notes: this touches `.github/workflows/ci.yml` only. No plugin code, tests, or generated artifacts are modified.

## Security And Privacy

- [x] N/A — no provider, session, or model data is handled.
- [x] N/A — no permission or authorization behavior changes.
- [x] Filesystem, process, credential, MCP, and external-path boundaries are unchanged.
- [x] The uploaded artifact is Jest's own output for this repository's test suite. The suites run against fixtures and mocks, not a real vault or real provider credentials.

Security notes: no security boundary change. `permissions: contents: read` at the workflow level already covers the new job; it needs no additional token scope. Both third-party actions are pinned by commit SHA in line with the existing job — `actions/upload-artifact` is added at `330a01c` (v5).

## Verification

Automated commands run (macOS):

```text
node -e "require('yaml').parse(fs.readFileSync('.github/workflows/ci.yml','utf8'))"
bash --noprofile --norc -eo pipefail summarize.sh
```

The workflow parses as valid YAML with both jobs and the expected step list. The summary script was extracted from the workflow and executed under `bash --noprofile --norc -eo pipefail` — the exact shell GitHub uses for `shell: bash` — against a real Jest log. It rendered the counts and the failing-test list correctly, and the fallback branch (Jest producing no summary line, i.e. a run that dies before the suite starts) was exercised separately against an empty log. Each `grep` is guarded with `|| true`, because under `-e` a no-match exit would otherwise kill the step.

Manual verification: Not run in the sense that matters most here — how `npm ci` and Jest actually behave on GitHub's Windows runners cannot be determined from macOS. That is what the job exists to find out, and the first run on this PR is the real test of it. Expect the test step to report failures; that is the intended initial state, not a broken job. A failure in `Install isolated npm 12.0.2`, `Verify npm version`, or `Install dependencies` would be a genuine problem with this PR and should block it.

## Generated Artifacts

- [x] N/A — no source change, so no bundle to regenerate.
- [x] N/A — no dependency changes.
- [x] Generated root bundles, `dist/grimoire`, and local-only artifacts are not included.

## Review Checklist

- [x] The PR is focused on one coherent problem (Windows has no CI signal).
- [x] N/A — CI configuration change; the job's own output is the verification.
- [x] N/A — no protocol payloads or error codes involved.
- [x] Documentation and user-facing copy are in English.
- [x] The description separates what was verified locally from what only the first CI run can confirm.


---

## First-run baseline (added after this PR's own CI run)

The job works end to end on `windows-latest`: the npm 12 pin resolved with the Windows `--prefix` layout, `npm ci` succeeded, the suite ran in 59s (job total 2m11s, cheaper than the Linux `validate` job at 2m54s), and the summary and artifact both rendered. Everything this PR could not verify from macOS is now confirmed.

Baseline on `main`: **77 failing tests across 27 suites, out of 7070.**

| Class | Count | Fixable without a Windows machine? |
|---|---|---|
| Path shape — drive letter, `\` vs `/`, `PATH` delimiter | ~46 | Yes, mechanically |
| `AntigravityChatRuntime` 5s timeouts | 8 | Already addressed by #74 |
| Process-launch shape (`cmd.exe`, `/bin/`, `SHELL`) | 6 | Yes — `buildAntigravityProcessLaunch` takes `platform` as a parameter |
| Everything else | ~17 | Case by case |

Concentration: `AntigravityChatRuntime` 14, `sdkSession` 10, `utils.ts` 6, `resolveWorkspacePath` 5, `normalizePathForFilesystem` 4, then a long tail including 15 singletons.

**This already validates #74 against real runner output.** Eight of the fourteen `AntigravityChatRuntime` failures are `Exceeded timeout of 5000 ms` — exactly the symptom that PR diagnoses, where the `--help` probe is never recognized inside the `cmd.exe` wrapper so the promise never settles. That was an argument in a PR description before this job existed; now it is observed behavior.

**Some failures look like real Windows product bugs rather than fixture debt**, and are worth separating from the mechanical sweep:

- `GrokUsageMetadataStore › loads session cost and context usage from persisted Grok session files` — expects `{amount: 1.5, currency: "USD"}`, receives `null`. If that is path resolution rather than the fixture, session cost tracking silently does nothing on Windows.
- `AgentManager › excludes file-loaded agents from built-in list` — expects `vault`, receives `builtin`. Consistent with a path comparison that never matches on Windows, which would classify a vault agent as built-in.
- `permission request CSS › uses the branded permission shell and accents only safe action icons` — the received string is empty, not merely different. An empty read points at the file, not the assertion.

Clear fixture debt on the other side of the line: `findClaudeCLIPath › on Unix/macOS › should check cli-wrapper.cjs paths as fallback on Unix` fails only because it is not skipped off POSIX, and `parsePathEntries › splits on platform separator` feeds a `:`-delimited `PATH` and gets back `["A:", "B:", "C:"]`.

One case needs a product decision rather than a fix: `sdkSession › encodeVaultPathForSDK` (4 failures) expects `-Users-test-vault` and gets `D--Users-test-vault`. The encoder is faithfully encoding the drive letter, so the test expectation is probably what is wrong — but this determines the on-disk session directory name for Windows users, so it should be decided deliberately rather than patched to match current behavior.

Full log: the `windows-unit-log` artifact on [run 32597093226](https://github.com/sandsaber/Grimoire/actions/runs/32597093226).

Remediation is deliberately **not** in this PR. Landing it here would mean ~77 changes across 27 files and every provider, mixing pure fixture edits with `src/` changes that need sibling-provider review (OpenCode and MiMoCode mirror each other by design) — and it would collide with #74, which already touches some of these fixtures. This PR is the instrument; the fixes follow class by class, each re-measured by the job it adds.
