### PR TITLE
test(utils): anchor CLI-discovery fixtures to the host platform

### DIFF
--- a/tests/unit/utils/env.test.ts
+++ b/tests/unit/utils/env.test.ts
@@ -1216,7 +1216,14 @@ describe('getExtraBinaryPaths (Windows branches)', () => {
   });
 });
 
-describe('Obsidian CLI path integration', () => {
+// getEnhancedPath composes with path.join and path.delimiter, which stay bound
+// to the host no matter what process.platform is overridden to. On a Windows
+// runner these macOS- and Linux-specific expectations would be comparing
+// `\`-joined candidates against a `;`-delimited string, so they are skipped
+// rather than rewritten into an assertion about neither platform.
+const describeOnPosix = isWindows ? describe.skip : describe;
+
+describeOnPosix('Obsidian CLI path integration', () => {
   const originalPlatform = process.platform;
   const originalExecPath = process.execPath;
   const originalEnv = { ...process.env };

--- a/tests/unit/utils/path.test.ts
+++ b/tests/unit/utils/path.test.ts
@@ -413,6 +413,20 @@ describe('normalizePathForVault', () => {
   });
 });
 
+// getNpmClaudeCodeEntrypointPaths probes a different package parent per
+// platform — %USERPROFILE%\AppData\Roaming\npm on Windows, ~/.npm-global/lib
+// on POSIX — because global npm has no lib/ level on Windows. Anchoring a
+// fixture to the other platform's layout only proves that nothing is there.
+const NPM_PACKAGE_PARENT = isWindows
+  ? path.join(os.homedir(), 'AppData', 'Roaming', 'npm')
+  : path.join(os.homedir(), '.npm-global', 'lib');
+
+function claudeCodeEntrypoint(entrypoint: string): string {
+  return path.join(
+    NPM_PACKAGE_PARENT, 'node_modules', '@anthropic-ai', 'claude-code', entrypoint,
+  );
+}
+
 describe('findClaudeCLIPath', () => {
   afterEach(() => {
     jest.restoreAllMocks();
@@ -460,10 +474,7 @@ describe('findClaudeCLIPath', () => {
   });
 
   it('falls back to npm cli-wrapper.cjs paths when binary not found', () => {
-    const cliWrapperPath = path.join(
-      os.homedir(), '.npm-global', 'lib', 'node_modules',
-      '@anthropic-ai', 'claude-code', 'cli-wrapper.cjs'
-    );
+    const cliWrapperPath = claudeCodeEntrypoint('cli-wrapper.cjs');
 
     jest.spyOn(fs, 'existsSync').mockImplementation(
       p => String(p) === cliWrapperPath
@@ -477,10 +488,7 @@ describe('findClaudeCLIPath', () => {
   });
 
   it('keeps legacy npm cli.js fallback when cli-wrapper.cjs is absent', () => {
-    const legacyCliPath = path.join(
-      os.homedir(), '.npm-global', 'lib', 'node_modules',
-      '@anthropic-ai', 'claude-code', 'cli.js'
-    );
+    const legacyCliPath = claudeCodeEntrypoint('cli.js');
 
     jest.spyOn(fs, 'existsSync').mockImplementation(
       p => String(p) === legacyCliPath
@@ -494,9 +502,12 @@ describe('findClaudeCLIPath', () => {
   });
 
   it('falls back to PATH environment when common and npm paths fail', () => {
-    const envClaudePath = '/env/specific/bin/claude';
+    // Windows PATH resolution looks for claude.exe before claude, and PATH
+    // itself is delimiter-separated per platform.
+    const envBinDir = isWindows ? 'C:\\env\\specific\\bin' : '/env/specific/bin';
+    const envClaudePath = path.join(envBinDir, isWindows ? 'claude.exe' : 'claude');
     const originalPath = process.env.PATH;
-    process.env.PATH = `/env/specific/bin:${originalPath}`;
+    process.env.PATH = [envBinDir, originalPath].join(path.delimiter);
 
     jest.spyOn(fs, 'existsSync').mockImplementation(
       p => String(p) === envClaudePath

--- a/tests/unit/utils/utils.test.ts
+++ b/tests/unit/utils/utils.test.ts
@@ -481,6 +481,12 @@ describe('utils.ts', () => {
     // Windows runner: path.join would still produce `\`-separated candidates
     // that the POSIX fixtures below can never match. Skipped rather than
     // early-returned so the run reports them as skipped instead of passed.
+    //
+    // The whole block is skipped, not just the four cases that fail on
+    // Windows. The other two pass there only vacuously: both assert a null
+    // result, and on Windows this POSIX branch is unreachable, so they would
+    // return null no matter what the resolver did. Keeping them running would
+    // add two green lights that cannot measure a regression.
     describeOnPosix('on Unix/macOS', () => {
       beforeEach(() => {
         Object.defineProperty(process, 'platform', { value: 'darwin' });
@@ -501,6 +507,7 @@ describe('utils.ts', () => {
         expect(findClaudeCLIPath()).toBe('/home/test/.local/bin/claude');
       });
 
+      // Vacuous on Windows — see the note on describeOnPosix above.
       it('should return null when Claude CLI is not found', () => {
         jest.spyOn(os, 'homedir').mockReturnValue('/home/test');
         jest.spyOn(fs, 'existsSync').mockReturnValue(false);
@@ -530,6 +537,7 @@ describe('utils.ts', () => {
         expect(findClaudeCLIPath(customPath)).toBe('/home/test/bin/claude');
       });
 
+      // Vacuous on Windows — see the note on describeOnPosix above.
       it('should not return a directory path even if it exists', () => {
         jest.spyOn(os, 'homedir').mockReturnValue('/home/test');
         const dirPath = path.join('/home/test', '.local', 'bin', 'claude');

--- a/tests/unit/utils/utils.test.ts
+++ b/tests/unit/utils/utils.test.ts
@@ -206,7 +206,8 @@ describe('utils.ts', () => {
       process.env[envKey] = '/tmp/grimoire-test';
 
       try {
-        expect(normalizePathForFilesystem(`$${envKey}/notes/file.md`)).toBe('/tmp/grimoire-test/notes/file.md');
+        expect(normalizePathForFilesystem(`$${envKey}/notes/file.md`))
+          .toBe(path.normalize('/tmp/grimoire-test/notes/file.md'));
       } finally {
         if (originalValue === undefined) {
           delete process.env[envKey];
@@ -232,9 +233,10 @@ describe('utils.ts', () => {
     });
 
     it('handles non-existent environment variables', () => {
-      // Non-existent env vars should be left as-is
-      expect(normalizePathForFilesystem('$NONEXISTENT/path')).toBe('$NONEXISTENT/path');
-      expect(normalizePathForFilesystem('%NONEXISTENT%/path')).toBe('%NONEXISTENT%/path');
+      // Non-existent env vars are left as-is; only the separators are
+      // normalized for the host platform.
+      expect(normalizePathForFilesystem('$NONEXISTENT/path')).toBe(path.normalize('$NONEXISTENT/path'));
+      expect(normalizePathForFilesystem('%NONEXISTENT%/path')).toBe(path.normalize('%NONEXISTENT%/path'));
     });
 
     it('handles mixed path separators', () => {
@@ -457,6 +459,8 @@ describe('utils.ts', () => {
     });
   });
 
+  const describeOnPosix = process.platform === 'win32' ? describe.skip : describe;
+
   describe('findClaudeCLIPath', () => {
     const originalPlatform = process.platform;
     let originalEnv: NodeJS.ProcessEnv;
@@ -472,7 +476,12 @@ describe('utils.ts', () => {
       process.env = originalEnv;
     });
 
-    describe('on Unix/macOS', () => {
+    // Overriding process.platform does not redirect the `path` module, which
+    // stays bound to the host, so POSIX resolution cannot be exercised from a
+    // Windows runner: path.join would still produce `\`-separated candidates
+    // that the POSIX fixtures below can never match. Skipped rather than
+    // early-returned so the run reports them as skipped instead of passed.
+    describeOnPosix('on Unix/macOS', () => {
       beforeEach(() => {
         Object.defineProperty(process, 'platform', { value: 'darwin' });
       });


### PR DESCRIPTION
## Problem

Second slice of the Windows failures the `windows-unit` job reports. #76 took the suites down to 42; this one takes the eleven remaining failures in the shared utility suites — `utils/path`, `utils/utils`, and `utils/env`.

They split into two genuinely different problems that happened to look alike in the log.

## Root Cause

**Five fixtures pinned a layout the code deliberately does not use on Windows.**

`getNpmClaudeCodeEntrypointPaths` probes `%USERPROFILE%\AppData\Roaming\npm` on Windows, not `~/.npm-global/lib`, because a global npm install has no `lib/` level there. Two fixtures hard-coded the POSIX parent, so on Windows they were proving that nothing exists at a path the resolver never consults — `Received: null` was the resolver behaving correctly.

The PATH fallback had the same shape from a different angle: it spliced `PATH` with a hard-coded `':'` and expected a bare `claude`, while `resolveClaudeFromPathEntries` looks for `claude.exe` before `claude` and `PATH` is delimiter-separated per platform.

Two `normalizePathForFilesystem` expectations were plain separator literals in a file whose neighbouring cases already build theirs with `path.normalize`.

**Six could not be repaired at all — only honestly scoped.**

`findClaudeCLIPath > on Unix/macOS` and `Obsidian CLI path integration` already override `process.platform` to `darwin`/`linux` and re-require the module. That is not enough, and the reason is worth stating plainly because it will come up again: **overriding `process.platform` does not redirect the `path` module.** `path.join` keeps emitting `\`-separated candidates and `path.delimiter` keeps returning `';'` on a Windows host, so POSIX resolution is unreachable there no matter what the platform value says. `getEnhancedPath` composes with both, so the macOS app-bundle and Linux AppImage expectations were comparing `\`-joined candidates against a `;`-delimited string.

## Approach

For the first group, expectations now derive the package parent, the binary name, and the delimiter from the host instead of spelling out one platform's answer. No production code changed — the resolver was right in every case.

For the second group, the tests are skipped on Windows through a `describeOnPosix` binding:

```ts
const describeOnPosix = process.platform === 'win32' ? describe.skip : describe;
```

Two notes on that choice. It is `describe.skip` rather than the `if (isWindows) return;` idiom already present elsewhere in these files, because an early return reports the test as **passed** — which is exactly the kind of quiet false signal the `windows-unit` job exists to remove. Skipped tests show as skipped. And the coverage is not lost: the Linux `validate` job runs all of them on every PR, which is the platform they describe.

Rewriting them to pass on Windows was considered and rejected. The only way to do it would be to normalize the expected macOS and Linux paths through the host's `path`, at which point the assertion is about neither platform.

## Architecture

- [x] N/A — tests only, no `src/` change.
- [x] N/A — no shared contract touched.
- [x] N/A — no provider behavior changed.

## Security And Privacy

- [x] N/A — no provider, session, or model data handled.
- [x] N/A — no permission or authorization behavior changes.
- [x] Filesystem, process, credential, MCP, and external-path boundaries are unchanged.
- [x] Fixtures contain no secrets or real vault contents.

Security notes: no security boundary change. Worth flagging one thing a reviewer should push back on if they disagree: skipping the POSIX CLI-discovery tests on Windows means a Windows-only regression in that code path would not be caught by the Windows job. That is acceptable because the code path is explicitly `if (!isWindows)`-gated, and the Windows branch has its own coverage in the same file — but it is a deliberate reduction in where those assertions run, not a no-op.

## Verification

Automated commands run (macOS):

```text
npm run test -- --selectProjects unit --testPathPatterns "utils/env|utils/utils|utils/path"
npm run typecheck
npm run lint
```

276 tests pass across the three touched suites; typecheck and lint clean.

Manual verification: Not run — test-only change.

The `windows-unit` job on this PR is the real check. Expected: **42 → 31**, with five failures repaired and six moving to skipped. No suite should enter the failure list, and the Linux job should be unchanged since `describeOnPosix` resolves to plain `describe` there.

## Generated Artifacts

- [x] N/A — no source change.
- [x] N/A — no dependency changes.
- [x] Generated root bundles, `dist/grimoire`, and local-only artifacts are not included.

## Review Checklist

- [x] The PR is focused on one coherent problem (host-platform assumptions in the shared utility fixtures).
- [x] N/A — no behavior change; these fixtures are the regression tests.
- [x] N/A — no protocol payloads or error codes involved.
- [x] Documentation and user-facing copy are in English.
- [x] The description separates what was verified locally from what only the Windows job can confirm.
