### PR TITLE
build: pin checkout line endings to LF so Windows builds reproduce the release bundle

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+# Git for Windows ships core.autocrlf=true in its system config, so a default
+# Windows clone materializes every tracked text file with CRLF while the index
+# stores LF. Multi-line template literals in src/ carry those bytes straight
+# into the minified bundle, so `npm run build:release` on Windows produces a
+# main.js that differs from the release CI builds on ubuntu-latest even with an
+# identical commit and toolchain. Pin the working tree to LF for everyone.
+* text=auto eol=lf


### PR DESCRIPTION
## Problem

`npm run build:release` on Windows does not reproduce the published release bundle, and the difference is in shipped content rather than in formatting.

Building tag `1.1.9` (`c001881`) from a default Windows clone with the CI-pinned toolchain (Node 22.22.2, npm 12.0.2) yields:

| Bundle | SHA-256 |
|---|---|
| `dist/grimoire/main.js`, default Windows clone | `7383218053af0214866e0ff18fb968568c3601a75ebcc6dd369c86f9749d7eb5` |
| `main.js` published as the 1.1.9 release asset | `36e43950b4d4a9bb7204284b018f149036e85367f2382c1a5cf4ff856d2b747f` |

Same commit, same Node, same npm, different bytes — and the Windows bundle is 1 524 bytes larger.

This blocks the check `CONTRIBUTING.md` asks for ("Verify the release bundle from source before tagging") for anyone on Windows, and it makes "is this asset really built from this tag?" unanswerable for a Windows reviewer.

No issue number. Found while verifying my own build after #74.

## Root Cause

Two independent facts combine.

**1. A default Windows clone has a CRLF working tree.** Git for Windows ships `core.autocrlf=true` in its *system* config, so this is the out-of-the-box state for essentially every Windows contributor, not a personal setting:

```
$ git config --show-origin --show-scope --get-all core.autocrlf
system  file:C:/Program Files/Git/etc/gitconfig       true
$ git --version
git version 2.50.0.windows.1
```

The index is already clean — LF everywhere — but the checkout is not:

```
$ git ls-files --eol | awk '{print $1}' | sort | uniq -c    # index
   1110 i/lf
      4 i/-text
$ git ls-files --eol | awk '{print $2}' | sort | uniq -c    # working tree, fresh clone on Windows
   1110 w/crlf
      4 w/-text
```

**2. Exactly one working-tree file reaches the bundle as raw text.** Everything else in the repository passes through a parser that normalizes line terminators: the ECMAScript spec normalizes CRLF inside template literals (verified separately — minifying a CRLF source and its LF twin through this repo's own esbuild produced byte-identical output), and the CSS pipeline normalizes as well. The exception is `esbuild.config.mjs`:

```js
const changelogMarkdown = readFileSync('CHANGELOG.md', 'utf-8');   // line 33
…
  define: {
    GRIMOIRE_CHANGELOG_MARKDOWN: JSON.stringify(changelogMarkdown), // line 192
  },
```

`define` substitutes the literal at each surviving use site in `src/app/changelog/source.ts`, and esbuild emits the long multi-line string as a template literal. A raw LF inside a template literal costs one byte; a CR cannot stay raw there (the spec would normalize it away), so esbuild escapes each one as `\r` — two bytes, and a character that is now genuinely part of the shipped string.

The arithmetic closes exactly:

- `CHANGELOG.md` at 1.1.9 has 381 line endings;
- after minification two copies of the literal survive;
- escaped `\r` sequences in the bundle: **122** (LF build) → **884** (CRLF build) = **+762** = 2 × 381;
- bundle size delta: 762 × 2 bytes = **1 524** — the exact observed difference.

First differing byte (offset 3 476 731) is inside that literal:

```
LF build:    …function Hzt(){try{if(`# Changelog
             
             ## 1.1.9 - 2026-08-22
CRLF build:  …function Hzt(){try{if(`# Changelog\r
             \r
             ## 1.1.9 - 2026-08-22\r
```

So `getEmbeddedChangelogMarkdown()` returns markdown containing 381 CR characters when the plugin is built on Windows. I did not test whether the changelog renderer visibly misbehaves on that input — the point here is that the shipped string differs, not only the file hash.

## Approach

Add a `.gitattributes` that pins the working tree to LF for every tracked text file:

```
* text=auto eol=lf
```

`text=auto` leaves Git's own binary detection in charge, so the four PNGs under `assets/readme/` (already `i/-text`) are untouched. The repository contains no `.bat`, `.cmd`, `.ps1`, or `.sh` files that would want CRLF (`git ls-files` matches none), so no per-glob exceptions are needed.

**The change is content-neutral.** Every tracked text blob is already LF in the index, so adding the file rewrites nothing:

```
$ git add --renormalize .
$ git diff --cached --numstat | wc -l
0
```

**Alternative considered and rejected: normalize at the embed point** (`readFileSync('CHANGELOG.md', 'utf-8').replace(/\r\n/g, '\n')`). It is a smaller diff and it does fix this symptom. I did not propose it because it fixes one instance of a class: any future `readFileSync` of a working-tree file re-opens the same trap silently, and the Windows fixture work in #74/#76/#78 has been steadily uncovering neighbouring path- and separator-shaped assumptions. Pinning the checkout removes the input, not the one symptom. If you prefer the narrow fix, I am happy to swap it — the evidence above applies either way.

**Migration note for existing Windows clones.** `.gitattributes` governs future checkouts; a clone that already materialized CRLF keeps it until the tree is re-read once:

```
git rm --cached -r .
git reset --hard
```

Worth a line in `CONTRIBUTING.md` if you want it; I left the docs alone to keep this PR to one coherent change.

## Architecture

- [x] Provider-native behavior remains inside `src/providers/<provider>/`.
- [x] Shared code is provider-neutral and used by at least two providers, or the PR explains why it belongs there.
- [x] I checked sibling providers when changing a shared ACP or provider contract.

Architecture notes:

No source, provider, or shared contract is touched. This is repository-level checkout policy — the owning layer is the build/VCS configuration, and `.gitattributes` at the root is where Git looks for it.

## Security And Privacy

- [x] Provider/session/model data is treated as untrusted input.
- [x] Permission changes cannot silently widen persistent authorization.
- [x] Filesystem, process, credential, MCP, and external-path boundaries are unchanged or explained below.
- [x] Logs and fixtures contain no secrets, prompts, note contents, local paths, or unsanitized provider payloads.

Security notes:

No security boundary change. The change is a checkout-time normalization of line endings for text files. It has one adjacent benefit worth naming: a reproducible bundle is what lets a reviewer confirm that a published release asset corresponds to the reviewed source, which today cannot be done from Windows.

## Verification

Automated commands run:

```text
# Fresh clone of 1.1.9 (c001881), default Windows settings, Node 22.22.2 / npm 12.0.2
npm ci
npm run build:release            # -> main.js sha256 73832180…  (does not match the release asset)

printf '* text=auto eol=lf\n' > .gitattributes
git add --renormalize .          # 0 files staged: content-neutral
git rm --cached -r . && git reset --hard
git ls-files --eol               # 1110 w/lf, 4 w/-text

npm run build:release            # -> main.js sha256 36e43950…  (byte-identical to the 1.1.9 release asset)
```

Both builds ran `prebuild:release` (`lint`, `review:source`, `review:css`, `review:deps`) and the bundle self-check ("Verified release bundle loads from isolated install dir" / "opens grimoire-view") without errors.

Reverting the experiment (removing `.gitattributes`, re-checking out to CRLF, rebuilding) reproduced `73832180…` again, so the result is not order-dependent.

Manual verification: Windows 11, Obsidian desktop. The 1.1.9 release asset currently installed in my vault hashes to `36e43950…`, which is what the LF build reproduces. No Obsidian workflow change is expected from this PR and none was exercised.

## Generated Artifacts

- [x] `npm run build:release` recreates `dist/grimoire/main.js`, `manifest.json`, and `styles.css` from the submitted source.
- [x] `package-lock.json` matches `package.json` when dependencies change.
- [x] Generated root bundles, `dist/grimoire`, and local-only artifacts are not included.

## Review Checklist

- [x] The PR is focused on one coherent problem.
- [ ] Behavior changes have focused regression tests. — see the note below; no unit-testable surface.
- [ ] Protocol tests use real structured payloads and error codes. — not applicable, no protocol code is touched.
- [x] Documentation and user-facing copy are in English.
- [x] The PR description accurately distinguishes automated tests from manual verification.

On the regression-test box: there is no unit-testable surface here — the defect lives in what Git materializes before any code runs, so the guard is the byte comparison above rather than a test file. If you would like it enforced, the natural place is the `windows-unit` job from #75: build the bundle on Windows and on Linux from the same commit and compare hashes. I did not add that here because it belongs to the CI conversation you are already running, not to this one-line policy change.
