### PR TITLE
test(antigravity): clear the last three Windows failures in the provider suite

### DIFF
--- a/tests/helpers/antigravityLaunchShape.ts
+++ b/tests/helpers/antigravityLaunchShape.ts
@@ -1,0 +1,84 @@
+/**
+ * Launch-shape normalization for the Antigravity fixtures.
+ *
+ * `buildAntigravityProcessLaunch` hands the CLI to the OS in three different
+ * shapes (POSIX login shell, Windows `cmd.exe` wrapper, direct exec), so a
+ * fixture that reads the spawn arguments literally asserts the host's
+ * process-launch convention instead of the behavior under test. Normalizing
+ * back to the agy arguments keeps the assertions platform-independent.
+ *
+ * Shared between the Antigravity suites; `launch-shape normalization helpers`
+ * in `AntigravityChatRuntime.test.ts` pins both functions against the real
+ * producer (`buildWindowsShellCommandLine` / `buildAntigravityProcessLaunch`).
+ */
+
+/**
+ * Invert the quoting `buildWindowsShellCommandLine` applies, so assertions can
+ * read the agy flags out of a `cmd.exe /d /s /c "<line>"` launch the same way
+ * they read them out of a POSIX one. Kept lossless for every argument shape
+ * the launch builder can emit.
+ */
+export function parseWindowsShellCommandLine(line: string): string[] {
+  const parsed: string[] = [];
+  let current = '';
+  let quoted = false;
+  let started = false;
+  let index = 0;
+  while (index < line.length) {
+    const char = line[index];
+    if (char === '\\') {
+      let backslashes = 0;
+      while (line[index] === '\\') {
+        backslashes += 1;
+        index += 1;
+      }
+      // quoteWindowsArgument doubles the run that precedes a quote or the
+      // closing quote; every other run reaches the child verbatim.
+      const wasDoubled = line[index] === '"';
+      current += '\\'.repeat(wasDoubled ? Math.floor(backslashes / 2) : backslashes);
+      started = true;
+      continue;
+    }
+    index += 1;
+    if (char === '"') {
+      if (quoted && line[index] === '"') {
+        current += '"';
+        index += 1;
+      } else {
+        quoted = !quoted;
+      }
+      started = true;
+      continue;
+    }
+    if (char === ' ' && !quoted) {
+      if (started) {
+        parsed.push(current);
+        current = '';
+        started = false;
+      }
+      continue;
+    }
+    current += char;
+    started = true;
+  }
+  if (started) {
+    parsed.push(current);
+  }
+  return parsed;
+}
+
+/**
+ * Normalizes every launch shape `buildAntigravityProcessLaunch` can produce
+ * (POSIX login shell, Windows cmd.exe wrapper, direct exec) back to the agy
+ * arguments themselves, so the fixtures assert behavior instead of the host
+ * platform's process-launch convention.
+ */
+export function toAgyArgs(spawnArgs: string[]): string[] {
+  if (spawnArgs[0] === '-lc' && spawnArgs[1] === 'exec "$0" "$@"') {
+    return spawnArgs.slice(3);
+  }
+  if (spawnArgs[0] === '/d' && spawnArgs[1] === '/s' && spawnArgs[2] === '/c') {
+    return parseWindowsShellCommandLine(spawnArgs[3] ?? '').slice(1);
+  }
+  return spawnArgs;
+}

--- a/tests/unit/providers/antigravity/AntigravityChatRuntime.test.ts
+++ b/tests/unit/providers/antigravity/AntigravityChatRuntime.test.ts
@@ -7,6 +7,8 @@ import os from 'node:os';
 import path from 'node:path';
 import { PassThrough } from 'node:stream';
 
+import { parseWindowsShellCommandLine, toAgyArgs } from '@test/helpers/antigravityLaunchShape';
+
 import { ProviderWorkspaceRegistry } from '@/core/providers/ProviderWorkspaceRegistry';
 import type { StreamChunk } from '@/core/types';
 import { setLocale } from '@/i18n/i18n';
@@ -118,78 +120,6 @@ function writeStreamJsonResult(
   writeStreamJsonFrame(proc, { event: 'result', result });
 }
 
-/**
- * Invert the quoting `buildWindowsShellCommandLine` applies, so assertions can
- * read the agy flags out of a `cmd.exe /d /s /c "<line>"` launch the same way
- * they read them out of a POSIX one. Kept lossless for every argument shape
- * the launch builder can emit; `launch-shape normalization helpers` pins that
- * against the producer.
- */
-function parseWindowsShellCommandLine(line: string): string[] {
-  const parsed: string[] = [];
-  let current = '';
-  let quoted = false;
-  let started = false;
-  let index = 0;
-  while (index < line.length) {
-    const char = line[index];
-    if (char === '\\') {
-      let backslashes = 0;
-      while (line[index] === '\\') {
-        backslashes += 1;
-        index += 1;
-      }
-      // quoteWindowsArgument doubles the run that precedes a quote or the
-      // closing quote; every other run reaches the child verbatim.
-      const wasDoubled = line[index] === '"';
-      current += '\\'.repeat(wasDoubled ? Math.floor(backslashes / 2) : backslashes);
-      started = true;
-      continue;
-    }
-    index += 1;
-    if (char === '"') {
-      if (quoted && line[index] === '"') {
-        current += '"';
-        index += 1;
-      } else {
-        quoted = !quoted;
-      }
-      started = true;
-      continue;
-    }
-    if (char === ' ' && !quoted) {
-      if (started) {
-        parsed.push(current);
-        current = '';
-        started = false;
-      }
-      continue;
-    }
-    current += char;
-    started = true;
-  }
-  if (started) {
-    parsed.push(current);
-  }
-  return parsed;
-}
-
-/**
- * Normalizes every launch shape `buildAntigravityProcessLaunch` can produce
- * (POSIX login shell, Windows cmd.exe wrapper, direct exec) back to the agy
- * arguments themselves, so the fixtures assert behavior instead of the host
- * platform's process-launch convention.
- */
-function toAgyArgs(spawnArgs: string[]): string[] {
-  if (spawnArgs[0] === '-lc' && spawnArgs[1] === 'exec "$0" "$@"') {
-    return spawnArgs.slice(3);
-  }
-  if (spawnArgs[0] === '/d' && spawnArgs[1] === '/s' && spawnArgs[2] === '/c') {
-    return parseWindowsShellCommandLine(spawnArgs[3] ?? '').slice(1);
-  }
-  return spawnArgs;
-}
-
 function isHelpProbeArgs(spawnArgs: string[]): boolean {
   return toAgyArgs(spawnArgs).includes('--help');
 }
@@ -209,6 +139,25 @@ function getPrintLogFilePath(): string {
   const [, args] = mockedSpawn.mock.calls[mockedSpawn.mock.calls.length - 1] as [string, string[]];
   const agyArgs = toAgyArgs(args);
   return agyArgs[agyArgs.indexOf('--log-file') + 1];
+}
+
+/**
+ * `runPrint` resolves the turn from inside its `try` and unlinks the agy log in
+ * the `finally` that follows, so cleanup is still in flight when the awaited
+ * promise settles. The number of hops between the two is not fixed - the
+ * `fs.promises` call lands on the threadpool - so a single `setImmediate` is an
+ * arbitrary barrier that passes or fails with the scheduling of whatever else
+ * shares the worker. Wait for the condition instead of for a tick count.
+ */
+async function waitForRemovedFile(filePath: string): Promise<void> {
+  for (let attempt = 0; attempt < 1_000; attempt += 1) {
+    const exists = await fs.access(filePath).then(() => true, () => false);
+    if (!exists) {
+      return;
+    }
+    await new Promise((resolve) => setImmediate(resolve));
+  }
+  throw new Error(`Timed out waiting for ${filePath} to be removed`);
 }
 
 // FIFOs exist on POSIX only; the drain-race test parks transcript recovery
@@ -1296,8 +1245,7 @@ describe('AntigravityChatRuntime', () => {
 
       // The turn produced an answer, so its log file is removed.
       jest.useRealTimers();
-      await new Promise((resolve) => setImmediate(resolve));
-      await expect(fs.access(logFilePath)).rejects.toThrow();
+      await waitForRemovedFile(logFilePath);
       logFilePath = '';
     } finally {
       jest.useRealTimers();
@@ -1454,8 +1402,7 @@ describe('AntigravityChatRuntime', () => {
       succeedingProc.stdout.write('Hi\n');
       emitProcessExit(succeedingProc, 0, null);
       await expect(succeedingResult).resolves.toBe('Hi\n');
-      await new Promise((resolve) => setImmediate(resolve));
-      await expect(fs.access(succeedingLogPath)).rejects.toThrow();
+      await waitForRemovedFile(succeedingLogPath);
     } finally {
       await fs.rm(failingLogPath, { force: true });
       await fs.rm(succeedingLogPath, { force: true });

--- a/tests/unit/providers/antigravity/AntigravityModelDiscovery.test.ts
+++ b/tests/unit/providers/antigravity/AntigravityModelDiscovery.test.ts
@@ -5,6 +5,8 @@ import os from 'node:os';
 import path from 'node:path';
 import { PassThrough } from 'node:stream';
 
+import { toAgyArgs } from '@test/helpers/antigravityLaunchShape';
+
 import {
   discoverAntigravityModels,
   parseAntigravityModels,
@@ -47,10 +49,7 @@ function createMockChildProcess(): any {
 
 function getSpawnedAgyArgs(): string[] {
   const [, args] = mockedSpawn.mock.calls[0] as [string, string[]];
-  if (args[0] === '-lc' && args[1] === 'exec "$0" "$@"') {
-    return args.slice(3);
-  }
-  return args;
+  return toAgyArgs(args);
 }
 
 describe('AntigravityModelDiscovery', () => {
@@ -85,16 +84,19 @@ describe('AntigravityModelDiscovery', () => {
 
     try {
       const resultPromise = discoverAntigravityModels(plugin);
-      const spawnArgs = mockedSpawn.mock.calls[0][1] as string[];
+      const spawnArgs = getSpawnedAgyArgs();
       const logFileArgIndex = spawnArgs.indexOf('--log-file');
-      const logFilePath = logFileArgIndex >= 0 ? spawnArgs[logFileArgIndex + 1] : '';
-      if (logFilePath) {
-        await fs.mkdir(appDataDir, { recursive: true });
-        await fs.writeFile(logFilePath, `I0620 common.go:156] CLI app data directory: ${appDataDir}`);
-        await fs.writeFile(path.join(appDataDir, 'settings.json'), JSON.stringify({
-          model: 'Claude 4.5 Sonnet',
-        }));
-      }
+      // Without the log file the recovery falls back to the real Antigravity
+      // app-data directory of whoever runs the suite, so a missing path has to
+      // fail here rather than silently turn this into a test of the host's own
+      // settings.json.
+      expect(logFileArgIndex).toBeGreaterThanOrEqual(0);
+      const logFilePath = spawnArgs[logFileArgIndex + 1];
+      await fs.mkdir(appDataDir, { recursive: true });
+      await fs.writeFile(logFilePath, `I0620 common.go:156] CLI app data directory: ${appDataDir}`);
+      await fs.writeFile(path.join(appDataDir, 'settings.json'), JSON.stringify({
+        model: 'Claude 4.5 Sonnet',
+      }));
       proc.emit('exit', 0, null);
 
       await expect(resultPromise).resolves.toEqual([
@@ -108,8 +110,6 @@ describe('AntigravityModelDiscovery', () => {
         { label: 'Claude Opus 4.6 (Thinking)', rawId: 'Claude Opus 4.6 (Thinking)' },
         { label: 'GPT-OSS 120B (Medium)', rawId: 'GPT-OSS 120B (Medium)' },
       ]);
-      expect(logFileArgIndex).toBeGreaterThanOrEqual(0);
-      expect(logFilePath).toBeTruthy();
       expect(getSpawnedAgyArgs()).toEqual(expect.arrayContaining([
         '--log-file',
         logFilePath,


### PR DESCRIPTION
## Problem

The `windows-unit` job from #75 still reports three failures under `tests/unit/providers/antigravity` after #74, #76 and #78. This is the next slice, and it finishes the directory: 3 failures → 0.

None of the three is a defect in the code under test. All three are fixtures asserting something other than their subject, which is the same shape of problem #76 described ("a fixture that measured something other than its subject", "a mock that could not match").

No issue number — the triage list lives in #75's description and in the `windows-unit-log` artifact.

## Root Cause

**Two of them are one race.** `runPrint` resolves the turn from inside its `try`, and unlinks the agy log in the `finally` that follows:

```ts
succeeded = Boolean(directOutput || transcriptOutput);
resolve(directOutput || transcriptOutput);
return;
} finally {
  if (succeeded || cancelledByUser) {
    await fs.unlink(printLogFilePath).catch(() => undefined);
  }
```

So cleanup is still in flight when the promise the fixture awaits settles. Both `preserves the agy log file when the run fails and removes it on success` and `resolves with an already-delivered answer when the CLI hangs after it` then waited exactly one tick before asserting the file was gone:

```ts
await expect(succeedingResult).resolves.toBe('Hi\n');
await new Promise((resolve) => setImmediate(resolve));
await expect(fs.access(succeedingLogPath)).rejects.toThrow();
```

The number of hops between `resolve` and the completed `fs.unlink` is not fixed — the `fs.promises` call lands on the threadpool — so one `setImmediate` is an arbitrary barrier. Instrumenting the wait made this explicit: the unlink **always** happens, after 1 to 4 extra ticks depending on how many suites share the worker. Concretely, on `main` at `c11b9bb`:

| Invocation | Result |
|---|---|
| whole `providers/antigravity` directory (9 suites) | ticks needed ≤ 1 → passes |
| `AntigravityChatRuntime.test.ts` alone | 3 ticks needed → fails |
| the single test via `-t` | 3 ticks needed → fails |

A test whose outcome depends on how many neighbours are running is worth fixing even where it currently passes; it is also why this one looked like a regression from unrelated work.

**The third is a launch-shape assumption**, the kind #74 removed elsewhere. `recovers models from Antigravity settings when agy models stdout is empty` read the flag out of the raw spawn arguments:

```ts
const spawnArgs = mockedSpawn.mock.calls[0][1] as string[];
const logFileArgIndex = spawnArgs.indexOf('--log-file');
const logFilePath = logFileArgIndex >= 0 ? spawnArgs[logFileArgIndex + 1] : '';
if (logFilePath) { /* write the log and settings.json the test depends on */ }
```

On Windows the arguments are nested inside the `cmd.exe /d /s /c "<line>"` wrapper, so `indexOf('--log-file')` returns `-1`, the guard is false and the fixture writes neither file. `recoverAntigravityModelsFromSettings` then finds no log to parse, falls back to `getDefaultAntigravityAppDataDir`, and reads the **real** `~/.gemini/antigravity-cli/settings.json` of whoever is running the suite.

That is the part worth flagging beyond this PR: on a machine that actually uses Antigravity, the fixture silently became a test of the developer's own configuration. The failure I saw reported a model-ordering diff — expected `Claude 4.5 Sonnet` first, received `Gemini 3.5 Flash (Low)` first — because `Gemini 3.5 Flash (Low)` is what my local `settings.json` selects, prepended by the recovery and then deduplicated out of its usual position in the fallback catalogue. Nothing in that diff points at process launch. The same fixture would also produce a *different* wrong answer on a different machine, and would pass by luck on a machine with no Antigravity installed at all.

## Approach

1. **`waitForRemovedFile`** replaces the fixed tick in both places. It polls the condition and fails with a named timeout instead of asserting on a scheduling assumption.

2. **`toAgyArgs` in the model-discovery fixture**, plus the guard hoisted to *before* the recovery runs:

```ts
const spawnArgs = getSpawnedAgyArgs();
const logFileArgIndex = spawnArgs.indexOf('--log-file');
// Without the log file the recovery falls back to the real Antigravity
// app-data directory of whoever runs the suite, so a missing path has to
// fail here rather than silently turn this into a test of the host's own
// settings.json.
expect(logFileArgIndex).toBeGreaterThanOrEqual(0);
```

The two assertions that checked the same thing *after* the main expectation are removed as redundant now that the guard runs first — that is the only deletion in this PR that is not a replacement.

3. **`toAgyArgs` and `parseWindowsShellCommandLine` move to `tests/helpers/antigravityLaunchShape.ts`** instead of being copied into a second suite. `AntigravityModelDiscovery.test.ts` had its own POSIX-only version of the same idea; a second copy of ~40 lines of quoting logic is exactly what drifts. `launch-shape normalization helpers` keeps pinning both functions against the real producer from the new location, so the round-trip coverage you added in `586059a` is unchanged and now protects both suites. The directory follows the existing `tests/helpers/` convention (`acpLaunchMocks.ts`, `sdkMessages.ts`).

**Not changed on purpose.** The `finally`-after-`resolve` ordering in `runPrint` is fine as production behavior — the turn should not wait on cleanup — so this PR adapts the fixtures rather than serializing the runtime. And the "log file is preserved on failure" assertion still uses a single tick: asserting that a file *is still there* cannot be made condition-based in the same way, and it is not order-dependent, so I left it alone.

## Architecture

- [x] Provider-native behavior remains inside `src/providers/<provider>/`.
- [x] Shared code is provider-neutral and used by at least two providers, or the PR explains why it belongs there.
- [x] I checked sibling providers when changing a shared ACP or provider contract.

Architecture notes:

Test-only. No `src/` file is touched and no contract changes. The new helper is Antigravity-specific by name and content and lives under `tests/helpers/`, alongside the existing per-area helpers; it is shared between the two Antigravity suites rather than being provider-neutral, which is why it is not generalized further.

## Security And Privacy

- [x] Provider/session/model data is treated as untrusted input.
- [x] Permission changes cannot silently widen persistent authorization.
- [x] Filesystem, process, credential, MCP, and external-path boundaries are unchanged or explained below.
- [x] Logs and fixtures contain no secrets, prompts, note contents, local paths, or unsanitized provider payloads.

Security notes:

No security boundary change, but one privacy-adjacent improvement: the model-discovery fixture could previously read the host's real `~/.gemini/antigravity-cli/settings.json`. It only ever compared a model label, so nothing sensitive was surfaced, but a fixture reaching into the developer's actual CLI configuration is a boundary worth closing, and the hoisted guard closes it.

## Verification

Automated commands run (Windows 11, Node 22.22.2, npm 12.0.2 — the CI-pinned versions):

```text
npm run typecheck                                            # clean
npm run lint                                                 # clean
npm run test -- --selectProjects unit --testPathPatterns "providers/antigravity"
#   before: 3 failed, 144 passed, 147 total
#   after:  147 passed, 147 total   (3 consecutive runs)

# the invocations that used to be order-dependent, now all green:
npm run test -- --selectProjects unit --testPathPatterns "providers/antigravity/AntigravityChatRuntime"
npm run test -- --selectProjects unit --testPathPatterns "providers/antigravity/AntigravityChatRuntime" -t "preserves the agy log file"

npm run test -- --selectProjects unit
#   main @ c11b9bb: 39 failed, 8 skipped, 7055 passed, 7102 total  (25 failing suites)
#   this branch:    36 failed, 8 skipped, 7058 passed, 7102 total  (23 failing suites)
```

The failing-test sets were diffed, not just counted: the three names above leave the set and **no new name enters it**.

Manual verification: not run. There is no user-facing behavior in this change.

## Generated Artifacts

- [x] `npm run build:release` recreates `dist/grimoire/main.js`, `manifest.json`, and `styles.css` from the submitted source.
- [x] `package-lock.json` matches `package.json` when dependencies change.
- [x] Generated root bundles, `dist/grimoire`, and local-only artifacts are not included.

## Review Checklist

- [x] The PR is focused on one coherent problem.
- [x] Behavior changes have focused regression tests.
- [x] Protocol tests use real structured payloads and error codes.
- [x] Documentation and user-facing copy are in English.
- [x] The PR description accurately distinguishes automated tests from manual verification.
