### PR TITLE
fix(providers): stop re-running model discovery on every picker open and plugin load

### DIFF
--- a/src/providers/claude/app/ClaudeModelCatalog.ts
+++ b/src/providers/claude/app/ClaudeModelCatalog.ts
@@ -105,6 +105,27 @@ export function createClaudeModelCatalog(plugin: GrimoirePlugin): ProviderModelC
   const refreshAttemptsByKey = new Map<string, number>();
   const refreshesByKey = new Map<string, Promise<boolean>>();
 
+  // The attempt log only lives in memory, so every plugin load would otherwise
+  // probe again on the first picker that is built - and probing starts a full
+  // Claude Code session, which bills against the plan window.
+  //
+  // Only an already SDK-sourced catalog is seeded. A persisted `api` catalog
+  // (or a partial one) still gets its single per-load probe, because that probe
+  // exists to upgrade the cheap API listing to the authenticated SDK list.
+  const initialSettings = getClaudeProviderSettings(plugin.settings ?? {});
+  if (
+    initialSettings.discoveredModels.length > 0
+    && initialSettings.discoveredModels.every(model => model.source === 'sdk')
+  ) {
+    refreshAttemptsByKey.set(
+      buildClaudeModelCatalogCacheKey(
+        initialSettings,
+        plugin.getResolvedProviderCliPath?.('claude') ?? '',
+      ),
+      Date.now(),
+    );
+  }
+
   return {
     isAvailable(settings) {
       return getClaudeProviderSettings(settings).enabled;

--- a/src/providers/gemini/app/GeminiWorkspaceServices.ts
+++ b/src/providers/gemini/app/GeminiWorkspaceServices.ts
@@ -1,5 +1,6 @@
 import { McpServerManager } from '../../../core/mcp/McpServerManager';
 import type { ProviderCommandCatalog } from '../../../core/providers/commands/ProviderCommandCatalog';
+import { ProviderModelCatalogRefreshCache } from '../../../core/providers/ProviderModelCatalogRefreshCache';
 import { ProviderWorkspaceRegistry } from '../../../core/providers/ProviderWorkspaceRegistry';
 import type {
   ProviderCliResolver,
@@ -38,21 +39,67 @@ const geminiTabWarmupPolicy: ProviderTabWarmupPolicy = {
   },
 };
 
+const MODEL_CATALOG_CACHE_TTL_MS = 10 * 60 * 1000;
+
+function buildGeminiModelCatalogFingerprint(
+  plugin: GrimoirePlugin,
+  settings: ReturnType<typeof getGeminiProviderSettings>,
+): string {
+  return JSON.stringify({
+    cliPath: plugin.getResolvedProviderCliPath?.('gemini') ?? settings.cliPath,
+    cliPathsByHost: settings.cliPathsByHost,
+    environmentVariables: plugin.getActiveEnvironmentVariables?.('gemini')
+      ?? settings.environmentVariables,
+  });
+}
+
 function createGeminiModelCatalog(plugin: GrimoirePlugin): ProviderModelCatalog {
+  const initialSettings = getGeminiProviderSettings(plugin.settings ?? {});
+  const refreshCache = new ProviderModelCatalogRefreshCache(MODEL_CATALOG_CACHE_TTL_MS);
+  if (initialSettings.discoveredModels.length > 0) {
+    refreshCache.seed(buildGeminiModelCatalogFingerprint(plugin, initialSettings));
+  }
+
   return {
     isAvailable(settings) {
       return getGeminiProviderSettings(settings).enabled;
     },
     async refreshModels({ settings }) {
-      const before = JSON.stringify(getGeminiProviderSettings(settings).discoveredModels);
-      const runtime = new GeminiChatRuntime(plugin);
-      try {
-        const loaded = await runtime.ensureReady({ allowSessionCreation: true });
-        const after = JSON.stringify(getGeminiProviderSettings(settings).discoveredModels);
-        return loaded && before !== after;
-      } finally {
-        runtime.cleanup();
+      // Discovery boots the real CLI over ACP and creates a session, so it must
+      // not run again for every model dropdown that opens.
+      const currentSettings = getGeminiProviderSettings(settings);
+      const fingerprint = buildGeminiModelCatalogFingerprint(plugin, currentSettings);
+      const hasCachedModels = currentSettings.discoveredModels.length > 0;
+      if (refreshCache.isFresh(fingerprint, hasCachedModels)) {
+        plugin.recordDebugLog?.({
+          data: {
+            modelCount: currentSettings.discoveredModels.length,
+            providerId: 'gemini',
+            reason: 'cache_fresh',
+            ttlMs: MODEL_CATALOG_CACHE_TTL_MS,
+          },
+          event: 'modelCatalog.refresh.skipped',
+          level: 'debug',
+          scope: 'provider.gemini',
+        });
+        return false;
       }
+
+      return refreshCache.refresh({
+        fingerprint,
+        hasCachedModels,
+        load: async () => {
+          const before = JSON.stringify(getGeminiProviderSettings(settings).discoveredModels);
+          const runtime = new GeminiChatRuntime(plugin);
+          try {
+            const loaded = await runtime.ensureReady({ allowSessionCreation: true });
+            const after = JSON.stringify(getGeminiProviderSettings(settings).discoveredModels);
+            return loaded && before !== after;
+          } finally {
+            runtime.cleanup();
+          }
+        },
+      });
     },
   };
 }

--- a/src/providers/qwen/app/QwenWorkspaceServices.ts
+++ b/src/providers/qwen/app/QwenWorkspaceServices.ts
@@ -1,5 +1,6 @@
 import { McpServerManager } from '../../../core/mcp/McpServerManager';
 import type { ProviderCommandCatalog } from '../../../core/providers/commands/ProviderCommandCatalog';
+import { ProviderModelCatalogRefreshCache } from '../../../core/providers/ProviderModelCatalogRefreshCache';
 import { ProviderWorkspaceRegistry } from '../../../core/providers/ProviderWorkspaceRegistry';
 import type {
   ProviderCliResolver,
@@ -38,21 +39,67 @@ const qwenTabWarmupPolicy: ProviderTabWarmupPolicy = {
   },
 };
 
+const MODEL_CATALOG_CACHE_TTL_MS = 10 * 60 * 1000;
+
+function buildQwenModelCatalogFingerprint(
+  plugin: GrimoirePlugin,
+  settings: ReturnType<typeof getQwenProviderSettings>,
+): string {
+  return JSON.stringify({
+    cliPath: plugin.getResolvedProviderCliPath?.('qwen') ?? settings.cliPath,
+    cliPathsByHost: settings.cliPathsByHost,
+    environmentVariables: plugin.getActiveEnvironmentVariables?.('qwen')
+      ?? settings.environmentVariables,
+  });
+}
+
 function createQwenModelCatalog(plugin: GrimoirePlugin): ProviderModelCatalog {
+  const initialSettings = getQwenProviderSettings(plugin.settings ?? {});
+  const refreshCache = new ProviderModelCatalogRefreshCache(MODEL_CATALOG_CACHE_TTL_MS);
+  if (initialSettings.discoveredModels.length > 0) {
+    refreshCache.seed(buildQwenModelCatalogFingerprint(plugin, initialSettings));
+  }
+
   return {
     isAvailable(settings) {
       return getQwenProviderSettings(settings).enabled;
     },
     async refreshModels({ settings }) {
-      const before = JSON.stringify(getQwenProviderSettings(settings).discoveredModels);
-      const runtime = new QwenChatRuntime(plugin);
-      try {
-        const loaded = await runtime.ensureReady({ allowSessionCreation: true });
-        const after = JSON.stringify(getQwenProviderSettings(settings).discoveredModels);
-        return loaded && before !== after;
-      } finally {
-        runtime.cleanup();
+      // Discovery boots the real CLI over ACP and creates a session, so it must
+      // not run again for every model dropdown that opens.
+      const currentSettings = getQwenProviderSettings(settings);
+      const fingerprint = buildQwenModelCatalogFingerprint(plugin, currentSettings);
+      const hasCachedModels = currentSettings.discoveredModels.length > 0;
+      if (refreshCache.isFresh(fingerprint, hasCachedModels)) {
+        plugin.recordDebugLog?.({
+          data: {
+            modelCount: currentSettings.discoveredModels.length,
+            providerId: 'qwen',
+            reason: 'cache_fresh',
+            ttlMs: MODEL_CATALOG_CACHE_TTL_MS,
+          },
+          event: 'modelCatalog.refresh.skipped',
+          level: 'debug',
+          scope: 'provider.qwen',
+        });
+        return false;
       }
+
+      return refreshCache.refresh({
+        fingerprint,
+        hasCachedModels,
+        load: async () => {
+          const before = JSON.stringify(getQwenProviderSettings(settings).discoveredModels);
+          const runtime = new QwenChatRuntime(plugin);
+          try {
+            const loaded = await runtime.ensureReady({ allowSessionCreation: true });
+            const after = JSON.stringify(getQwenProviderSettings(settings).discoveredModels);
+            return loaded && before !== after;
+          } finally {
+            runtime.cleanup();
+          }
+        },
+      });
     },
   };
 }

--- a/tests/unit/providers/claude/app/ClaudeModelCatalog.test.ts
+++ b/tests/unit/providers/claude/app/ClaudeModelCatalog.test.ts
@@ -61,8 +61,42 @@ describe('ClaudeModelCatalog', () => {
     const catalog = createClaudeModelCatalog(plugin);
 
     await expect(catalog.refreshModels({ plugin, settings })).resolves.toBe(false);
+    expect(mockedProbe).toHaveBeenCalledTimes(1);
     expect(getClaudeProviderSettings(settings).discoveredModels).toEqual([
       { id: 'legacy', displayName: 'Legacy', source: 'api' },
     ]);
+  });
+
+  it('does not probe again after a reload when a catalog is already persisted', async () => {
+    const settings: Record<string, unknown> = {};
+    updateClaudeProviderSettings(settings, {
+      enabled: true,
+      discoveredModels: [{ id: 'opus', displayName: 'Opus', source: 'sdk' }],
+    });
+    mockedProbe.mockResolvedValue([{ id: 'opus', displayName: 'Opus', source: 'sdk' }]);
+    const plugin = createPlugin(settings);
+
+    // A fresh catalog stands in for a plugin reload: the in-memory attempt log
+    // starts empty, but the persisted models must still suppress the probe.
+    const catalog = createClaudeModelCatalog(plugin);
+    await expect(catalog.refreshModels({ plugin, settings })).resolves.toBe(false);
+
+    expect(mockedProbe).not.toHaveBeenCalled();
+  });
+
+  it('still probes after a reload when the resolved CLI path changed', async () => {
+    const settings: Record<string, unknown> = {};
+    updateClaudeProviderSettings(settings, {
+      enabled: true,
+      discoveredModels: [{ id: 'opus', displayName: 'Opus', source: 'sdk' }],
+    });
+    mockedProbe.mockResolvedValue([{ id: 'sonnet', displayName: 'Sonnet', source: 'sdk' }]);
+    const plugin = createPlugin(settings);
+    const catalog = createClaudeModelCatalog(plugin);
+    plugin.getResolvedProviderCliPath.mockReturnValue('/opt/claude');
+
+    await catalog.refreshModels({ plugin, settings });
+
+    expect(mockedProbe).toHaveBeenCalledTimes(1);
   });
 });

--- a/tests/unit/providers/gemini/GeminiWorkspaceServices.test.ts
+++ b/tests/unit/providers/gemini/GeminiWorkspaceServices.test.ts
@@ -1,10 +1,68 @@
 import { createGeminiWorkspaceServices } from '@/providers/gemini/app/GeminiWorkspaceServices';
+import { GeminiChatRuntime } from '@/providers/gemini/runtime/GeminiChatRuntime';
 
 describe('createGeminiWorkspaceServices', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
   it('registers a usage provider for ACP cost updates', async () => {
     const services = await createGeminiWorkspaceServices({} as any, {} as any);
 
     expect(services.commandCatalog).toBeDefined();
     expect(services.usageProvider).toBeDefined();
+  });
+
+  it('skips discovery while a seeded catalog stays fresh so opening the model dropdown does not boot the CLI', async () => {
+    const ensureReady = jest.spyOn(GeminiChatRuntime.prototype, 'ensureReady');
+    const cleanup = jest.spyOn(GeminiChatRuntime.prototype, 'cleanup').mockImplementation(() => {});
+    const settings = {
+      providerConfigs: {
+        gemini: {
+          discoveredModels: [{ label: 'Gemini 2.5 Pro', rawId: 'gemini-2.5-pro' }],
+          enabled: true,
+        },
+      },
+    };
+    const plugin = { settings };
+
+    const services = await createGeminiWorkspaceServices(plugin as any, {} as any);
+    const changed = await services.modelCatalog?.refreshModels({
+      plugin: plugin as any,
+      settings: settings,
+    });
+
+    expect(changed).toBe(false);
+    expect(ensureReady).not.toHaveBeenCalled();
+    expect(cleanup).not.toHaveBeenCalled();
+  });
+
+  it('rediscovers models when the resolved CLI path changes', async () => {
+    const ensureReady = jest
+      .spyOn(GeminiChatRuntime.prototype, 'ensureReady')
+      .mockResolvedValue(true);
+    jest.spyOn(GeminiChatRuntime.prototype, 'cleanup').mockImplementation(() => {});
+    const settings = {
+      providerConfigs: {
+        gemini: {
+          discoveredModels: [{ label: 'Gemini 2.5 Pro', rawId: 'gemini-2.5-pro' }],
+          enabled: true,
+        },
+      },
+    };
+    let resolvedCliPath = '/usr/local/bin/gemini';
+    const plugin = {
+      getResolvedProviderCliPath: () => resolvedCliPath,
+      settings,
+    };
+
+    const services = await createGeminiWorkspaceServices(plugin as any, {} as any);
+    await services.modelCatalog?.refreshModels({ plugin: plugin as any, settings: settings });
+    expect(ensureReady).not.toHaveBeenCalled();
+
+    resolvedCliPath = '/opt/homebrew/bin/gemini';
+    await services.modelCatalog?.refreshModels({ plugin: plugin as any, settings: settings });
+
+    expect(ensureReady).toHaveBeenCalledTimes(1);
   });
 });

--- a/tests/unit/providers/qwen/QwenWorkspaceServices.test.ts
+++ b/tests/unit/providers/qwen/QwenWorkspaceServices.test.ts
@@ -1,10 +1,68 @@
 import { createQwenWorkspaceServices } from '@/providers/qwen/app/QwenWorkspaceServices';
+import { QwenChatRuntime } from '@/providers/qwen/runtime/QwenChatRuntime';
 
 describe('createQwenWorkspaceServices', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
   it('registers a usage provider for ACP cost updates', async () => {
     const services = await createQwenWorkspaceServices({} as any, {} as any);
 
     expect(services.commandCatalog).toBeDefined();
     expect(services.usageProvider).toBeDefined();
+  });
+
+  it('skips discovery while a seeded catalog stays fresh so opening the model dropdown does not boot the CLI', async () => {
+    const ensureReady = jest.spyOn(QwenChatRuntime.prototype, 'ensureReady');
+    const cleanup = jest.spyOn(QwenChatRuntime.prototype, 'cleanup').mockImplementation(() => {});
+    const settings = {
+      providerConfigs: {
+        qwen: {
+          discoveredModels: [{ label: 'Qwen3 Coder', rawId: 'qwen3-coder-plus' }],
+          enabled: true,
+        },
+      },
+    };
+    const plugin = { settings };
+
+    const services = await createQwenWorkspaceServices(plugin as any, {} as any);
+    const changed = await services.modelCatalog?.refreshModels({
+      plugin: plugin as any,
+      settings: settings,
+    });
+
+    expect(changed).toBe(false);
+    expect(ensureReady).not.toHaveBeenCalled();
+    expect(cleanup).not.toHaveBeenCalled();
+  });
+
+  it('rediscovers models when the resolved CLI path changes', async () => {
+    const ensureReady = jest
+      .spyOn(QwenChatRuntime.prototype, 'ensureReady')
+      .mockResolvedValue(true);
+    jest.spyOn(QwenChatRuntime.prototype, 'cleanup').mockImplementation(() => {});
+    const settings = {
+      providerConfigs: {
+        qwen: {
+          discoveredModels: [{ label: 'Qwen3 Coder', rawId: 'qwen3-coder-plus' }],
+          enabled: true,
+        },
+      },
+    };
+    let resolvedCliPath = '/usr/local/bin/qwen';
+    const plugin = {
+      getResolvedProviderCliPath: () => resolvedCliPath,
+      settings,
+    };
+
+    const services = await createQwenWorkspaceServices(plugin as any, {} as any);
+    await services.modelCatalog?.refreshModels({ plugin: plugin as any, settings: settings });
+    expect(ensureReady).not.toHaveBeenCalled();
+
+    resolvedCliPath = '/opt/homebrew/bin/qwen';
+    await services.modelCatalog?.refreshModels({ plugin: plugin as any, settings: settings });
+
+    expect(ensureReady).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
Related to #84.

## Problem

`refreshTabModelOptions` fans out to **every enabled provider**, and `ModelSelector`
asks for that refresh both in its constructor and in `setOpen()`. So each dropdown
open — and each tab restored at startup — triggers a catalog refresh for all
providers, not just the active one.

That is cheap for providers that cache their catalog. It is expensive for the ones
that do not:

**Gemini and Qwen had no cache at all.** Each `refreshModels` built a throwaway ACP
runtime and called `ensureReady({ allowSessionCreation: true })`, which boots the real
CLI, completes an ACP handshake and creates a session, then tears it down.

Measured on Windows 11 with the shipped 1.1.9 build, using the paths the resolver
actually returns:

| Call | shell | Time |
|---|---|---|
| `gemini.cmd --version` (npm shim → `node.exe` → CLI) | `true` | 2501 ms / 2503 ms |
| `grok.exe --version` | `false` | 385 ms cold / 102 ms warm |

`--version` is the cheapest possible invocation; discovery does strictly more than
that. The user-visible symptom is a dropdown that stalls for seconds on every open,
plus a console window that flashes on Windows because a `.cmd` launcher has to be
run through `cmd.exe`.

**Claude had a TTL but it never survived a reload.** Its ten-minute throttle lives in
an in-memory `Map` rebuilt on every plugin load, and nothing seeded it from the
already persisted catalog — unlike Codex (`refreshCache.seed`) and Antigravity
(`lastRefreshAt`). So the first picker built after each start probed again, and the
Claude probe starts a full Claude Code session through the Agent SDK. On a
subscription plan that is billed against the rolling plan window: a user reported a
repeatable spend at every Grimoire start with no Claude tab open, and their settings
already contained five `source: sdk` models, so the probe was pure waste. Filed as #84.

## Changes

**Gemini, Qwen** — reuse `ProviderModelCatalogRefreshCache` exactly as Codex,
OpenCode, MiMoCode and Kimi Code already do. Fingerprinted on the resolved CLI path,
`cliPathsByHost` and the effective environment, so a real toolchain change still
rediscovers immediately.

**Claude** — seed the attempt log from the persisted catalog, but **only when every
persisted model is already SDK-sourced**. A persisted `api` catalog still gets its
single per-load probe, because that probe exists to upgrade the cheap API listing to
the authenticated SDK list. `refreshes a persisted catalog on first picker open`
therefore passes unchanged.

The picker still calls `refreshModels` on open. The call now returns from cache
instead of spawning.

This closes the startup-repetition half of #84 (the probe no longer re-runs on every
plugin load). It does not close #84 itself: the probe still starts a real, billable
Claude Code session the first time a load needs to discover models at all, which is
the deeper concern that issue tracks. Not marking this as `Fixes #84` on purpose —
happy to pick that up as a follow-up once there's agreement on which of the three
directions listed in #84 to take.

## Deliberately not changed

Three further changes were considered and dropped, because each contradicts an
existing test that pins the current behaviour on purpose. Listing them so reviewers
do not have to rediscover the reasoning:

| Considered | Existing test it would break |
|---|---|
| Throttle the refresh inside `ModelSelector` | `ModelSelector › refreshes model options when opened while keeping fallback options visible` |
| Cache negative/empty results | `ProviderModelCatalogRefreshCache › does not mark failed refreshes as fresh` |
| Give Grok the same TTL cache | `createGrokWorkspaceServices › runs another live CLI refresh on the next picker open instead of skipping a recent catalog` |

If any of those contracts is open to revisiting, happy to follow up separately —
Grok in particular still shells out on every picker open, though at ~100–385 ms it is
an order of magnitude cheaper than Gemini was.

## Testing

`npm run test -- --selectProjects unit`, `npm run typecheck`, `npm run lint`.

A baseline was captured on a clean `main` **before** any edit: 38 failing tests across
24 suites, all pre-existing Windows environment failures of the kind `AGENTS.md`
warns about. After the change: **38 failing tests across 24 suites — identical** — with
six added passing tests. Intermediate versions of this branch that included the
dropped changes above produced 43 and 41 failures respectively, which is how they
were caught.

One existing test, `restores the prior catalog if saving the refreshed result fails`,
gained an explicit `expect(mockedProbe).toHaveBeenCalledTimes(1)`. Without it the test
would silently stop exercising the restore path under some seeding variants, and a
quietly vacuous test is worse than a failing one.
