### PR TITLE
fix(claude): name the todo tools so the plan panel keeps working

### DIFF
--- a/src/providers/claude/runtime/ClaudeQueryOptionsBuilder.ts
+++ b/src/providers/claude/runtime/ClaudeQueryOptionsBuilder.ts
@@ -23,6 +23,7 @@ import {
 import { createCustomSpawnFunction } from './customSpawn';
 import {
   DISABLED_BUILTIN_SUBAGENTS,
+  OPT_IN_BUILTIN_TOOLS,
   type PersistentQueryConfig,
   UNSUPPORTED_SDK_TOOLS,
 } from './types';
@@ -149,6 +150,7 @@ export class QueryOptionsBuilder {
       ...UNSUPPORTED_SDK_TOOLS,
       ...DISABLED_BUILTIN_SUBAGENTS,
     ];
+    options.allowedTools = [...OPT_IN_BUILTIN_TOOLS];
 
     QueryOptionsBuilder.applyPermissionMode(
       options,
@@ -201,6 +203,7 @@ export class QueryOptionsBuilder {
       ...UNSUPPORTED_SDK_TOOLS,
       ...DISABLED_BUILTIN_SUBAGENTS,
     ];
+    options.allowedTools = [...OPT_IN_BUILTIN_TOOLS];
 
     QueryOptionsBuilder.applyPermissionMode(
       options,

--- a/src/providers/claude/runtime/types.ts
+++ b/src/providers/claude/runtime/types.ts
@@ -5,6 +5,7 @@ import type {
 } from '@anthropic-ai/claude-agent-sdk';
 
 import type { ChatRuntimeEnsureReadyOptions } from '../../../core/runtime/types';
+import { TOOL_TODO_WRITE } from '../../../core/tools/toolNames';
 import type { ImageAttachment, StreamChunk } from '../../../core/types';
 import type { PermissionMode } from '../../../core/types/settings';
 import type { ClaudeModel, EffortLevel } from '../types/models';
@@ -123,6 +124,18 @@ export interface SessionState {
 }
 
 export const UNSUPPORTED_SDK_TOOLS = [] as const;
+
+/**
+ * Built-in tools the sdk stopped offering by default. Since 0.3.233 the todo
+ * tools are out of the default surface on Opus 4.8, Sonnet 5, Fable 5 and
+ * newer, so a run that does not name them never emits TodoWrite and the plan
+ * panel stays empty. Naming them in `allowedTools` keeps them available
+ * without replacing the rest of the default surface, which is what setting
+ * `tools` would do.
+ */
+export const OPT_IN_BUILTIN_TOOLS = [
+  TOOL_TODO_WRITE,
+] as const;
 
 /** Built-in subagents that don't apply to Obsidian context. */
 export const DISABLED_BUILTIN_SUBAGENTS = [

--- a/tests/unit/providers/claude/runtime/QueryOptionsBuilder.test.ts
+++ b/tests/unit/providers/claude/runtime/QueryOptionsBuilder.test.ts
@@ -330,6 +330,22 @@ describe('QueryOptionsBuilder', () => {
   });
 
   describe('buildPersistentQueryOptions', () => {
+    it('names the todo tools so the plan panel survives the sdk default surface', () => {
+      // The sdk dropped the todo tools from its default surface in 0.3.233, so
+      // a run that names nothing never emits TodoWrite. allowedTools re-adds
+      // them without replacing the rest of the default tools.
+      const ctx = {
+        ...createMockContext(),
+        abortController: new AbortController(),
+        hooks: {},
+      };
+
+      const options = QueryOptionsBuilder.buildPersistentQueryOptions(ctx);
+
+      expect(options.allowedTools).toContain('TodoWrite');
+      expect(options.tools).toBeUndefined();
+    });
+
     it('maps full_access to bypassPermissions', () => {
       const ctx = {
         ...createMockContext({
@@ -637,6 +653,39 @@ describe('QueryOptionsBuilder', () => {
   });
 
   describe('buildColdStartQueryOptions', () => {
+    it('names the todo tools on a cold start too', () => {
+      const ctx = {
+        ...createMockContext(),
+        abortController: new AbortController(),
+        hooks: {},
+        mcpMentions: new Set<string>(),
+        hasEditorContext: false,
+      };
+
+      const options = QueryOptionsBuilder.buildColdStartQueryOptions(ctx);
+
+      expect(options.allowedTools).toContain('TodoWrite');
+    });
+
+    it('keeps naming the todo tools when a slash command restricts the tool set', () => {
+      // A restricting command replaces the base surface through the tools
+      // option, so the todo opt-in has to stay on allowedTools rather than
+      // ride on the default surface.
+      const ctx = {
+        ...createMockContext(),
+        abortController: new AbortController(),
+        hooks: {},
+        mcpMentions: new Set<string>(),
+        hasEditorContext: false,
+        allowedTools: ['Read', 'Grep'],
+      };
+
+      const options = QueryOptionsBuilder.buildColdStartQueryOptions(ctx);
+
+      expect(options.tools).toEqual(expect.arrayContaining(['Read', 'Grep']));
+      expect(options.allowedTools).toContain('TodoWrite');
+    });
+
     it('includes MCP servers when available', () => {
       const mcpManager = createMockMcpManager();
       mcpManager.getActiveServers.mockReturnValue({


### PR DESCRIPTION
Follow-up to #83.

## Problem

Grimoire never declared a tool surface to the Claude Agent SDK. `options.tools` is set in exactly one place — [`ClaudeQueryOptionsBuilder.ts`](https://github.com/sandsaber/Grimoire/blob/main/src/providers/claude/runtime/ClaudeQueryOptionsBuilder.ts), and only when a slash command restricts the set:

```ts
if (ctx.allowedTools !== undefined && ctx.allowedTools.length > 0) {
  options.tools = ctx.allowedTools;
}
```

In ordinary chat that branch never runs, so the provider relied entirely on the SDK's default surface. `CLAUDE_CODE_ENABLE_TODO_TOOLS` appears nowhere in the repo either.

That was fine until 0.3.233, whose release notes say the todo/task tools are no longer in the default surface on Opus 4.8, Sonnet 5, Fable 5 and newer, and must be named in `tools` or referenced in `allowedTools` to be kept.

## Impact

Silent. The model simply never emits `TodoWrite`, so the plan panel in a Claude tab stops appearing — indistinguishable from a turn where the model chose not to plan. `ToolCallRenderer` and `StatusPanel` don't throw; they just never receive the call. Nothing fails, which is why CI is green on `main` today despite the regression.

Scope is Claude-only and model-dependent:

- Older Claude models keep the todo tools in the default surface, so only the newest models are affected.
- Other providers have their own source and are untouched — Codex synthesizes `TodoWrite` from `update_plan`, and the ACP providers map their own `todowrite`.

## Change

Name the tools through `allowedTools`, not `tools`.

That choice matters. Per the SDK typings, `tools` specifies the **base set** of built-in tools — `string[]`, `[]`, or the `claude_code` preset. Using it to add one tool would mean enumerating every default tool and re-auditing that list on every SDK bump, with a silent loss of `Read`/`Edit`/`Bash` as the failure mode if the list drifts. `allowedTools` is additive and is the mechanism the 0.3.233 notes point at.

Applied to both `buildPersistentQueryOptions` and `buildColdStartQueryOptions`, since either can start a turn.

Only `TodoWrite` is named. The `TaskCreate`/`TaskGet`/`TaskUpdate`/`TaskList` tools went the same way upstream, but nothing in Grimoire reads them, so naming them would widen the tool surface for no gain.

## Testing

Three unit tests in `QueryOptionsBuilder.test.ts`: the persistent path names the tool and still leaves `tools` unset, the cold-start path names it, and a restricting slash command keeps naming it while `tools` carries the command's own list.

`npm run typecheck`, `npm run lint` and `npm run build:release` are all green, and `build:release` reports no drift in the generated artifacts.

Unit suite: 7113 passing, 9 failing. All 9 failures are `ReferenceError: setImmediate is not defined` in the two Antigravity suites, are identical on a clean `main`, and come from running locally on Node 26 rather than CI's Node 22.

## One thing a reviewer should confirm

The SDK notes say a tool referenced in `allowedTools` is kept, and separately that `tools` sets the base surface. What they do not spell out is the interaction: whether `allowedTools` re-adds a tool that a restricting `tools` list omits. The third test pins Grimoire's side of that contract, but the restricted-slash-command case is worth a quick check against a real run on a new model before relying on it.
