### PR TITLE
fix(claude): rebuild the plan panel from the sdk's task tools

### DIFF
--- a/src/core/tools/toolNames.ts
+++ b/src/core/tools/toolNames.ts
@@ -18,6 +18,13 @@ export const TOOL_SUBAGENT_LEGACY = 'Task' as const;
 // Kept as an alias while the internal codebase is still named around "Task".
 export const TOOL_TASK = TOOL_SUBAGENT;
 export const TOOL_TODO_WRITE = 'TodoWrite' as const;
+// Task tracking replaced TodoWrite in Claude Code 2.1.233. Grimoire still renders
+// plans through TOOL_TODO_WRITE, so provider adapters fold these into that shape.
+export const TOOL_TASK_CREATE = 'TaskCreate' as const;
+export const TOOL_TASK_GET = 'TaskGet' as const;
+export const TOOL_TASK_LIST = 'TaskList' as const;
+export const TOOL_TASK_UPDATE = 'TaskUpdate' as const;
+
 export const TOOL_TOOL_SEARCH = 'ToolSearch' as const;
 export const TOOL_WEB_FETCH = 'WebFetch' as const;
 export const TOOL_WEB_SEARCH = 'WebSearch' as const;

--- a/src/providers/claude/runtime/ClaudeChatRuntime.ts
+++ b/src/providers/claude/runtime/ClaudeChatRuntime.ts
@@ -75,6 +75,7 @@ import { encodeClaudeTurn } from '../prompt/ClaudeTurnEncoder';
 import { isContextWindowEvent, isSessionInitEvent, isStreamChunk } from '../sdk/typeGuards';
 import type { TransformEvent } from '../sdk/types';
 import { getClaudeProviderSettings } from '../settings';
+import { createClaudeTaskPlanState } from '../stream/claudeTaskPlanState';
 import {
   createTransformStreamState,
   createTransformUsageState,
@@ -270,6 +271,7 @@ export class ClaudeChatRuntime implements ChatRuntime {
   private turnMetadata: ChatTurnMetadata = {};
   private bufferedUsageChunk: StreamChunk & { type: 'usage' } | null = null;
   private streamTransformState = createTransformStreamState();
+  private taskPlanState = createClaudeTaskPlanState();
   private usageTransformState = createTransformUsageState();
 
   private getLegacyPluginDeps(): GrimoirePlugin & {
@@ -935,6 +937,7 @@ export class ClaudeChatRuntime implements ChatRuntime {
       ),
       streamState,
       usageState,
+      taskPlanState: this.taskPlanState,
     };
   }
 

--- a/src/providers/claude/runtime/types.ts
+++ b/src/providers/claude/runtime/types.ts
@@ -5,7 +5,12 @@ import type {
 } from '@anthropic-ai/claude-agent-sdk';
 
 import type { ChatRuntimeEnsureReadyOptions } from '../../../core/runtime/types';
-import { TOOL_TODO_WRITE } from '../../../core/tools/toolNames';
+import {
+  TOOL_TASK_CREATE,
+  TOOL_TASK_GET,
+  TOOL_TASK_LIST,
+  TOOL_TASK_UPDATE,
+} from '../../../core/tools/toolNames';
 import type { ImageAttachment, StreamChunk } from '../../../core/types';
 import type { PermissionMode } from '../../../core/types/settings';
 import type { ClaudeModel, EffortLevel } from '../types/models';
@@ -126,15 +131,21 @@ export interface SessionState {
 export const UNSUPPORTED_SDK_TOOLS = [] as const;
 
 /**
- * Built-in tools the sdk stopped offering by default. Since 0.3.233 the todo
- * tools are out of the default surface on Opus 4.8, Sonnet 5, Fable 5 and
- * newer, so a run that does not name them never emits TodoWrite and the plan
- * panel stays empty. Naming them in `allowedTools` keeps them available
- * without replacing the rest of the default surface, which is what setting
- * `tools` would do.
+ * Built-in tools the sdk stopped offering by default. Since 0.3.233 the task
+ * tracking tools are out of the default surface on Opus 4.8, Sonnet 5, Fable 5
+ * and newer, so a run that names none of them can never track a plan. Naming
+ * them in `allowedTools` re-enables the whole group without replacing the rest
+ * of the default surface, which is what setting `tools` would do.
+ *
+ * Verified against Claude Code 2.1.233: naming even one of these turns the
+ * group back on, and `allowedTools` does NOT re-add anything past a
+ * restricting `tools` list.
  */
 export const OPT_IN_BUILTIN_TOOLS = [
-  TOOL_TODO_WRITE,
+  TOOL_TASK_CREATE,
+  TOOL_TASK_GET,
+  TOOL_TASK_LIST,
+  TOOL_TASK_UPDATE,
 ] as const;
 
 /** Built-in subagents that don't apply to Obsidian context. */

--- a/src/providers/claude/stream/claudeTaskPlanState.ts
+++ b/src/providers/claude/stream/claudeTaskPlanState.ts
@@ -1,0 +1,204 @@
+/**
+ * Claude task-plan ledger.
+ *
+ * Claude Code 2.1.233 retired the single-call TodoWrite tool in favour of an
+ * incremental TaskCreate / TaskGet / TaskUpdate / TaskList family. A create
+ * carries no task id until its result comes back, and an update names only the
+ * fields it changes, so no single call ever describes the whole plan.
+ *
+ * The chat plan panel is fed by whole-list TodoWrite input, which is also what
+ * the Codex adapter synthesizes from `update_plan`. This ledger accumulates the
+ * task calls so the same provider-neutral shape can be replayed for Claude.
+ */
+
+import type { TodoItem } from '../../../core/tools/todo';
+import {
+  TOOL_TASK_CREATE,
+  TOOL_TASK_GET,
+  TOOL_TASK_LIST,
+  TOOL_TASK_UPDATE,
+} from '../../../core/tools/toolNames';
+
+/** Synthetic tool-call id for the replayed plan, stable so the panel updates in place. */
+export const CLAUDE_TASK_PLAN_TOOL_ID = 'claude-task-plan';
+
+const TASK_TOOL_NAMES: ReadonlySet<string> = new Set<string>([
+  TOOL_TASK_CREATE,
+  TOOL_TASK_GET,
+  TOOL_TASK_LIST,
+  TOOL_TASK_UPDATE,
+]);
+
+const TODO_STATUSES: ReadonlySet<string> = new Set(['pending', 'in_progress', 'completed']);
+
+export interface ClaudeTaskPlanState {
+  /** Tool name per tool-use id: a result only carries the id it answers. */
+  toolNamesById: Map<string, string>;
+  /** Create inputs held until the result assigns the task its id. */
+  pendingCreates: Map<string, { content: string; activeForm: string }>;
+  /** Insertion-ordered task ledger. */
+  tasks: Map<string, TodoItem>;
+}
+
+export function createClaudeTaskPlanState(): ClaudeTaskPlanState {
+  return {
+    toolNamesById: new Map(),
+    pendingCreates: new Map(),
+    tasks: new Map(),
+  };
+}
+
+export function isTaskPlanTool(name: string): boolean {
+  return TASK_TOOL_NAMES.has(name);
+}
+
+function readString(source: Record<string, unknown>, key: string): string {
+  const value = source[key];
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function readStatus(value: unknown): TodoItem['status'] | 'deleted' | null {
+  if (typeof value !== 'string') return null;
+  if (value === 'deleted') return 'deleted';
+  return TODO_STATUSES.has(value) ? (value as TodoItem['status']) : null;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
+  return value as Record<string, unknown>;
+}
+
+/** Full plan, or null when there is nothing the panel could render. */
+function snapshot(state: ClaudeTaskPlanState): TodoItem[] | null {
+  const todos = [...state.tasks.values()].filter(
+    (task) => task.content.length > 0 && task.activeForm.length > 0,
+  );
+  return todos.length > 0 ? todos.map((task) => ({ ...task })) : null;
+}
+
+function upsertTask(
+  state: ClaudeTaskPlanState,
+  taskId: string,
+  content: string,
+  activeForm: string,
+  status: TodoItem['status'],
+): void {
+  const existing = state.tasks.get(taskId);
+  state.tasks.set(taskId, {
+    content: content || existing?.content || '',
+    activeForm: activeForm || existing?.activeForm || content || existing?.content || '',
+    status,
+  });
+}
+
+/**
+ * Folds a task tool call into the ledger.
+ *
+ * Safe to call twice for the same id: the streamed and the assembled form of a
+ * block both surface as a tool use, and a create only reaches the ledger once
+ * its result arrives.
+ */
+export function recordTaskToolUse(
+  state: ClaudeTaskPlanState,
+  toolUseId: string,
+  name: string,
+  input: Record<string, unknown>,
+): TodoItem[] | null {
+  if (!isTaskPlanTool(name) || toolUseId.length === 0) return null;
+  state.toolNamesById.set(toolUseId, name);
+
+  if (name === TOOL_TASK_CREATE) {
+    const content = readString(input, 'subject');
+    if (content.length === 0) return null;
+    state.pendingCreates.set(toolUseId, {
+      content,
+      activeForm: readString(input, 'activeForm') || content,
+    });
+    return null;
+  }
+
+  if (name === TOOL_TASK_UPDATE) {
+    const taskId = readString(input, 'taskId');
+    const existing = state.tasks.get(taskId);
+    if (taskId.length === 0 || !existing) return null;
+
+    const status = readStatus(input.status);
+    if (status === 'deleted') {
+      state.tasks.delete(taskId);
+      return snapshot(state);
+    }
+
+    upsertTask(
+      state,
+      taskId,
+      readString(input, 'subject') || existing.content,
+      readString(input, 'activeForm') || existing.activeForm,
+      status ?? existing.status,
+    );
+    return snapshot(state);
+  }
+
+  return null;
+}
+
+/** Folds a task tool result into the ledger, resolving ids a create could not know. */
+export function recordTaskToolResult(
+  state: ClaudeTaskPlanState,
+  toolUseId: string,
+  result: unknown,
+): TodoItem[] | null {
+  const name = state.toolNamesById.get(toolUseId);
+  if (!name) return null;
+
+  const payload = asRecord(result);
+  state.toolNamesById.delete(toolUseId);
+  const pending = state.pendingCreates.get(toolUseId);
+  state.pendingCreates.delete(toolUseId);
+
+  if (!payload) return null;
+
+  if (name === TOOL_TASK_CREATE) {
+    const task = asRecord(payload.task);
+    const taskId = task ? readString(task, 'id') : '';
+    if (taskId.length === 0) return null;
+    const subject = task ? readString(task, 'subject') : '';
+    const content = pending?.content || subject;
+    upsertTask(state, taskId, content, pending?.activeForm || content, 'pending');
+    return snapshot(state);
+  }
+
+  if (name === TOOL_TASK_GET) {
+    const task = asRecord(payload.task);
+    const taskId = task ? readString(task, 'id') : '';
+    const status = task ? readStatus(task.status) : null;
+    if (taskId.length === 0 || status === null || status === 'deleted') return null;
+    const subject = readString(task as Record<string, unknown>, 'subject');
+    upsertTask(state, taskId, subject, subject, status);
+    return snapshot(state);
+  }
+
+  if (name === TOOL_TASK_LIST) {
+    if (!Array.isArray(payload.tasks)) return null;
+    // A list is the authoritative snapshot, so it replaces the ledger rather
+    // than merging - a task deleted elsewhere has to disappear from the panel.
+    const rebuilt = new Map<string, TodoItem>();
+    for (const entry of payload.tasks) {
+      const task = asRecord(entry);
+      if (!task) continue;
+      const taskId = readString(task, 'id');
+      const status = readStatus(task.status);
+      if (taskId.length === 0 || status === null || status === 'deleted') continue;
+      const subject = readString(task, 'subject');
+      const previous = state.tasks.get(taskId);
+      rebuilt.set(taskId, {
+        content: subject || previous?.content || '',
+        activeForm: previous?.activeForm || subject || '',
+        status,
+      });
+    }
+    state.tasks = rebuilt;
+    return snapshot(state);
+  }
+
+  return null;
+}

--- a/src/providers/claude/stream/transformClaudeMessage.ts
+++ b/src/providers/claude/stream/transformClaudeMessage.ts
@@ -1,10 +1,18 @@
 import type { SDKMessage, SDKResultError } from '@anthropic-ai/claude-agent-sdk';
 
+import type { TodoItem } from '../../../core/tools/todo';
+import { TOOL_TODO_WRITE } from '../../../core/tools/toolNames';
 import type { SDKToolUseResult, StreamChunk, UsageInfo } from '../../../core/types';
 import { isBlockedMessage } from '../sdk/messages';
 import { extractToolResultContent } from '../sdk/toolResultContent';
 import type { TransformEvent } from '../sdk/types';
 import { getContextWindowSize, isDefaultClaudeModel } from '../types/models';
+import {
+  CLAUDE_TASK_PLAN_TOOL_ID,
+  type ClaudeTaskPlanState,
+  recordTaskToolResult,
+  recordTaskToolUse,
+} from './claudeTaskPlanState';
 import { createTransformStreamState, type TransformStreamState } from './toolInputStreamState';
 
 type ToolUseFields = { id: string; name: string; input: Record<string, unknown> };
@@ -32,6 +40,22 @@ function emitToolResult(parentToolUseId: string | null, fields: ToolResultFields
     return { type: 'tool_result', ...fields };
   }
   return { type: 'subagent_tool_result', subagentId: parentToolUseId, ...fields };
+}
+
+/**
+ * Replays the accumulated task plan as TodoWrite input.
+ *
+ * The plan panel is fed by whole-list TodoWrite chunks, and Claude Code 2.1.233
+ * only emits incremental task calls. Reusing one id keeps this a single
+ * updating entry rather than a new card per task call. Subagent plans are left
+ * out: the panel tracks the main agent's plan.
+ */
+function* emitTaskPlan(
+  parentToolUseId: string | null,
+  todos: TodoItem[] | null,
+): Generator<StreamChunk> {
+  if (parentToolUseId !== null || !todos) return;
+  yield { type: 'tool_use', id: CLAUDE_TASK_PLAN_TOOL_ID, name: TOOL_TODO_WRITE, input: { todos } };
 }
 
 function normalizeTaskNotificationStatus(status: unknown): AsyncSubagentResultStatus {
@@ -76,6 +100,8 @@ export interface TransformOptions {
   streamState?: TransformStreamState;
   /** Tracks prompt-token usage across Anthropic-compatible stream events. */
   usageState?: TransformUsageState;
+  /** Accumulates Claude's incremental task calls into a whole-plan snapshot. */
+  taskPlanState?: ClaudeTaskPlanState;
 }
 
 export interface MessageUsage {
@@ -417,11 +443,17 @@ export function* transformSDKMessage(
               yield { type: 'text', content: block.text };
             }
           } else if (block.type === 'tool_use') {
-            yield emitToolUse(parentToolUseId, {
-              id: block.id || `tool-${Date.now()}-${Math.random().toString(36).substring(2, 11)}`,
-              name: block.name || 'unknown',
-              input: getToolInput(block.input),
-            });
+            const toolUseId = block.id
+              || `tool-${Date.now()}-${Math.random().toString(36).substring(2, 11)}`;
+            const toolName = block.name || 'unknown';
+            const toolInput = getToolInput(block.input);
+            yield emitToolUse(parentToolUseId, { id: toolUseId, name: toolName, input: toolInput });
+            if (options?.taskPlanState) {
+              yield* emitTaskPlan(
+                parentToolUseId,
+                recordTaskToolUse(options.taskPlanState, toolUseId, toolName, toolInput),
+              );
+            }
           }
         }
       }
@@ -466,6 +498,16 @@ export function* transformSDKMessage(
           isError: false,
           ...(toolUseResult !== undefined ? { toolUseResult } : {}),
         });
+      }
+      const resultContent = message.message?.content;
+      if (options?.taskPlanState && message.tool_use_result !== undefined && Array.isArray(resultContent)) {
+        for (const block of resultContent) {
+          if (typeof block === 'string' || block.type !== 'tool_result' || !block.tool_use_id) continue;
+          yield* emitTaskPlan(
+            parentToolUseId,
+            recordTaskToolResult(options.taskPlanState, block.tool_use_id, message.tool_use_result),
+          );
+        }
       }
       // Also check message.message.content for tool_result blocks
       if (message.message?.content && Array.isArray(message.message.content)) {

--- a/src/providers/claude/stream/transformClaudeMessage.ts
+++ b/src/providers/claude/stream/transformClaudeMessage.ts
@@ -49,6 +49,9 @@ function emitToolResult(parentToolUseId: string | null, fields: ToolResultFields
  * only emits incremental task calls. Reusing one id keeps this a single
  * updating entry rather than a new card per task call. Subagent plans are left
  * out: the panel tracks the main agent's plan.
+ *
+ * The result has to follow the call: a synthesized tool use that never
+ * completes leaves the plan entry running forever.
  */
 function* emitTaskPlan(
   parentToolUseId: string | null,
@@ -56,6 +59,7 @@ function* emitTaskPlan(
 ): Generator<StreamChunk> {
   if (parentToolUseId !== null || !todos) return;
   yield { type: 'tool_use', id: CLAUDE_TASK_PLAN_TOOL_ID, name: TOOL_TODO_WRITE, input: { todos } };
+  yield { type: 'tool_result', id: CLAUDE_TASK_PLAN_TOOL_ID, content: 'Plan updated', isError: false };
 }
 
 function normalizeTaskNotificationStatus(status: unknown): AsyncSubagentResultStatus {

--- a/tests/unit/providers/claude/runtime/QueryOptionsBuilder.test.ts
+++ b/tests/unit/providers/claude/runtime/QueryOptionsBuilder.test.ts
@@ -330,10 +330,10 @@ describe('QueryOptionsBuilder', () => {
   });
 
   describe('buildPersistentQueryOptions', () => {
-    it('names the todo tools so the plan panel survives the sdk default surface', () => {
-      // The sdk dropped the todo tools from its default surface in 0.3.233, so
-      // a run that names nothing never emits TodoWrite. allowedTools re-adds
-      // them without replacing the rest of the default tools.
+    it('names the task tools so a plan can be tracked at all', () => {
+      // The sdk dropped the task tools from its default surface in 0.3.233, so
+      // a run that names none of them can never track a plan. allowedTools
+      // re-enables the group without replacing the rest of the default tools.
       const ctx = {
         ...createMockContext(),
         abortController: new AbortController(),
@@ -342,7 +342,9 @@ describe('QueryOptionsBuilder', () => {
 
       const options = QueryOptionsBuilder.buildPersistentQueryOptions(ctx);
 
-      expect(options.allowedTools).toContain('TodoWrite');
+      expect(options.allowedTools).toEqual(
+        expect.arrayContaining(['TaskCreate', 'TaskGet', 'TaskList', 'TaskUpdate']),
+      );
       expect(options.tools).toBeUndefined();
     });
 
@@ -653,7 +655,7 @@ describe('QueryOptionsBuilder', () => {
   });
 
   describe('buildColdStartQueryOptions', () => {
-    it('names the todo tools on a cold start too', () => {
+    it('names the task tools on a cold start too', () => {
       const ctx = {
         ...createMockContext(),
         abortController: new AbortController(),
@@ -664,13 +666,14 @@ describe('QueryOptionsBuilder', () => {
 
       const options = QueryOptionsBuilder.buildColdStartQueryOptions(ctx);
 
-      expect(options.allowedTools).toContain('TodoWrite');
+      expect(options.allowedTools).toContain('TaskCreate');
     });
 
-    it('keeps naming the todo tools when a slash command restricts the tool set', () => {
+    it('keeps naming the task tools when a slash command restricts the tool set', () => {
       // A restricting command replaces the base surface through the tools
-      // option, so the todo opt-in has to stay on allowedTools rather than
-      // ride on the default surface.
+      // option. Verified against Claude Code 2.1.233: allowedTools does not
+      // re-add anything past that list, so such a command deliberately gives
+      // up plan tracking - this only pins that Grimoire still names them.
       const ctx = {
         ...createMockContext(),
         abortController: new AbortController(),
@@ -683,7 +686,7 @@ describe('QueryOptionsBuilder', () => {
       const options = QueryOptionsBuilder.buildColdStartQueryOptions(ctx);
 
       expect(options.tools).toEqual(expect.arrayContaining(['Read', 'Grep']));
-      expect(options.allowedTools).toContain('TodoWrite');
+      expect(options.allowedTools).toContain('TaskCreate');
     });
 
     it('includes MCP servers when available', () => {

--- a/tests/unit/providers/claude/stream/claudeTaskPlanState.test.ts
+++ b/tests/unit/providers/claude/stream/claudeTaskPlanState.test.ts
@@ -1,0 +1,134 @@
+import { parseTodoInput } from '@/core/tools/todo';
+import {
+  createClaudeTaskPlanState,
+  recordTaskToolResult,
+  recordTaskToolUse,
+} from '@/providers/claude/stream/claudeTaskPlanState';
+
+function createTask(
+  state: ReturnType<typeof createClaudeTaskPlanState>,
+  toolUseId: string,
+  subject: string,
+  taskId: string,
+  activeForm?: string,
+) {
+  recordTaskToolUse(state, toolUseId, 'TaskCreate', {
+    subject,
+    description: subject,
+    ...(activeForm ? { activeForm } : {}),
+  });
+  return recordTaskToolResult(state, toolUseId, { task: { id: taskId, subject } });
+}
+
+describe('claudeTaskPlanState', () => {
+  it('holds a create back until its result assigns the task id', () => {
+    const state = createClaudeTaskPlanState();
+
+    // The create call itself carries no id, so nothing can be rendered yet.
+    const onUse = recordTaskToolUse(state, 'call-1', 'TaskCreate', {
+      subject: 'Run tests',
+      description: 'Run the unit suite',
+      activeForm: 'Running tests',
+    });
+    expect(onUse).toBeNull();
+
+    const onResult = recordTaskToolResult(state, 'call-1', { task: { id: 't1', subject: 'Run tests' } });
+
+    expect(onResult).toEqual([
+      { content: 'Run tests', activeForm: 'Running tests', status: 'pending' },
+    ]);
+  });
+
+  it('produces a plan the shared todo parser accepts', () => {
+    const state = createClaudeTaskPlanState();
+    const todos = createTask(state, 'call-1', 'Run tests', 't1', 'Running tests');
+
+    // The panel is fed through parseTodoInput, so the replayed shape has to
+    // survive that validator rather than merely look similar.
+    expect(parseTodoInput({ todos })).toEqual(todos);
+  });
+
+  it('falls back to the subject when a create omits activeForm', () => {
+    const state = createClaudeTaskPlanState();
+
+    const todos = createTask(state, 'call-1', 'Ship the release', 't1');
+
+    expect(todos).toEqual([
+      { content: 'Ship the release', activeForm: 'Ship the release', status: 'pending' },
+    ]);
+  });
+
+  it('applies a status change and keeps the original order', () => {
+    const state = createClaudeTaskPlanState();
+    createTask(state, 'call-1', 'First', 't1');
+    createTask(state, 'call-2', 'Second', 't2');
+
+    const todos = recordTaskToolUse(state, 'call-3', 'TaskUpdate', {
+      taskId: 't2',
+      status: 'in_progress',
+    });
+
+    expect(todos).toEqual([
+      { content: 'First', activeForm: 'First', status: 'pending' },
+      { content: 'Second', activeForm: 'Second', status: 'in_progress' },
+    ]);
+  });
+
+  it('drops a task deleted through an update', () => {
+    const state = createClaudeTaskPlanState();
+    createTask(state, 'call-1', 'First', 't1');
+    createTask(state, 'call-2', 'Second', 't2');
+
+    const todos = recordTaskToolUse(state, 'call-3', 'TaskUpdate', {
+      taskId: 't1',
+      status: 'deleted',
+    });
+
+    expect(todos).toEqual([{ content: 'Second', activeForm: 'Second', status: 'pending' }]);
+  });
+
+  it('ignores an update for a task it never saw created', () => {
+    const state = createClaudeTaskPlanState();
+
+    expect(recordTaskToolUse(state, 'call-1', 'TaskUpdate', {
+      taskId: 'unknown',
+      status: 'completed',
+    })).toBeNull();
+  });
+
+  it('lets a list result replace the ledger so removals disappear', () => {
+    const state = createClaudeTaskPlanState();
+    createTask(state, 'call-1', 'First', 't1', 'Doing first');
+    createTask(state, 'call-2', 'Second', 't2');
+
+    recordTaskToolUse(state, 'call-3', 'TaskList', {});
+    const todos = recordTaskToolResult(state, 'call-3', {
+      tasks: [{ id: 't1', subject: 'First', status: 'completed', blockedBy: [] }],
+    });
+
+    // t2 is gone from the authoritative snapshot, and t1 keeps the activeForm
+    // the list output does not carry.
+    expect(todos).toEqual([
+      { content: 'First', activeForm: 'Doing first', status: 'completed' },
+    ]);
+  });
+
+  it('stays stable when the same create is seen twice', () => {
+    const state = createClaudeTaskPlanState();
+
+    // A streamed block surfaces as a tool use before the assembled message
+    // repeats it, so folding the same call twice must not duplicate the task.
+    recordTaskToolUse(state, 'call-1', 'TaskCreate', { subject: 'Run tests', description: '' });
+    recordTaskToolUse(state, 'call-1', 'TaskCreate', { subject: 'Run tests', description: '' });
+    const todos = recordTaskToolResult(state, 'call-1', { task: { id: 't1', subject: 'Run tests' } });
+
+    expect(todos).toHaveLength(1);
+  });
+
+  it('ignores tools that are not part of the task family', () => {
+    const state = createClaudeTaskPlanState();
+
+    expect(recordTaskToolUse(state, 'call-1', 'Read', { file_path: '/tmp/x' })).toBeNull();
+    expect(recordTaskToolResult(state, 'call-1', { ok: true })).toBeNull();
+  });
+});

--- a/tests/unit/providers/claude/stream/transformSDKMessage.test.ts
+++ b/tests/unit/providers/claude/stream/transformSDKMessage.test.ts
@@ -1,5 +1,6 @@
 import { buildSDKMessage } from '@test/helpers/sdkMessages';
 
+import { createClaudeTaskPlanState } from '@/providers/claude/stream/claudeTaskPlanState';
 import {
   createTransformStreamState,
   createTransformUsageState,
@@ -9,6 +10,64 @@ import {
 const msg = buildSDKMessage;
 
 describe('transformSDKMessage', () => {
+  describe('task plan replay', () => {
+    it('replays the accumulated task plan as a TodoWrite chunk', () => {
+      const taskPlanState = createClaudeTaskPlanState();
+
+      const createChunks = [...transformSDKMessage(
+        msg({
+          type: 'assistant',
+          message: {
+            content: [{
+              type: 'tool_use',
+              id: 'call-1',
+              name: 'TaskCreate',
+              input: { subject: 'Run tests', description: 'Run them', activeForm: 'Running tests' },
+            }],
+          },
+        }),
+        { taskPlanState },
+      )];
+
+      // The create alone has no task id yet, so only the real call is emitted.
+      expect(createChunks.filter((chunk) => chunk.type === 'tool_use')).toHaveLength(1);
+
+      const resultChunks = [...transformSDKMessage(
+        msg({
+          type: 'user',
+          tool_use_result: { task: { id: 't1', subject: 'Run tests' } },
+          message: {
+            content: [{ type: 'tool_result', tool_use_id: 'call-1', content: 'created' }],
+          },
+        }),
+        { taskPlanState },
+      )];
+
+      expect(resultChunks).toContainEqual({
+        type: 'tool_use',
+        id: 'claude-task-plan',
+        name: 'TodoWrite',
+        input: { todos: [{ content: 'Run tests', activeForm: 'Running tests', status: 'pending' }] },
+      });
+    });
+
+    it('leaves the plan alone without a task plan state', () => {
+      const chunks = [...transformSDKMessage(msg({
+        type: 'assistant',
+        message: {
+          content: [{
+            type: 'tool_use',
+            id: 'call-1',
+            name: 'TaskCreate',
+            input: { subject: 'Run tests', description: 'Run them' },
+          }],
+        },
+      }))];
+
+      expect(chunks.every((chunk) => chunk.type !== 'tool_use' || chunk.name !== 'TodoWrite')).toBe(true);
+    });
+  });
+
   describe('system messages', () => {
     it('yields session_init event for init subtype with session_id', () => {
       const message = msg({

--- a/tests/unit/providers/claude/stream/transformSDKMessage.test.ts
+++ b/tests/unit/providers/claude/stream/transformSDKMessage.test.ts
@@ -49,6 +49,14 @@ describe('transformSDKMessage', () => {
         name: 'TodoWrite',
         input: { todos: [{ content: 'Run tests', activeForm: 'Running tests', status: 'pending' }] },
       });
+
+      // Without a result the plan entry renders as running forever.
+      expect(resultChunks).toContainEqual({
+        type: 'tool_result',
+        id: 'claude-task-plan',
+        content: 'Plan updated',
+        isError: false,
+      });
     });
 
     it('leaves the plan alone without a task plan state', () => {


### PR DESCRIPTION
Corrects #86, which did not achieve what its description claimed.

## What #86 got wrong

#86 named `TodoWrite` in `allowedTools` to keep the plan panel working. Probing Claude Code 2.1.233 directly — starting sessions and reading the `tools` array off the SDK's `init` message — shows that was based on a misreading of the 0.3.233 notes.

**`TodoWrite` does not exist as a tool any more.** It was replaced by `TaskCreate` / `TaskGet` / `TaskUpdate` / `TaskList`. The release notes listed the old and new names together as one group; #86 read that as five tools to restore.

| Configuration | Tools | `TodoWrite` | `Task*` |
|---|---|---|---|
| `sonnet`, no options | 29 | no | no |
| `sonnet` + `allowedTools: ['TodoWrite']` (#86) | 33 | **no** | all four |
| `sonnet` + `CLAUDE_CODE_ENABLE_TODO_TOOLS=1` | 33 | no | all four |
| `sonnet` + `allowedTools` with all five names | 33 | no | all four |
| `claude-sonnet-4-5` (older model), no options | 33 | no | all four |
| stock (`settingSources: []`) | 27 | no | no |
| stock + `allowedTools: ['TodoWrite']` | 31 | no | all four |
| `tools: ['Read','Grep']` + `allowedTools: ['TodoWrite']` | 3 | no | no |

So #86 *did* re-enable the group — naming any member is enough, even the retired name — but the panel stayed empty, because the renderer keys on `TodoWrite` and nothing emits it any more.

The regression is also **wider than #86 assumed**: row 5 shows an older model has no `TodoWrite` either, so this was never limited to the newest models.

## Changes

**Name the real tools in the opt-in constant.** Functionally the same key, but the retired name read like a typo to anyone opening the file later.

**Fold the task calls back into the plan panel.** This is the actual fix. `TodoWrite` carried the whole list in one call. The task tools are incremental — a create carries no id until its result returns, and an update names only the fields it changes — so no single call ever describes the plan.

`claudeTaskPlanState` accumulates the calls and replays them as whole-list `TodoWrite` input. That is the same provider-neutral shape the Codex adapter already synthesizes from `update_plan` ([`CodexNotificationRouter.ts`](https://github.com/sandsaber/Grimoire/blob/main/src/providers/codex/runtime/CodexNotificationRouter.ts)), so nothing in `src/features/` changes and the existing renderer, panel, and conversation-restore paths are reused untouched.

Details worth a reviewer's attention:

- A `TaskList` result **replaces** the ledger rather than merging. It is the authoritative snapshot, so a task deleted elsewhere has to disappear from the panel.
- The replay reuses one tool-call id, so the plan stays a single updating entry instead of a new card per task call.
- Subagent plans are excluded — the panel tracks the main agent.
- Folding the same create twice is a no-op, because a streamed block surfaces as a tool use before the assembled message repeats it.

## The open question from #86 is now answered

The last table row settles it: **`allowedTools` does not re-add anything past a restricting `tools` list.** A slash command that restricts tools therefore gives up plan tracking. That is the command's own intent, so it is pinned by a test rather than worked around.

## Testing

Nine unit tests for the ledger, covering the deferred create, the `activeForm` fallback, status changes and ordering, deletion, an update for an unknown task, list-replaces-ledger, and double-folding. One asserts the replayed shape survives the shared `parseTodoInput` validator rather than merely looking similar. Two more at the transform level cover the emitted chunk and the no-state case.

`npm run typecheck`, `npm run lint` and `npm run build:release` are green, with no drift in generated artifacts.

Unit suite: 7124 passing, 9 failing. All 9 are `ReferenceError: setImmediate is not defined` in the two Antigravity suites, identical on a clean `main`, caused by running locally on Node 26 rather than CI's Node 22.

## Not covered by tests

The ledger is driven by the shapes in the SDK's `sdk-tools.d.ts` (`TaskCreateOutput`, `TaskListOutput`, and friends), not by a captured live transcript. The wiring is worth one manual run in the vault to confirm the panel actually populates.
