### PR TITLE
test(antigravity): bind setImmediate through the module, not the global

### DIFF
--- a/tests/unit/providers/antigravity/AntigravityChatRuntime.test.ts
+++ b/tests/unit/providers/antigravity/AntigravityChatRuntime.test.ts
@@ -6,6 +6,10 @@ import { promises as fs } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { PassThrough } from 'node:stream';
+// Bound through the module, not the global: jest.useRealTimers() does not put
+// the lazily defined global setImmediate back on newer Node, so one suite that
+// fakes timers would otherwise strand every later test in the file without it.
+import { setImmediate } from 'node:timers';
 
 import { parseWindowsShellCommandLine, toAgyArgs } from '@test/helpers/antigravityLaunchShape';
 

--- a/tests/unit/providers/antigravity/AntigravityCliCapabilities.test.ts
+++ b/tests/unit/providers/antigravity/AntigravityCliCapabilities.test.ts
@@ -1,6 +1,10 @@
 import { spawn } from 'node:child_process';
 import { EventEmitter } from 'node:events';
 import { PassThrough } from 'node:stream';
+// Bound through the module, not the global: jest.useRealTimers() does not put
+// the lazily defined global setImmediate back on newer Node, so one suite that
+// fakes timers would otherwise strand every later test in the file without it.
+import { setImmediate } from 'node:timers';
 
 import {
   probeAntigravityCliCapabilities,


### PR DESCRIPTION
Fixes the nine local test failures that have been shadowing every run this week.

## Symptom

Nine tests across the two Antigravity suites fail locally on Node 26 with `ReferenceError: setImmediate is not defined`. CI on Node 22 stays green, so this never blocked a PR — it just made the local suite permanently red.

The tests are not broken. Each one passes when run in isolation:

```
npx jest --selectProjects unit --testPathPatterns "AntigravityCliCapabilities" \
  -t "does not cache a probe that failed to spawn"
# → 1 passed
```

## Cause

Cross-test pollution. Reproducible in eight lines with no Antigravity code involved:

```ts
it('a', () => { jest.useFakeTimers(); jest.useRealTimers(); });
it('b', () => { expect(typeof setImmediate).toBe('function'); });  // Received: "undefined"
it('c', async () => { await new Promise((r) => setImmediate(r)); }); // ReferenceError
```

`jest-environment-node` installs Node's globals on the sandbox as lazy accessors that materialize on first read. Faking timers replaces `setImmediate`; **restoring them does not put the accessor back**, so the global is gone for every later test in the file.

Both suites fake timers exactly once, in a balanced `try`/`finally` — the teardown is correct, it just doesn't restore this particular global on newer Node.

The practical cost is worse than nine red lines: the failures land on tests *downstream* of the timer swap rather than on anything actually broken, so a real regression in those files would be indistinguishable from the noise.

## Fix

Import the real `setImmediate` from `node:timers` in both files. A module binding is unaffected by whatever happens to the global, and the semantics are unchanged — every one of these call sites already runs under real timers, so nothing that was faked becomes real.

## Result

Local unit suite: **7133 passing, 0 failing, 407 suites** — green for the first time. `typecheck`, `lint` and `build:release` are also green, with no drift in generated artifacts.

## Note for reviewers

This treats the symptom in our code rather than the underlying jest behaviour, which seems worth reporting upstream. Two other options were considered and dropped: pinning a Node version for local dev doesn't fix anything and only hides it from whoever happens to run the matching version, and re-defining the global in a jest setup file would paper over the same class of breakage everywhere, including places where losing a global should be loud.
