### PR TITLE
fix(chat): render LaTeX-delimited math instead of leaking its markup

### DIFF
--- a/src/features/chat/rendering/MessageRenderer.ts
+++ b/src/features/chat/rendering/MessageRenderer.ts
@@ -17,7 +17,10 @@ import { scheduleAnimationFrame } from '../../../utils/animationFrame';
 import { formatDurationMmSs } from '../../../utils/date';
 import { hasProcessableWikilink, processFileLinks, registerFileLinkHandler } from '../../../utils/fileLink';
 import { replaceImageEmbedsWithHtml } from '../../../utils/imageEmbed';
-import { escapeMathDelimitersForStreaming } from '../../../utils/markdownMath';
+import {
+  escapeMathDelimitersForStreaming,
+  normalizeLatexDelimiters,
+} from '../../../utils/markdownMath';
 import { findRewindContext } from '../rewind';
 import { renderVaultSearchSources } from '../ui/VaultSearchSources';
 import { getAssistantResponseProviderLabel } from '../utils/assistantResponseMetadata';
@@ -944,10 +947,11 @@ export class MessageRenderer {
     el.empty();
 
     try {
+      const normalizedMarkdown = normalizeLatexDelimiters(markdown);
       const renderMarkdown = normalizePipeTablesForMarkdown(
         options?.deferMath
-          ? escapeMathDelimitersForStreaming(markdown)
-          : markdown
+          ? escapeMathDelimitersForStreaming(normalizedMarkdown)
+          : normalizedMarkdown
       );
       // Normalize embeds before MarkdownRenderer consumes them.
       const processedMarkdown = replaceImageEmbedsWithHtml(

--- a/src/utils/markdownMath.ts
+++ b/src/utils/markdownMath.ts
@@ -3,6 +3,32 @@ interface FenceState {
   length: number;
 }
 
+type DelimiterKind = 'displayOpen' | 'displayClose' | 'inlineOpen' | 'inlineClose';
+
+interface DelimiterToken {
+  index: number;
+  kind: DelimiterKind;
+}
+
+interface DelimiterPair {
+  close: DelimiterToken;
+  display: boolean;
+  open: DelimiterToken;
+}
+
+interface Replacement {
+  end: number;
+  start: number;
+  text: string;
+}
+
+const DELIMITER_KINDS: Record<string, DelimiterKind> = {
+  '(': 'inlineOpen',
+  ')': 'inlineClose',
+  '[': 'displayOpen',
+  ']': 'displayClose',
+};
+
 function getFenceRun(line: string): string | null {
   const match = line.match(/^ {0,3}(`{3,}|~{3,})/);
   return match?.[1] ?? null;
@@ -26,17 +52,28 @@ function readBacktickRun(line: string, index: number): number {
   return length;
 }
 
-function escapeMathDelimitersInLine(line: string): string {
-  let escaped = '';
+function visitPlainSegmentsInLine(
+  line: string,
+  lineOffset: number,
+  visit: (segment: string, offset: number) => void,
+): void {
   let inlineCodeRunLength = 0;
   let inHtmlTag = false;
+  let segmentStart: number | null = null;
+
+  const closeSegment = (end: number): void => {
+    if (segmentStart !== null) {
+      visit(line.slice(segmentStart, end), lineOffset + segmentStart);
+      segmentStart = null;
+    }
+  };
 
   for (let index = 0; index < line.length; index += 1) {
     const char = line[index];
 
     if (char === '`') {
+      closeSegment(index);
       const runLength = readBacktickRun(line, index);
-      escaped += line.slice(index, index + runLength);
       index += runLength - 1;
       if (inlineCodeRunLength === 0) {
         inlineCodeRunLength = runLength;
@@ -47,12 +84,12 @@ function escapeMathDelimitersInLine(line: string): string {
     }
 
     if (inlineCodeRunLength > 0) {
-      escaped += char;
+      closeSegment(index);
       continue;
     }
 
     if (inHtmlTag) {
-      escaped += char;
+      closeSegment(index);
       if (char === '>') {
         inHtmlTag = false;
       }
@@ -60,12 +97,64 @@ function escapeMathDelimitersInLine(line: string): string {
     }
 
     if (char === '<' && isHtmlTagStart(line, index)) {
+      closeSegment(index);
       inHtmlTag = true;
-      escaped += char;
       continue;
     }
 
-    if (char === '\\' && line[index + 1] === '$') {
+    if (segmentStart === null) {
+      segmentStart = index;
+    }
+  }
+
+  closeSegment(line.length);
+}
+
+/**
+ * Visits the parts of `markdown` that are outside fenced code blocks, code
+ * spans and raw HTML tags, with their absolute offsets. Both math passes work
+ * from this single scan so they agree on what counts as prose.
+ */
+function forEachPlainSegment(
+  markdown: string,
+  visit: (segment: string, offset: number) => void,
+): void {
+  let fence: FenceState | null = null;
+  let lineStart = 0;
+
+  while (lineStart < markdown.length) {
+    const newlineIndex = markdown.indexOf('\n', lineStart);
+    const lineEnd = newlineIndex === -1 ? markdown.length : newlineIndex + 1;
+    const line = markdown.slice(lineStart, lineEnd);
+    const lineWithoutNewline = line.endsWith('\n') ? line.slice(0, -1) : line;
+
+    if (fence) {
+      if (isClosingFence(lineWithoutNewline, fence)) {
+        fence = null;
+      }
+    } else {
+      const fenceRun = getFenceRun(lineWithoutNewline);
+      if (fenceRun) {
+        fence = {
+          marker: fenceRun[0] as '`' | '~',
+          length: fenceRun.length,
+        };
+      } else {
+        visitPlainSegmentsInLine(line, lineStart, visit);
+      }
+    }
+
+    lineStart = lineEnd;
+  }
+}
+
+function escapeDollarsInPlainSegment(segment: string): string {
+  let escaped = '';
+
+  for (let index = 0; index < segment.length; index += 1) {
+    const char = segment[index];
+
+    if (char === '\\' && segment[index + 1] === '$') {
       escaped += '\\$';
       index += 1;
       continue;
@@ -75,6 +164,135 @@ function escapeMathDelimitersInLine(line: string): string {
   }
 
   return escaped;
+}
+
+function collectLatexDelimiters(markdown: string): DelimiterToken[] {
+  const tokens: DelimiterToken[] = [];
+
+  forEachPlainSegment(markdown, (segment, offset) => {
+    for (let index = 0; index < segment.length; index += 1) {
+      if (segment[index] !== '\\') {
+        continue;
+      }
+
+      let runLength = 1;
+      while (segment[index + runLength] === '\\') {
+        runLength += 1;
+      }
+
+      const next = segment[index + runLength];
+      const kind = next ? DELIMITER_KINDS[next] : undefined;
+      // A doubled backslash is LaTeX's own line break, so `\\[2pt]` is row
+      // spacing inside a formula rather than a display-math opener.
+      if (kind && runLength % 2 === 1) {
+        tokens.push({ index: offset + index + runLength - 1, kind });
+      }
+
+      index += runLength;
+    }
+  });
+
+  return tokens;
+}
+
+function pairLatexDelimiters(tokens: DelimiterToken[]): DelimiterPair[] {
+  const pairs: DelimiterPair[] = [];
+  let openDisplay: DelimiterToken | null = null;
+  let openInline: DelimiterToken | null = null;
+
+  for (const token of tokens) {
+    if (openDisplay) {
+      // Anything between `\[` and `\]` belongs to the formula, including
+      // parentheses that look like inline delimiters.
+      if (token.kind === 'displayClose') {
+        pairs.push({ close: token, display: true, open: openDisplay });
+        openDisplay = null;
+      }
+      continue;
+    }
+
+    if (token.kind === 'displayOpen') {
+      openInline = null;
+      openDisplay = token;
+      continue;
+    }
+
+    if (token.kind === 'inlineOpen') {
+      openInline = token;
+      continue;
+    }
+
+    if (token.kind === 'inlineClose' && openInline) {
+      pairs.push({ close: token, display: false, open: openInline });
+      openInline = null;
+    }
+  }
+
+  return pairs;
+}
+
+function isInlinePadding(char: string | undefined): boolean {
+  return char === ' ' || char === '\t';
+}
+
+function buildDelimiterReplacements(markdown: string, pairs: DelimiterPair[]): Replacement[] {
+  const replacements: Replacement[] = [];
+
+  for (const { close, display, open } of pairs) {
+    if (display) {
+      replacements.push({ end: open.index + 2, start: open.index, text: '$$' });
+      replacements.push({ end: close.index + 2, start: close.index, text: '$$' });
+      continue;
+    }
+
+    // Obsidian is strict about padding inside `$...$`, so the spaces LaTeX
+    // authors put next to `\(` and `\)` are absorbed into the delimiters.
+    let innerStart = open.index + 2;
+    let innerEnd = close.index;
+    while (innerStart < innerEnd && isInlinePadding(markdown[innerStart])) {
+      innerStart += 1;
+    }
+    while (innerEnd > innerStart && isInlinePadding(markdown[innerEnd - 1])) {
+      innerEnd -= 1;
+    }
+
+    replacements.push({ end: innerStart, start: open.index, text: '$' });
+    replacements.push({ end: close.index + 2, start: innerEnd, text: '$' });
+  }
+
+  return replacements.sort((left, right) => left.start - right.start);
+}
+
+/**
+ * Rewrites LaTeX math delimiters into the dollar form Obsidian renders.
+ *
+ * Models routinely answer with `\( x \)` and `\[ x \]`, which Obsidian's
+ * MathJax integration does not recognize - Markdown reads the backslash as an
+ * escape, so the formula lands as literal text with its brackets stripped and
+ * its subscripts turned into emphasis. Only matched pairs outside code are
+ * rewritten, so prose that merely mentions an escaped bracket is left alone.
+ */
+export function normalizeLatexDelimiters(markdown: string): string {
+  if (!markdown.includes('\\')) {
+    return markdown;
+  }
+
+  const replacements = buildDelimiterReplacements(
+    markdown,
+    pairLatexDelimiters(collectLatexDelimiters(markdown)),
+  );
+  if (replacements.length === 0) {
+    return markdown;
+  }
+
+  let result = '';
+  let cursor = 0;
+  for (const replacement of replacements) {
+    result += markdown.slice(cursor, replacement.start) + replacement.text;
+    cursor = replacement.end;
+  }
+
+  return result + markdown.slice(cursor);
 }
 
 /**
@@ -88,43 +306,20 @@ export function escapeMathDelimitersForStreaming(markdown: string): string {
   }
 
   let result = '';
-  let fence: FenceState | null = null;
-  let lineStart = 0;
+  let cursor = 0;
+  forEachPlainSegment(markdown, (segment, offset) => {
+    result += markdown.slice(cursor, offset) + escapeDollarsInPlainSegment(segment);
+    cursor = offset + segment.length;
+  });
 
-  while (lineStart < markdown.length) {
-    const newlineIndex = markdown.indexOf('\n', lineStart);
-    const lineEnd = newlineIndex === -1 ? markdown.length : newlineIndex + 1;
-    const line = markdown.slice(lineStart, lineEnd);
-    const lineWithoutNewline = line.endsWith('\n') ? line.slice(0, -1) : line;
-
-    if (fence) {
-      result += line;
-      if (isClosingFence(lineWithoutNewline, fence)) {
-        fence = null;
-      }
-    } else {
-      const fenceRun = getFenceRun(lineWithoutNewline);
-      if (fenceRun) {
-        result += line;
-        fence = {
-          marker: fenceRun[0] as '`' | '~',
-          length: fenceRun.length,
-        };
-      } else {
-        result += escapeMathDelimitersInLine(line);
-      }
-    }
-
-    lineStart = lineEnd;
-  }
-
-  return result;
+  return result + markdown.slice(cursor);
 }
 
 export function hasStreamingMathDelimiters(markdown: string): boolean {
-  if (!markdown.includes('$')) {
+  const normalized = normalizeLatexDelimiters(markdown);
+  if (!normalized.includes('$')) {
     return false;
   }
 
-  return escapeMathDelimitersForStreaming(markdown) !== markdown;
+  return escapeMathDelimitersForStreaming(normalized) !== normalized;
 }

--- a/tests/unit/features/chat/rendering/MessageRenderer.test.ts
+++ b/tests/unit/features/chat/rendering/MessageRenderer.test.ts
@@ -1693,6 +1693,24 @@ describe('MessageRenderer', () => {
     );
   });
 
+  it('renderContent rewrites latex math delimiters into the dollar form Obsidian renders', async () => {
+    const { MarkdownRenderer } = await import('obsidian');
+    const { renderer } = createRenderer();
+    const el = createMockEl();
+
+    await renderer.renderContent(
+      el,
+      'Since \\((x,y)\\neq(0,0)\\):\n\\[\nd^2 = 3 - 2\\sqrt2\n\\]'
+    );
+
+    expect(MarkdownRenderer.renderMarkdown).toHaveBeenCalledWith(
+      'Since $(x,y)\\neq(0,0)$:\n$$\nd^2 = 3 - 2\\sqrt2\n$$',
+      el,
+      '',
+      expect.anything()
+    );
+  });
+
   it('renderContent separates prose from following pipe tables before markdown rendering', async () => {
     const { MarkdownRenderer } = await import('obsidian');
     const { renderer } = createRenderer();

--- a/tests/unit/utils/markdownMath.test.ts
+++ b/tests/unit/utils/markdownMath.test.ts
@@ -1,6 +1,7 @@
 import {
   escapeMathDelimitersForStreaming,
   hasStreamingMathDelimiters,
+  normalizeLatexDelimiters,
 } from '@/utils/markdownMath';
 
 describe('markdownMath', () => {
@@ -44,11 +45,64 @@ describe('markdownMath', () => {
     });
   });
 
+  describe('normalizeLatexDelimiters', () => {
+    it('rewrites paired display and inline delimiters into dollar math', () => {
+      expect(normalizeLatexDelimiters('\\[\nx^2 = 1\n\\]')).toBe('$$\nx^2 = 1\n$$');
+      expect(normalizeLatexDelimiters('point \\((x,y)\\neq(0,0)\\) holds')).toBe(
+        'point $(x,y)\\neq(0,0)$ holds'
+      );
+    });
+
+    it('absorbs the padding LaTeX authors leave inside inline delimiters', () => {
+      expect(normalizeLatexDelimiters('value \\( \\lambda \\) here')).toBe(
+        'value $\\lambda$ here'
+      );
+    });
+
+    it('leaves unpaired delimiters alone', () => {
+      expect(normalizeLatexDelimiters('an escaped bracket \\[ stays put')).toBe(
+        'an escaped bracket \\[ stays put'
+      );
+      expect(normalizeLatexDelimiters('closing only \\) here')).toBe('closing only \\) here');
+    });
+
+    it('keeps delimiters inside code spans and fenced code', () => {
+      const markdown = [
+        '`\\(x\\)`',
+        '```tex',
+        '\\[y\\]',
+        '```',
+        'and \\(z\\)',
+      ].join('\n');
+
+      expect(normalizeLatexDelimiters(markdown)).toBe([
+        '`\\(x\\)`',
+        '```tex',
+        '\\[y\\]',
+        '```',
+        'and $z$',
+      ].join('\n'));
+    });
+
+    it('treats a doubled backslash as a LaTeX line break, not a delimiter', () => {
+      expect(normalizeLatexDelimiters('\\[\na \\\\[2pt] b\n\\]')).toBe('$$\na \\\\[2pt] b\n$$');
+    });
+
+    it('keeps parentheses inside display math out of the pairing', () => {
+      expect(normalizeLatexDelimiters('\\[\nf\\(x\\) = 1\n\\]')).toBe('$$\nf\\(x\\) = 1\n$$');
+    });
+  });
+
   describe('hasStreamingMathDelimiters', () => {
     it('detects unescaped dollars outside code', () => {
       expect(hasStreamingMathDelimiters('math $x$')).toBe(true);
       expect(hasStreamingMathDelimiters('`echo $PATH`')).toBe(false);
       expect(hasStreamingMathDelimiters('\\$5')).toBe(false);
+    });
+
+    it('detects latex delimiters that only become dollars after normalization', () => {
+      expect(hasStreamingMathDelimiters('math \\(x\\)')).toBe(true);
+      expect(hasStreamingMathDelimiters('unpaired \\( x')).toBe(false);
     });
   });
 });


### PR DESCRIPTION
Fixes #81.

## Symptom

Math answers arrive as raw markup. From the report's screenshot, with Codex answering:

```
这不是"为了求 (\lambda) 强行说有解"，而是：真实的极值点 ((x,y)\neq(0,0)) …
[
\lambda=-3\pm2\sqrt2.
]
```

`\((x,y)\neq(0,0)\)` reached the reader as `((x,y)\neq(0,0))`, the display delimiters
became bare `[` / `]` on their own lines, and `d_{\min}=…` was rendered in italics.

## Root cause

The model answers in LaTeX delimiters — `\( … \)` and `\[ … \]`, what OpenAI-style models
default to — and Obsidian's MathJax integration only recognizes `$ … $` and `$$ … $$`.
Markdown then reads the backslash as an escape: `\[` collapses to `[`, `\(` to `(`,
`\neq` survives because `n` is not escapable, and the surviving `_{…}_` pairs turn into
emphasis. That is exactly the shape in the screenshot.

The provider is not involved. Nothing in the Codex path touches message text — every
`replace(/\\/g, …)` there is path normalization — and Codex and OpenCode both render
through `MessageRenderer.renderContent`. The reporter saw a difference because the two
models answered in different delimiter styles.

`src/utils/markdownMath.ts` only knew about `$`: `escapeMathDelimitersForStreaming` hides
dollars mid-stream, and `hasStreamingMathDelimiters` decides from them whether a deferred
re-render is needed. Neither could see this style, so it was raw during streaming and
still raw afterwards.

## Fix

`normalizeLatexDelimiters()` rewrites the delimiters at the single render choke point,
alongside the existing `normalizePipeTablesForMarkdown` — so it covers every provider,
live turns and history alike.

It is deliberately narrow:

- only **matched** pairs are rewritten, so prose that merely mentions an escaped bracket
  keeps it;
- fenced code, code spans and raw HTML tags are skipped;
- a **doubled** backslash stays a LaTeX line break, so `\\[2pt]` row spacing is not
  mistaken for a display opener;
- parentheses inside a display pair stay part of the formula;
- inline padding is absorbed (`\( x \)` → `$x$`), because Obsidian is strict about
  whitespace inside `$…$`.

Both math passes now share one scanner, so escaping and normalization cannot disagree
about what counts as prose, and `hasStreamingMathDelimiters()` normalizes first — without
that, streaming would still never defer math rendering for this delimiter style.

## Tests

Seven new cases in `markdownMath.test.ts` (paired display/inline rewriting, padding
absorption, unpaired delimiters left alone, code spans and fences untouched, `\\[2pt]`,
parentheses inside display math, streaming detection after normalization) and one in
`MessageRenderer.test.ts` pinning the wiring: reverting the single call in `renderContent`
fails it.

Full local gate: 407 suites / 7152 tests passing, `typecheck`, `lint` and `build:release`
clean.
