### PR TITLE
fix(claude): seed only a catalog that records the key it came from

### DIFF
--- a/src/providers/claude/app/ClaudeModelCatalog.ts
+++ b/src/providers/claude/app/ClaudeModelCatalog.ts
@@ -106,6 +106,29 @@ function buildClaudeModelCatalogCacheKey(
   });
 }
 
+/**
+ * FNV-1a over the cache key. The key embeds the raw environment variables, which
+ * can hold an API key, so only the digest is ever persisted.
+ */
+function hashClaudeModelCatalogCacheKey(cacheKey: string): string {
+  let hash = 0x811c9dc5;
+  for (let index = 0; index < cacheKey.length; index += 1) {
+    hash ^= cacheKey.charCodeAt(index);
+    hash = Math.imul(hash, 0x01000193) >>> 0;
+  }
+  return hash.toString(16).padStart(8, '0');
+}
+
+/**
+ * A catalog persisted before the fingerprint existed carries no record of the key
+ * it came from, so the seed keeps extending it the same trust it always did. Once
+ * a fingerprint is recorded, the seed only applies while it still matches.
+ */
+function seedFingerprintMatches(persistedFingerprint: string, cacheKey: string): boolean {
+  return persistedFingerprint === ''
+    || persistedFingerprint === hashClaudeModelCatalogCacheKey(cacheKey);
+}
+
 export function createClaudeModelCatalog(plugin: GrimoirePlugin): ProviderModelCatalog {
   const refreshAttemptsByKey = new Map<string, number>();
   const refreshesByKey = new Map<string, Promise<boolean>>();
@@ -136,10 +159,17 @@ export function createClaudeModelCatalog(plugin: GrimoirePlugin): ProviderModelC
     if (initialCliPath === null) {
       seedOnFirstRefresh = true;
     } else {
-      refreshAttemptsByKey.set(
-        buildClaudeModelCatalogCacheKey(initialSettings, initialCliPath),
-        Date.now(),
-      );
+      // The seed speaks for a catalog it did not watch being discovered. While a
+      // timer existed that guess self-healed within ten minutes; now it does not
+      // expire, so a CLI swapped while the plugin was not running is adopted by
+      // the seed instead of detected, pinning the previous CLI's models for good.
+      // A recorded fingerprint turns the guess into a check. An unrecorded one
+      // (a catalog persisted before this field existed) keeps the old behaviour
+      // rather than spending a probe to migrate.
+      const initialCacheKey = buildClaudeModelCatalogCacheKey(initialSettings, initialCliPath);
+      if (seedFingerprintMatches(initialSettings.discoveredModelsFingerprint, initialCacheKey)) {
+        refreshAttemptsByKey.set(initialCacheKey, Date.now());
+      }
     }
   }
 
@@ -164,7 +194,10 @@ export function createClaudeModelCatalog(plugin: GrimoirePlugin): ProviderModelC
           initialSettings,
           plugin.getResolvedProviderCliPath?.('claude') ?? '',
         );
-        if (!force && seededCacheKey === cacheKey && currentSettings.discoveredModels.length > 0) {
+        if (!force
+          && seededCacheKey === cacheKey
+          && currentSettings.discoveredModels.length > 0
+          && seedFingerprintMatches(currentSettings.discoveredModelsFingerprint, cacheKey)) {
           refreshAttemptsByKey.set(cacheKey, Date.now());
           plugin.recordDebugLog?.({
             data: {
@@ -204,6 +237,7 @@ export function createClaudeModelCatalog(plugin: GrimoirePlugin): ProviderModelC
       const refresh = (async () => {
         const envVars = getClaudeEffectiveEnvironmentVariables(settings);
         const previousDiscoveredModels = currentSettings.discoveredModels;
+        const previousFingerprint = currentSettings.discoveredModelsFingerprint;
         const before = JSON.stringify(previousDiscoveredModels);
         try {
           let discoveredModels = await probeRuntimeModels(plugin);
@@ -223,11 +257,19 @@ export function createClaudeModelCatalog(plugin: GrimoirePlugin): ProviderModelC
             return false;
           }
 
-          updateClaudeProviderSettings(settings, { discoveredModels });
+          // Record which key produced this list, so a later load can tell
+          // "discovered under this exact configuration" from "assumed".
+          updateClaudeProviderSettings(settings, {
+            discoveredModels,
+            discoveredModelsFingerprint: hashClaudeModelCatalogCacheKey(cacheKey),
+          });
           try {
             await plugin.saveSettings?.();
           } catch (error) {
-            updateClaudeProviderSettings(settings, { discoveredModels: previousDiscoveredModels });
+            updateClaudeProviderSettings(settings, {
+              discoveredModels: previousDiscoveredModels,
+              discoveredModelsFingerprint: previousFingerprint,
+            });
             throw error;
           }
 

--- a/src/providers/claude/settings.ts
+++ b/src/providers/claude/settings.ts
@@ -29,6 +29,7 @@ export interface ClaudeProviderSettings {
   respectProjectSettings: boolean;
   projectSettingsSnapshot: ClaudeCodeProjectSettingsSnapshot;
   discoveredModels: ClaudeDiscoveredModel[];
+  discoveredModelsFingerprint: string;
 }
 
 export interface ClaudeDiscoveredModel {
@@ -67,6 +68,7 @@ export const DEFAULT_CLAUDE_PROVIDER_SETTINGS: Readonly<ClaudeProviderSettings> 
   respectProjectSettings: true,
   projectSettingsSnapshot: DEFAULT_CLAUDE_CODE_PROJECT_SETTINGS_SNAPSHOT,
   discoveredModels: [],
+  discoveredModelsFingerprint: '',
 });
 
 function normalizeHostnameCliPaths(value: unknown): HostnameCliPaths {
@@ -266,6 +268,9 @@ export function getClaudeProviderSettings(
       config.projectSettingsSnapshot,
     ),
     discoveredModels: normalizeClaudeDiscoveredModels(config.discoveredModels),
+    discoveredModelsFingerprint: typeof config.discoveredModelsFingerprint === 'string'
+      ? config.discoveredModelsFingerprint
+      : DEFAULT_CLAUDE_PROVIDER_SETTINGS.discoveredModelsFingerprint,
   };
 }
 

--- a/tests/unit/providers/claude/app/ClaudeModelCatalog.test.ts
+++ b/tests/unit/providers/claude/app/ClaudeModelCatalog.test.ts
@@ -231,4 +231,66 @@ describe('ClaudeModelCatalog', () => {
     expect(mockedBinaryFingerprint).toHaveBeenCalledWith('/claude');
     expect(mockedProbe).toHaveBeenCalledTimes(1);
   });
+
+  it('re-probes when the CLI binary changed while the plugin was not running', async () => {
+    const settings: Record<string, unknown> = {};
+    updateClaudeProviderSettings(settings, { enabled: true });
+    mockedProbe.mockResolvedValue([{ id: 'opus', displayName: 'Opus', source: 'sdk' }]);
+    mockedBinaryFingerprint.mockReturnValue('100:1');
+    const plugin = createPlugin(settings);
+
+    // First session: discovery runs and records which key produced the catalog.
+    await createClaudeModelCatalog(plugin).refreshModels({ plugin, settings });
+    expect(mockedProbe).toHaveBeenCalledTimes(1);
+    expect(getClaudeProviderSettings(settings).discoveredModelsFingerprint).not.toBe('');
+
+    // Obsidian was closed, the user ran `npm install -g`, and reopened it. The
+    // new binary is already in place while the catalog is constructed, so both
+    // the seed and the lookup compute '120:2' - the in-memory key comparison
+    // cannot see the change, and with no timer left it would never self-heal.
+    mockedBinaryFingerprint.mockReturnValue('120:2');
+    mockedProbe.mockResolvedValue([{ id: 'sonnet', displayName: 'Sonnet', source: 'sdk' }]);
+    await createClaudeModelCatalog(plugin).refreshModels({ plugin, settings });
+
+    expect(mockedProbe).toHaveBeenCalledTimes(2);
+    expect(getClaudeProviderSettings(settings).discoveredModels).toEqual([
+      { id: 'sonnet', displayName: 'Sonnet', source: 'sdk' },
+    ]);
+  });
+
+  it('re-probes when the CLI path changed while the plugin was not running', async () => {
+    const settings: Record<string, unknown> = {};
+    updateClaudeProviderSettings(settings, { enabled: true });
+    mockedProbe.mockResolvedValue([{ id: 'opus', displayName: 'Opus', source: 'sdk' }]);
+    const plugin = createPlugin(settings);
+
+    await createClaudeModelCatalog(plugin).refreshModels({ plugin, settings });
+    expect(mockedProbe).toHaveBeenCalledTimes(1);
+
+    // The user switched install channel between sessions, so the path already
+    // resolves to the new location when the catalog is constructed.
+    plugin.getResolvedProviderCliPath.mockReturnValue('/opt/claude');
+    await createClaudeModelCatalog(plugin).refreshModels({ plugin, settings });
+
+    expect(mockedProbe).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps trusting a catalog persisted before the fingerprint existed', async () => {
+    const settings: Record<string, unknown> = {};
+    updateClaudeProviderSettings(settings, {
+      enabled: true,
+      discoveredModels: [{ id: 'opus', displayName: 'Opus', source: 'sdk' }],
+    });
+    mockedProbe.mockResolvedValue([{ id: 'sonnet', displayName: 'Sonnet', source: 'sdk' }]);
+    const plugin = createPlugin(settings);
+
+    // No fingerprint on disk: migrating must not cost a probe, and must not
+    // force a settings write either, so the catalog is trusted exactly as
+    // before. It gains a recorded baseline at its next real discovery.
+    const catalog = createClaudeModelCatalog(plugin);
+    await expect(catalog.refreshModels({ plugin, settings })).resolves.toBe(false);
+
+    expect(mockedProbe).not.toHaveBeenCalled();
+    expect(plugin.saveSettings).not.toHaveBeenCalled();
+  });
 });

--- a/tests/unit/providers/claude/settings.test.ts
+++ b/tests/unit/providers/claude/settings.test.ts
@@ -1,4 +1,8 @@
-import { snapshotClaudeCodeSettings } from '@/providers/claude/settings';
+import {
+  getClaudeProviderSettings,
+  snapshotClaudeCodeSettings,
+  updateClaudeProviderSettings,
+} from '@/providers/claude/settings';
 
 describe('Claude provider settings', () => {
   describe('snapshotClaudeCodeSettings', () => {
@@ -44,6 +48,26 @@ describe('Claude provider settings', () => {
 
       expect(snapshot.model).toBe('');
       expect(snapshot.env).toEqual({});
+    });
+  });
+
+  describe('discovered models fingerprint', () => {
+    it('defaults to an empty string and keeps a persisted one', () => {
+      const settings: Record<string, unknown> = {};
+
+      expect(getClaudeProviderSettings(settings).discoveredModelsFingerprint).toBe('');
+
+      updateClaudeProviderSettings(settings, { discoveredModelsFingerprint: 'a1b2c3d4' });
+
+      expect(getClaudeProviderSettings(settings).discoveredModelsFingerprint).toBe('a1b2c3d4');
+    });
+
+    it('ignores a non-string persisted fingerprint', () => {
+      const settings: Record<string, unknown> = {
+        providerConfigs: { claude: { discoveredModelsFingerprint: 42 } },
+      };
+
+      expect(getClaudeProviderSettings(settings).discoveredModelsFingerprint).toBe('');
     });
   });
 });


### PR DESCRIPTION
Follows up #92 / #90.

## Problem

#92 removed the timer. That turned an assumption the seed had always been making
into a permanent one.

The seed files the persisted catalog under whatever key *this load* computes.
Nothing records the key the catalog actually came from, so the seed cannot
distinguish "discovered under this configuration" from "assumed to match it".
While the TTL existed, a wrong assumption expired within ten minutes. It no
longer expires.

Close Obsidian, change the CLI, reopen: construction and lookup both read the new
CLI, so the key they compare is self-consistent. The seed applies, the probe is
suppressed, and the previous CLI's model list stays pinned indefinitely.

`claudeCliBinaryFingerprint` cannot cover this. It only helps when the key differs
from one recorded earlier *in the same process*; across a reload nothing was
recorded. The result runs opposite to the intent stated in #92:

| CLI upgraded | detected? |
| --- | --- |
| while Obsidian is running | yes — the key changes against the in-memory attempt |
| while Obsidian is closed | no — the seed adopts the new key, permanently |

`re-probes when the CLI binary changes behind an unchanged path` passes because it
flips the fingerprint *after* the catalog is constructed, which is the first row.

## Change

Persist `discoveredModelsFingerprint`: an FNV-1a digest of the cache key that
produced the catalog. A digest rather than the key itself, because the key embeds
`environmentVariables`, which can hold `ANTHROPIC_API_KEY` — the secret must not
be duplicated to a second place on disk.

The seed then applies only while that digest still matches the key of the current
load.

**An absent digest keeps today's behaviour exactly.** A catalog persisted before
this field existed is seeded as it always was. Migration therefore costs neither
a probe nor a settings write. Such a catalog gains a recorded baseline the next
time discovery actually runs — a new install, an `api` catalog being upgraded to
`sdk`, a genuine in-session key change, or the Refresh models button — and is
protected from that point on.

## Tradeoff stated plainly

An install that upgrades Grimoire with an already-settled `sdk` catalog and never
triggers discovery again keeps the current behaviour indefinitely: its catalog has
no recorded baseline, so a CLI swapped between sessions still goes unnoticed. That
is the status quo rather than a regression, and one press of Refresh models closes
it permanently.

Two stricter alternatives were tried and rejected:

- Refusing to seed without a recorded digest. Correct semantics, but it spends one
  full SDK session — about 2% of a five-hour plan window — on every existing
  install, which is the cost this thread exists to remove, and it rewrites the
  expectations of five existing tests.
- Adopting the current key as the baseline on first refresh. Free in plan terms,
  but it forces a settings write on a path that currently has none, which breaks
  `preserves a persisted catalog when both SDK and API discovery fail`
  (`expect(plugin.saveSettings).not.toHaveBeenCalled()`).

Both were dropped in favour of touching no existing expectation at all.

## Tests

Three cases added. The first two fail against `main`'s implementation, verified by
swapping `ClaudeModelCatalog.ts` back and re-running:

- `re-probes when the CLI binary changed while the plugin was not running`
- `re-probes when the CLI path changed while the plugin was not running`
- `keeps trusting a catalog persisted before the fingerprint existed` — pins the
  free migration, so neither a probe nor a write can be reintroduced here quietly

No existing expectation was modified. The `ClaudeModelCatalog` suite passes whole
(14/14, the 11 pre-existing cases untouched).

Full local gate on Windows: 22 failed suites / 36 failed tests both before and
after — an exact match with this machine's `main` baseline at 2db77cc, so zero
regressions; passing tests 7111 → 7116. `typecheck`, `lint` and `build:release`
are clean.

"Fixes #93"