### PR TITLE
fix(grok): expose xhigh reasoning effort for grok-4.6

### DIFF
--- a/src/providers/grok/models.ts
+++ b/src/providers/grok/models.ts
@@ -76,23 +76,18 @@ export function normalizeGrokLaunchReasoningEffort(
     : null;
 }
 
-export function isGrokNativeBuildModelId(rawModelId: string): boolean {
-  const normalized = rawModelId.trim();
-  if (!normalized) {
-    return false;
-  }
-
-  return normalized === 'grok-build' || normalized.startsWith('grok-composer-');
-}
-
-/** Native xAI model ids, as opposed to third-party catalog ids such as `anthropic/...`. */
+/**
+ * Native xAI model ids, as opposed to third-party catalog ids such as
+ * `anthropic/...`. Matched case-insensitively, like every other prefix test in
+ * this file, so a catalog that reports `Grok-4.6` is still recognised.
+ */
 export function isGrokNativeModelId(rawModelId: string): boolean {
-  const normalized = rawModelId.trim();
+  const normalized = rawModelId.trim().toLowerCase();
   if (!normalized || normalized.includes('/')) {
     return false;
   }
 
-  return normalized === 'grok' || normalized.startsWith('grok-');
+  return normalized === GROK_SYNTHETIC_MODEL_ID || normalized.startsWith('grok-');
 }
 
 export function encodeGrokModelId(rawModelId: string): string {
@@ -180,20 +175,50 @@ export function normalizeGrokModelVariants(value: unknown): GrokModelVariant[] {
   return dedupeGrokVariants(variants);
 }
 
+/**
+ * Model ids reach this from the agent and from persisted settings, so they are
+ * untrusted keys: `__proto__` would replace this object's prototype instead of
+ * adding an entry.
+ */
+const UNSAFE_MODEL_ID_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
 export function normalizeGrokThinkingOptionsByModel(
   value: unknown,
-  discoveredModels: GrokDiscoveredModel[] = [],
+  discoveredModels: GrokDiscoveredModel[] | Set<string> = [],
 ): GrokThinkingOptionsByModel {
   if (!value || typeof value !== 'object' || Array.isArray(value)) {
     return {};
   }
 
+  // Built once rather than per key: resolveGrokBaseModelRawId would otherwise
+  // rebuild it for every entry, and this map now holds a whole catalog.
+  const discoveredRawIds = discoveredModels instanceof Set
+    ? discoveredModels
+    : new Set(discoveredModels.map((model) => model.rawId));
+
   const normalized: GrokThinkingOptionsByModel = {};
+  const exactRawIds = new Set<string>();
   for (const [rawId, variants] of Object.entries(value as Record<string, unknown>)) {
-    const normalizedRawId = resolveGrokBaseModelRawId(rawId.trim(), discoveredModels);
+    const trimmedRawId = rawId.trim();
+    if (UNSAFE_MODEL_ID_KEYS.has(trimmedRawId)) {
+      continue;
+    }
+
+    const normalizedRawId = resolveGrokBaseModelRawId(trimmedRawId, discoveredRawIds);
     const normalizedVariants = normalizeGrokModelVariants(variants);
     if (!normalizedRawId || normalizedVariants.length === 0) {
       continue;
+    }
+
+    // A variant id collapses onto its base, so `grok-4.6/high` must not
+    // overwrite what `grok-4.6` itself reported - otherwise iteration order
+    // decides which list the picker gets.
+    const isExact = normalizedRawId === trimmedRawId;
+    if (!isExact && exactRawIds.has(normalizedRawId)) {
+      continue;
+    }
+    if (isExact) {
+      exactRawIds.add(normalizedRawId);
     }
 
     normalized[normalizedRawId] = normalizedVariants;

--- a/src/providers/grok/models.ts
+++ b/src/providers/grok/models.ts
@@ -85,6 +85,16 @@ export function isGrokNativeBuildModelId(rawModelId: string): boolean {
   return normalized === 'grok-build' || normalized.startsWith('grok-composer-');
 }
 
+/** Native xAI model ids, as opposed to third-party catalog ids such as `anthropic/...`. */
+export function isGrokNativeModelId(rawModelId: string): boolean {
+  const normalized = rawModelId.trim();
+  if (!normalized || normalized.includes('/')) {
+    return false;
+  }
+
+  return normalized === 'grok' || normalized.startsWith('grok-');
+}
+
 export function encodeGrokModelId(rawModelId: string): string {
   const normalized = rawModelId.trim();
   return normalized ? `${GROK_MODEL_PREFIX}${normalized}` : GROK_SYNTHETIC_MODEL_ID;

--- a/src/providers/grok/runtime/GrokChatRuntime.ts
+++ b/src/providers/grok/runtime/GrokChatRuntime.ts
@@ -1282,13 +1282,17 @@ export class GrokChatRuntime implements ChatRuntime {
       ...currentSettings.thinkingOptionsByModel,
       ...acpModelThinkingOptions,
     };
+    // Forgetting a stale list is only meaningful when this call carried
+    // something that speaks about levels. A plain model switch calls in with
+    // nothing at all, and deleting on that would throw away what session/new
+    // reported the moment the user picks another model.
+    const describesSession = params.configOptions !== undefined
+      || params.models !== undefined
+      || params.modelThinkingOptions !== undefined;
     if (currentBaseRawModelId) {
       if (currentThinkingOptions.length > 0) {
         nextThinkingOptionsByModel[currentBaseRawModelId] = currentThinkingOptions;
-      } else if (!acpModelThinkingOptions[currentBaseRawModelId]) {
-        // Dropping a stale list stays the behaviour when nothing describes this
-        // model, but session/new carries the per-model levels without any
-        // thought_level option, so a report must not be deleted as if absent.
+      } else if (describesSession && !acpModelThinkingOptions[currentBaseRawModelId]) {
         delete nextThinkingOptionsByModel[currentBaseRawModelId];
       }
     }

--- a/src/providers/grok/runtime/GrokChatRuntime.ts
+++ b/src/providers/grok/runtime/GrokChatRuntime.ts
@@ -95,7 +95,6 @@ import {
   GROK_DEFAULT_THINKING_LEVEL,
   GROK_SYNTHETIC_MODEL_ID,
   type GrokDiscoveredModel,
-  type GrokThinkingOptionsByModel,
   isGrokModelSelectionId,
   normalizeGrokDiscoveredModels,
   normalizeGrokModelVariants,
@@ -392,6 +391,9 @@ export class GrokChatRuntime implements ChatRuntime {
     );
     const grokAuthPath = resolveGrokProviderAuthPath(this.plugin.settings, runtimeEnv);
 
+    // Already clamped to the selected model's levels: the settings snapshot
+    // runs effortLevel through getReasoningOptions for this model, which now
+    // reflects what the agent reported for it.
     const reasoningEffort = typeof providerSettings.effortLevel === 'string'
       ? providerSettings.effortLevel
       : null;
@@ -1219,15 +1221,20 @@ export class GrokChatRuntime implements ChatRuntime {
 
   private async syncSessionModelState(params: {
     configOptions?: AcpSessionConfigOption[] | null;
+    /**
+     * The agent's own `models` payload, not a normalized one: the per-model
+     * reasoning levels live in each entry's `_meta`, which normalizing strips.
+     * Both derivations happen here so no caller has to remember the second.
+     */
     models?: AcpSessionModelState | null;
-    modelThinkingOptions?: GrokThinkingOptionsByModel | null;
   }, options: {
     currentRawModelId?: string | null;
     seedActiveSelection?: boolean;
   } = {}): Promise<void> {
+    const rawModels = params.models ?? null;
     const acpState = extractAcpSessionModelState({
       configOptions: params.configOptions,
-      models: normalizeGrokAcpSessionModels(params.models),
+      models: normalizeGrokAcpSessionModels(rawModels),
     });
     const forcedCurrentRawModelId = typeof options.currentRawModelId === 'string'
       ? options.currentRawModelId.trim()
@@ -1262,39 +1269,52 @@ export class GrokChatRuntime implements ChatRuntime {
       })),
     );
     const currentThinkingLevel = thoughtLevelState.currentLevel;
-    this.currentSessionEffortConfigId = currentThinkingOptions.length > 0
-      ? thoughtLevelState.configId
-      : null;
-    this.currentSessionEffortValue = currentThinkingOptions.length > 0
-      ? currentThinkingLevel
-      : null;
-    this.currentSessionEffortValues = new Set(currentThinkingOptions.map((option) => option.value));
+    // Forgetting what the session said is only meaningful when this call
+    // carried something that speaks about levels. A plain model switch calls
+    // in with nothing at all.
+    const describesSession = params.configOptions !== undefined || params.models !== undefined;
+    if (currentThinkingOptions.length > 0) {
+      this.currentSessionEffortConfigId = thoughtLevelState.configId;
+      this.currentSessionEffortValue = currentThinkingLevel;
+      this.currentSessionEffortValues = new Set(currentThinkingOptions.map((option) => option.value));
+    } else if (describesSession) {
+      this.currentSessionEffortConfigId = null;
+      this.currentSessionEffortValue = null;
+      this.currentSessionEffortValues = new Set();
+    }
 
     // The agent reports the levels for every available model, so one session
     // makes the picker exact for models the user has not opened yet. The
     // `thought_level` option below still wins for the active model: it is the
     // live state of this session rather than a description of the catalog.
     const acpModelThinkingOptions = normalizeGrokThinkingOptionsByModel(
-      params.modelThinkingOptions ?? {},
+      readGrokAcpModelThinkingOptions(rawModels),
       discoveredModels,
     );
     const nextThinkingOptionsByModel = {
       ...currentSettings.thinkingOptionsByModel,
       ...acpModelThinkingOptions,
     };
-    // Forgetting a stale list is only meaningful when this call carried
-    // something that speaks about levels. A plain model switch calls in with
-    // nothing at all, and deleting on that would throw away what session/new
-    // reported the moment the user picks another model.
-    const describesSession = params.configOptions !== undefined
-      || params.models !== undefined
-      || params.modelThinkingOptions !== undefined;
     if (currentBaseRawModelId) {
       if (currentThinkingOptions.length > 0) {
         nextThinkingOptionsByModel[currentBaseRawModelId] = currentThinkingOptions;
       } else if (describesSession && !acpModelThinkingOptions[currentBaseRawModelId]) {
+        // Deleting on a call that said nothing would throw away what
+        // session/new reported the moment the user picks another model.
         delete nextThinkingOptionsByModel[currentBaseRawModelId];
       }
+    }
+
+    if (currentThinkingOptions.length === 0 && !describesSession && currentBaseRawModelId) {
+      // A model switch keeps the same session, so its thought-level option id
+      // still stands - clearing it would leave applySelectedEffort with nothing
+      // to call and the turn would silently run at the agent's default. Only
+      // the accepted values change with the model, and the effort has to be
+      // re-applied because the agent reverted to that model's own default.
+      this.currentSessionEffortValue = null;
+      this.currentSessionEffortValues = new Set(
+        (nextThinkingOptionsByModel[currentBaseRawModelId] ?? []).map((option) => option.value),
+      );
     }
 
     const discoveredBaseModelIds = buildGrokBaseModels(discoveredModels)
@@ -1398,6 +1418,7 @@ export class GrokChatRuntime implements ChatRuntime {
       await this.plugin.saveSettings();
     }
     this.refreshModelSelectors();
+  
   }
 
   private hydrateNativeModelCatalog(): void {
@@ -1566,8 +1587,7 @@ export class GrokChatRuntime implements ChatRuntime {
       this.updateSessionPaths(response.sessionId, cwd);
       await this.syncSessionModelState({
         configOptions: response.configOptions ?? null,
-        modelThinkingOptions: readGrokAcpModelThinkingOptions(response.models ?? null),
-        models: normalizeGrokAcpSessionModels(response.models ?? null),
+        models: response.models ?? null,
       });
       await this.syncSessionModeState({
         configOptions: response.configOptions ?? null,
@@ -1611,8 +1631,7 @@ export class GrokChatRuntime implements ChatRuntime {
       this.updateSessionPaths(response.sessionId, cwd);
       await this.syncSessionModelState({
         configOptions: response.configOptions ?? null,
-        modelThinkingOptions: readGrokAcpModelThinkingOptions(response.models ?? null),
-        models: normalizeGrokAcpSessionModels(response.models ?? null),
+        models: response.models ?? null,
       });
       await this.syncSessionModeState({
         configOptions: response.configOptions ?? null,

--- a/src/providers/grok/runtime/GrokChatRuntime.ts
+++ b/src/providers/grok/runtime/GrokChatRuntime.ts
@@ -95,9 +95,11 @@ import {
   GROK_DEFAULT_THINKING_LEVEL,
   GROK_SYNTHETIC_MODEL_ID,
   type GrokDiscoveredModel,
+  type GrokThinkingOptionsByModel,
   isGrokModelSelectionId,
   normalizeGrokDiscoveredModels,
   normalizeGrokModelVariants,
+  normalizeGrokThinkingOptionsByModel,
   resolveGrokBaseModelRawId,
 } from '../models';
 import {
@@ -144,7 +146,10 @@ import {
   isSupportedAcpSessionUpdate,
   parseGrokSessionNotification,
 } from './GrokSessionNotifications';
-import { normalizeGrokAcpSessionModels } from './normalizeGrokAcpSessionState';
+import {
+  normalizeGrokAcpSessionModels,
+  readGrokAcpModelThinkingOptions,
+} from './normalizeGrokAcpSessionState';
 
 /** Upper bound for an answer read back from Grok's own session log. */
 const GROK_RECOVERED_ANSWER_LIMIT_BYTES = 1_000_000;
@@ -1215,12 +1220,13 @@ export class GrokChatRuntime implements ChatRuntime {
   private async syncSessionModelState(params: {
     configOptions?: AcpSessionConfigOption[] | null;
     models?: AcpSessionModelState | null;
+    modelThinkingOptions?: GrokThinkingOptionsByModel | null;
   }, options: {
     currentRawModelId?: string | null;
     seedActiveSelection?: boolean;
   } = {}): Promise<void> {
     const acpState = extractAcpSessionModelState({
-      ...params,
+      configOptions: params.configOptions,
       models: normalizeGrokAcpSessionModels(params.models),
     });
     const forcedCurrentRawModelId = typeof options.currentRawModelId === 'string'
@@ -1264,11 +1270,25 @@ export class GrokChatRuntime implements ChatRuntime {
       : null;
     this.currentSessionEffortValues = new Set(currentThinkingOptions.map((option) => option.value));
 
-    const nextThinkingOptionsByModel = { ...currentSettings.thinkingOptionsByModel };
+    // The agent reports the levels for every available model, so one session
+    // makes the picker exact for models the user has not opened yet. The
+    // `thought_level` option below still wins for the active model: it is the
+    // live state of this session rather than a description of the catalog.
+    const acpModelThinkingOptions = normalizeGrokThinkingOptionsByModel(
+      params.modelThinkingOptions ?? {},
+      discoveredModels,
+    );
+    const nextThinkingOptionsByModel = {
+      ...currentSettings.thinkingOptionsByModel,
+      ...acpModelThinkingOptions,
+    };
     if (currentBaseRawModelId) {
       if (currentThinkingOptions.length > 0) {
         nextThinkingOptionsByModel[currentBaseRawModelId] = currentThinkingOptions;
-      } else {
+      } else if (!acpModelThinkingOptions[currentBaseRawModelId]) {
+        // Dropping a stale list stays the behaviour when nothing describes this
+        // model, but session/new carries the per-model levels without any
+        // thought_level option, so a report must not be deleted as if absent.
         delete nextThinkingOptionsByModel[currentBaseRawModelId];
       }
     }
@@ -1542,6 +1562,7 @@ export class GrokChatRuntime implements ChatRuntime {
       this.updateSessionPaths(response.sessionId, cwd);
       await this.syncSessionModelState({
         configOptions: response.configOptions ?? null,
+        modelThinkingOptions: readGrokAcpModelThinkingOptions(response.models ?? null),
         models: normalizeGrokAcpSessionModels(response.models ?? null),
       });
       await this.syncSessionModeState({
@@ -1586,6 +1607,7 @@ export class GrokChatRuntime implements ChatRuntime {
       this.updateSessionPaths(response.sessionId, cwd);
       await this.syncSessionModelState({
         configOptions: response.configOptions ?? null,
+        modelThinkingOptions: readGrokAcpModelThinkingOptions(response.models ?? null),
         models: normalizeGrokAcpSessionModels(response.models ?? null),
       });
       await this.syncSessionModeState({

--- a/src/providers/grok/runtime/normalizeGrokAcpSessionState.ts
+++ b/src/providers/grok/runtime/normalizeGrokAcpSessionState.ts
@@ -64,17 +64,46 @@ export function readGrokAcpModelThinkingOptions(
   for (const model of rawModels) {
     const rawId = readNonEmptyString(model.id) ?? readNonEmptyString(model.modelId);
     const meta = model._meta;
-    if (!rawId || !meta || typeof meta !== 'object' || Array.isArray(meta)) {
+    // Model ids come from the agent, so they are untrusted keys: one named
+    // `__proto__` would set this object's prototype instead of adding an entry.
+    if (!rawId || UNSAFE_MODEL_KEYS.has(rawId) || !meta || typeof meta !== 'object' || Array.isArray(meta)) {
       continue;
     }
 
-    const variants = normalizeGrokModelVariants((meta as Record<string, unknown>).reasoningEfforts);
+    const variants = normalizeGrokModelVariants(
+      readReasoningEffortEntries((meta as Record<string, unknown>).reasoningEfforts),
+    );
     if (variants.length > 0) {
       optionsByModel[rawId] = variants;
     }
   }
 
   return optionsByModel;
+}
+
+const UNSAFE_MODEL_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
+/**
+ * The captured frames carry each level as both `id` and `value`. Only `value`
+ * is read downstream, and the `thought_level` config option names the same
+ * field `id`, so a build that settles on `id` alone must not silently read as
+ * "this model reports no levels".
+ */
+function readReasoningEffortEntries(value: unknown): unknown[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return (value as unknown[]).map((entry): unknown => {
+    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
+      return entry;
+    }
+
+    const record = entry as Record<string, unknown>;
+    return typeof record.value === 'string' && record.value.trim()
+      ? record
+      : { ...record, value: record.id };
+  });
 }
 
 function readNonEmptyString(value: unknown): string | null {

--- a/src/providers/grok/runtime/normalizeGrokAcpSessionState.ts
+++ b/src/providers/grok/runtime/normalizeGrokAcpSessionState.ts
@@ -70,6 +70,13 @@ export function readGrokAcpModelThinkingOptions(
       continue;
     }
 
+    // A model can carry a vestigial level list while stating it takes no
+    // reasoning effort at all. Honouring the flag keeps the composer from
+    // showing effort controls that the model would only reject.
+    if ((meta as Record<string, unknown>).supportsReasoningEffort === false) {
+      continue;
+    }
+
     const variants = normalizeGrokModelVariants(
       readReasoningEffortEntries((meta as Record<string, unknown>).reasoningEfforts),
     );

--- a/src/providers/grok/runtime/normalizeGrokAcpSessionState.ts
+++ b/src/providers/grok/runtime/normalizeGrokAcpSessionState.ts
@@ -1,6 +1,8 @@
 import type { AcpSessionModelState } from '../../acp';
+import { type GrokThinkingOptionsByModel, normalizeGrokModelVariants } from '../models';
 
 type GrokAcpModelRecord = {
+  _meta?: unknown;
   description?: unknown;
   id?: unknown;
   modelId?: unknown;
@@ -38,6 +40,41 @@ export function normalizeGrokAcpSessionModels(
     availableModels,
     currentModelId,
   };
+}
+
+/**
+ * Grok Build states, per available model, which reasoning levels that model
+ * accepts - `session/new` and `session/load` both carry it in each model's
+ * `_meta`, and for every model rather than only the current one. The
+ * `thought_level` config option speaks for the active model alone, so without
+ * this the picker has to guess from the model id for every other model, and a
+ * guess is wrong whenever two native models differ: grok-4.6 takes `xhigh`
+ * while grok-4.5 offers only high/medium/low. Reading the levels the agent
+ * reports keeps the picker exact and lets a future model arrive with its own
+ * set without a code change.
+ */
+export function readGrokAcpModelThinkingOptions(
+  models: AcpSessionModelState | null | undefined,
+): GrokThinkingOptionsByModel {
+  const rawModels = Array.isArray(models?.availableModels)
+    ? models.availableModels as GrokAcpModelRecord[]
+    : [];
+
+  const optionsByModel: GrokThinkingOptionsByModel = {};
+  for (const model of rawModels) {
+    const rawId = readNonEmptyString(model.id) ?? readNonEmptyString(model.modelId);
+    const meta = model._meta;
+    if (!rawId || !meta || typeof meta !== 'object' || Array.isArray(meta)) {
+      continue;
+    }
+
+    const variants = normalizeGrokModelVariants((meta as Record<string, unknown>).reasoningEfforts);
+    if (variants.length > 0) {
+      optionsByModel[rawId] = variants;
+    }
+  }
+
+  return optionsByModel;
 }
 
 function readNonEmptyString(value: unknown): string | null {

--- a/src/providers/grok/ui/GrokChatUIConfig.ts
+++ b/src/providers/grok/ui/GrokChatUIConfig.ts
@@ -33,6 +33,18 @@ const GROK_FALLBACK_THINKING_OPTIONS: ProviderReasoningOption[] = [
   { value: 'high', label: 'High' },
 ];
 const GROK_FALLBACK_THINKING_DEFAULT = 'high';
+
+/**
+ * The bare `grok` option carries no `grok:` prefix, so decoding it yields
+ * nothing and the effort picker fell through to the three-level fallback - on a
+ * fresh vault that entry is the only model shown, which is exactly when the
+ * fallback matters most. It stands for Grok Build itself, so it resolves to the
+ * native id.
+ */
+function decodeGrokModelIdOrSynthetic(model: string): string | null {
+  return decodeGrokModelId(model)
+    ?? (model.trim() === GROK_SYNTHETIC_MODEL_ID ? GROK_SYNTHETIC_MODEL_ID : null);
+}
 const DEFAULT_CONTEXT_WINDOW = 200_000;
 
 const GROK_PERMISSION_MODE_TOGGLE: ProviderPermissionModeToggleConfig = {
@@ -138,7 +150,7 @@ export const grokChatUIConfig: ProviderChatUIConfig = {
   },
 
   getDefaultReasoningValue(model: string, settings: Record<string, unknown>): string {
-    const rawModelId = decodeGrokModelId(model);
+    const rawModelId = decodeGrokModelIdOrSynthetic(model);
     if (!rawModelId) {
       return GROK_FALLBACK_THINKING_DEFAULT;
     }
@@ -290,19 +302,16 @@ function getDefaultThinkingLevelForModel(
     return preferred;
   }
 
-  if (isGrokNativeModelId(baseRawId)) {
-    return (preferred && supportedValues.has(preferred)
-      ? preferred
-      : (supportedValues.has(GROK_NATIVE_THINKING_DEFAULT)
-        ? GROK_NATIVE_THINKING_DEFAULT
-        : options[0]?.value))
-      ?? GROK_NATIVE_THINKING_DEFAULT;
-  }
+  // A preferred level that the model supports already returned above, so both
+  // branches reduce to "the model's own default, else its lowest level".
+  const [fallbackDefault, lastResort] = isGrokNativeModelId(baseRawId)
+    ? [GROK_NATIVE_THINKING_DEFAULT, GROK_NATIVE_THINKING_DEFAULT]
+    : [GROK_FALLBACK_THINKING_DEFAULT, GROK_DEFAULT_THINKING_LEVEL];
 
-  return (supportedValues.has(GROK_FALLBACK_THINKING_DEFAULT)
-    ? GROK_FALLBACK_THINKING_DEFAULT
+  return (supportedValues.has(fallbackDefault)
+    ? fallbackDefault
     : options[0]?.value)
-    ?? GROK_DEFAULT_THINKING_LEVEL;
+    ?? lastResort;
 }
 
 function getSupportedThinkingOptionsForModel(
@@ -330,7 +339,7 @@ function getGrokThinkingOptions(
     return [];
   }
 
-  const rawModelId = decodeGrokModelId(model);
+  const rawModelId = decodeGrokModelIdOrSynthetic(model);
   if (!rawModelId) {
     return GROK_FALLBACK_THINKING_OPTIONS;
   }

--- a/src/providers/grok/ui/GrokChatUIConfig.ts
+++ b/src/providers/grok/ui/GrokChatUIConfig.ts
@@ -14,7 +14,7 @@ import {
   GROK_NATIVE_THINKING_OPTIONS,
   GROK_SYNTHETIC_MODEL_ID,
   isGrokModelSelectionId,
-  isGrokNativeBuildModelId,
+  isGrokNativeModelId,
   resolveGrokBaseModelRawId,
 } from '../models';
 import {
@@ -290,7 +290,7 @@ function getDefaultThinkingLevelForModel(
     return preferred;
   }
 
-  if (isGrokNativeBuildModelId(baseRawId)) {
+  if (isGrokNativeModelId(baseRawId)) {
     return (preferred && supportedValues.has(preferred)
       ? preferred
       : (supportedValues.has(GROK_NATIVE_THINKING_DEFAULT)
@@ -315,7 +315,7 @@ function getSupportedThinkingOptionsForModel(
     return discoveredOptions;
   }
 
-  if (isGrokNativeBuildModelId(baseRawId)) {
+  if (isGrokNativeModelId(baseRawId)) {
     return GROK_NATIVE_THINKING_OPTIONS;
   }
 

--- a/tests/unit/providers/grok/GrokChatRuntime.test.ts
+++ b/tests/unit/providers/grok/GrokChatRuntime.test.ts
@@ -1522,6 +1522,143 @@ describe('GrokChatRuntime', () => {
     expect(refreshModelSelector).toHaveBeenCalledTimes(1);
   });
 
+  it('records the reasoning levels each available model reports, not only the active one', async () => {
+    const plugin = createMockPlugin({
+      settings: {
+        model: 'grok:grok-4.6',
+        providerConfigs: {
+          grok: {
+            discoveredModels: [],
+            preferredThinkingByModel: {},
+            visibleModels: [],
+          },
+        },
+        settingsProvider: 'grok',
+      },
+    });
+    const runtime = new GrokChatRuntime(plugin);
+    jest.spyOn(ProviderRegistry, 'resolveSettingsProviderId').mockReturnValue('grok');
+
+    // Shape taken from a live session/new response: the agent states the levels
+    // for every model it offers, so one session settles the whole picker.
+    await (runtime as any).syncSessionModelState({
+      models: {
+        availableModels: [
+          { modelId: 'grok-4.6', name: 'Grok 4.6' },
+          { modelId: 'grok-4.5', name: 'Grok 4.5' },
+        ],
+        currentModelId: 'grok-4.6',
+      },
+      modelThinkingOptions: {
+        'grok-4.5': [
+          { label: 'High Effort', value: 'high' },
+          { label: 'Medium Effort', value: 'medium' },
+          { label: 'Low Effort', value: 'low' },
+        ],
+        'grok-4.6': [
+          { label: 'Extra High Effort', value: 'xhigh' },
+          { label: 'High Effort', value: 'high' },
+          { label: 'Medium Effort', value: 'medium' },
+          { label: 'Low Effort', value: 'low' },
+        ],
+      },
+    });
+
+    const thinkingOptions = getGrokProviderSettings(plugin.settings).thinkingOptionsByModel;
+    expect(thinkingOptions['grok-4.6'].map((variant) => variant.value)).toEqual([
+      'low',
+      'medium',
+      'high',
+      'xhigh',
+    ]);
+    // grok-4.5 was never the active model, and it must still not be offered a
+    // level Grok Build refuses for it.
+    expect(thinkingOptions['grok-4.5'].map((variant) => variant.value)).toEqual([
+      'low',
+      'medium',
+      'high',
+    ]);
+  });
+
+  it('lets the live thought-level option override the reported levels for the active model', async () => {
+    const plugin = createMockPlugin({
+      settings: {
+        model: 'grok:grok-4.6',
+        providerConfigs: {
+          grok: {
+            discoveredModels: [],
+            preferredThinkingByModel: {},
+            visibleModels: [],
+          },
+        },
+        settingsProvider: 'grok',
+      },
+    });
+    const runtime = new GrokChatRuntime(plugin);
+    jest.spyOn(ProviderRegistry, 'resolveSettingsProviderId').mockReturnValue('grok');
+
+    await (runtime as any).syncSessionModelState({
+      configOptions: [
+        {
+          category: 'thought_level',
+          currentValue: 'high',
+          id: 'effort',
+          name: 'Effort',
+          options: [
+            { name: 'High', value: 'high' },
+            { name: 'Low', value: 'low' },
+          ],
+          type: 'select',
+        },
+      ],
+      models: {
+        availableModels: [{ modelId: 'grok-4.6', name: 'Grok 4.6' }],
+        currentModelId: 'grok-4.6',
+      },
+      modelThinkingOptions: {
+        'grok-4.6': [
+          { label: 'Extra High Effort', value: 'xhigh' },
+          { label: 'High Effort', value: 'high' },
+        ],
+      },
+    });
+
+    // The option describes this session as it is now, the report describes the
+    // catalog, so the session wins where they disagree.
+    expect(getGrokProviderSettings(plugin.settings).thinkingOptionsByModel['grok-4.6']
+      .map((variant) => variant.value)).toEqual(['low', 'high']);
+  });
+
+  it('still forgets a stale level list when nothing in the session describes the model', async () => {
+    const plugin = createMockPlugin({
+      settings: {
+        model: 'grok:grok-4.6',
+        providerConfigs: {
+          grok: {
+            discoveredModels: [{ label: 'Grok 4.6', rawId: 'grok-4.6' }],
+            preferredThinkingByModel: {},
+            thinkingOptionsByModel: {
+              'grok-4.6': [{ label: 'Extra high', value: 'xhigh' }],
+            },
+            visibleModels: ['grok-4.6'],
+          },
+        },
+        settingsProvider: 'grok',
+      },
+    });
+    const runtime = new GrokChatRuntime(plugin);
+    jest.spyOn(ProviderRegistry, 'resolveSettingsProviderId').mockReturnValue('grok');
+
+    await (runtime as any).syncSessionModelState({
+      models: {
+        availableModels: [{ modelId: 'grok-4.6', name: 'Grok 4.6' }],
+        currentModelId: 'grok-4.6',
+      },
+    });
+
+    expect(getGrokProviderSettings(plugin.settings).thinkingOptionsByModel['grok-4.6']).toBeUndefined();
+  });
+
   it('warms selected model metadata through Grok session/set_model', async () => {
     const plugin = createMockPlugin({
       settings: {

--- a/tests/unit/providers/grok/GrokChatRuntime.test.ts
+++ b/tests/unit/providers/grok/GrokChatRuntime.test.ts
@@ -1544,23 +1544,33 @@ describe('GrokChatRuntime', () => {
     await (runtime as any).syncSessionModelState({
       models: {
         availableModels: [
-          { modelId: 'grok-4.6', name: 'Grok 4.6' },
-          { modelId: 'grok-4.5', name: 'Grok 4.5' },
+          {
+            modelId: 'grok-4.6',
+            name: 'Grok 4.6',
+            _meta: {
+              supportsReasoningEffort: true,
+              reasoningEfforts: [
+                { id: 'xhigh', value: 'xhigh', label: 'Extra High Effort' },
+                { id: 'high', value: 'high', label: 'High Effort' },
+                { id: 'medium', value: 'medium', label: 'Medium Effort' },
+                { id: 'low', value: 'low', label: 'Low Effort' },
+              ],
+            },
+          },
+          {
+            modelId: 'grok-4.5',
+            name: 'Grok 4.5',
+            _meta: {
+              supportsReasoningEffort: true,
+              reasoningEfforts: [
+                { id: 'high', value: 'high', label: 'High Effort' },
+                { id: 'medium', value: 'medium', label: 'Medium Effort' },
+                { id: 'low', value: 'low', label: 'Low Effort' },
+              ],
+            },
+          },
         ],
         currentModelId: 'grok-4.6',
-      },
-      modelThinkingOptions: {
-        'grok-4.5': [
-          { label: 'High Effort', value: 'high' },
-          { label: 'Medium Effort', value: 'medium' },
-          { label: 'Low Effort', value: 'low' },
-        ],
-        'grok-4.6': [
-          { label: 'Extra High Effort', value: 'xhigh' },
-          { label: 'High Effort', value: 'high' },
-          { label: 'Medium Effort', value: 'medium' },
-          { label: 'Low Effort', value: 'low' },
-        ],
       },
     });
 
@@ -1612,14 +1622,19 @@ describe('GrokChatRuntime', () => {
         },
       ],
       models: {
-        availableModels: [{ modelId: 'grok-4.6', name: 'Grok 4.6' }],
-        currentModelId: 'grok-4.6',
-      },
-      modelThinkingOptions: {
-        'grok-4.6': [
-          { label: 'Extra High Effort', value: 'xhigh' },
-          { label: 'High Effort', value: 'high' },
+        availableModels: [
+          {
+            modelId: 'grok-4.6',
+            name: 'Grok 4.6',
+            _meta: {
+              reasoningEfforts: [
+                { id: 'xhigh', value: 'xhigh', label: 'Extra High Effort' },
+                { id: 'high', value: 'high', label: 'High Effort' },
+              ],
+            },
+          },
         ],
+        currentModelId: 'grok-4.6',
       },
     });
 
@@ -1659,6 +1674,100 @@ describe('GrokChatRuntime', () => {
     expect(getGrokProviderSettings(plugin.settings).thinkingOptionsByModel['grok-4.6']).toBeUndefined();
   });
 
+  it('keeps the thought-level option alive across a model switch', async () => {
+    const plugin = createMockPlugin({
+      settings: {
+        effortLevel: 'high',
+        model: 'grok:grok-4.6',
+        providerConfigs: {
+          grok: { discoveredModels: [], preferredThinkingByModel: {}, visibleModels: [] },
+        },
+        settingsProvider: 'grok',
+      },
+    });
+    const runtime = new GrokChatRuntime(plugin);
+    jest.spyOn(ProviderRegistry, 'resolveSettingsProviderId').mockReturnValue('grok');
+
+    await (runtime as any).syncSessionModelState({
+      configOptions: [
+        {
+          category: 'thought_level',
+          currentValue: 'xhigh',
+          id: 'effort',
+          name: 'Effort',
+          options: [{ name: 'High', value: 'high' }, { name: 'Extra high', value: 'xhigh' }],
+          type: 'select',
+        },
+      ],
+      models: {
+        availableModels: [
+          { modelId: 'grok-4.6', name: 'Grok 4.6' },
+          {
+            modelId: 'grok-4.5',
+            name: 'Grok 4.5',
+            _meta: {
+              reasoningEfforts: [
+                { id: 'high', value: 'high', label: 'High Effort' },
+                { id: 'low', value: 'low', label: 'Low Effort' },
+              ],
+            },
+          },
+        ],
+        currentModelId: 'grok-4.6',
+      },
+    });
+    expect((runtime as any).currentSessionEffortConfigId).toBe('effort');
+
+    await (runtime as any).syncSessionModelState({}, { currentRawModelId: 'grok-4.5' });
+
+    // Same session, so the option id still stands - dropping it would leave
+    // applySelectedEffort with nothing to call.
+    expect((runtime as any).currentSessionEffortConfigId).toBe('effort');
+    // The accepted values follow the new model, and the effort must be applied
+    // again because the agent reverted to that model's default.
+    expect([...(runtime as any).currentSessionEffortValues]).toEqual(['low', 'high']);
+    expect((runtime as any).currentSessionEffortValue).toBeNull();
+  });
+
+  it('never launches with a level the selected model does not report', () => {
+    const plugin = createMockPlugin({
+      settings: {
+        effortLevel: 'xhigh',
+        model: 'grok:grok-4.5',
+        providerConfigs: {
+          grok: {
+            discoveredModels: [
+              { label: 'Grok 4.6', rawId: 'grok-4.6' },
+              { label: 'Grok 4.5', rawId: 'grok-4.5' },
+            ],
+            thinkingOptionsByModel: {
+              'grok-4.5': [
+                { label: 'Low', value: 'low' },
+                { label: 'High', value: 'high' },
+              ],
+              'grok-4.6': [
+                { label: 'High', value: 'high' },
+                { label: 'Extra high', value: 'xhigh' },
+              ],
+            },
+            visibleModels: ['grok-4.6', 'grok-4.5'],
+          },
+        },
+        settingsProvider: 'grok',
+      },
+    });
+    const runtime = new GrokChatRuntime(plugin);
+    jest.spyOn(ProviderRegistry, 'resolveSettingsProviderId').mockReturnValue('grok');
+
+    // The settings snapshot that feeds the launch args runs effortLevel through
+    // getReasoningOptions for the selected model, so a stored xhigh cannot
+    // reach `--reasoning-effort` for a model that never reported it.
+    expect((runtime as any).getProviderSettings().effortLevel).toBe('high');
+
+    plugin.settings.model = 'grok:grok-4.6';
+    expect((runtime as any).getProviderSettings().effortLevel).toBe('xhigh');
+  });
+
   it('keeps the reported levels when the user switches to another model', async () => {
     const plugin = createMockPlugin({
       settings: {
@@ -1679,20 +1788,28 @@ describe('GrokChatRuntime', () => {
     await (runtime as any).syncSessionModelState({
       models: {
         availableModels: [
-          { modelId: 'grok-4.6', name: 'Grok 4.6' },
-          { modelId: 'grok-4.5', name: 'Grok 4.5' },
+          {
+            modelId: 'grok-4.6',
+            name: 'Grok 4.6',
+            _meta: {
+              reasoningEfforts: [
+                { id: 'xhigh', value: 'xhigh', label: 'Extra High Effort' },
+                { id: 'low', value: 'low', label: 'Low Effort' },
+              ],
+            },
+          },
+          {
+            modelId: 'grok-4.5',
+            name: 'Grok 4.5',
+            _meta: {
+              reasoningEfforts: [
+                { id: 'high', value: 'high', label: 'High Effort' },
+                { id: 'low', value: 'low', label: 'Low Effort' },
+              ],
+            },
+          },
         ],
         currentModelId: 'grok-4.6',
-      },
-      modelThinkingOptions: {
-        'grok-4.5': [
-          { label: 'High Effort', value: 'high' },
-          { label: 'Low Effort', value: 'low' },
-        ],
-        'grok-4.6': [
-          { label: 'Extra High Effort', value: 'xhigh' },
-          { label: 'Low Effort', value: 'low' },
-        ],
       },
     });
 

--- a/tests/unit/providers/grok/GrokChatRuntime.test.ts
+++ b/tests/unit/providers/grok/GrokChatRuntime.test.ts
@@ -1659,6 +1659,52 @@ describe('GrokChatRuntime', () => {
     expect(getGrokProviderSettings(plugin.settings).thinkingOptionsByModel['grok-4.6']).toBeUndefined();
   });
 
+  it('keeps the reported levels when the user switches to another model', async () => {
+    const plugin = createMockPlugin({
+      settings: {
+        model: 'grok:grok-4.6',
+        providerConfigs: {
+          grok: {
+            discoveredModels: [],
+            preferredThinkingByModel: {},
+            visibleModels: [],
+          },
+        },
+        settingsProvider: 'grok',
+      },
+    });
+    const runtime = new GrokChatRuntime(plugin);
+    jest.spyOn(ProviderRegistry, 'resolveSettingsProviderId').mockReturnValue('grok');
+
+    await (runtime as any).syncSessionModelState({
+      models: {
+        availableModels: [
+          { modelId: 'grok-4.6', name: 'Grok 4.6' },
+          { modelId: 'grok-4.5', name: 'Grok 4.5' },
+        ],
+        currentModelId: 'grok-4.6',
+      },
+      modelThinkingOptions: {
+        'grok-4.5': [
+          { label: 'High Effort', value: 'high' },
+          { label: 'Low Effort', value: 'low' },
+        ],
+        'grok-4.6': [
+          { label: 'Extra High Effort', value: 'xhigh' },
+          { label: 'Low Effort', value: 'low' },
+        ],
+      },
+    });
+
+    // Switching models calls in with nothing to say about levels, which must
+    // not be read as "this model has none".
+    await (runtime as any).syncSessionModelState({}, { currentRawModelId: 'grok-4.5' });
+
+    const thinkingOptions = getGrokProviderSettings(plugin.settings).thinkingOptionsByModel;
+    expect(thinkingOptions['grok-4.5'].map((variant) => variant.value)).toEqual(['low', 'high']);
+    expect(thinkingOptions['grok-4.6'].map((variant) => variant.value)).toEqual(['low', 'xhigh']);
+  });
+
   it('warms selected model metadata through Grok session/set_model', async () => {
     const plugin = createMockPlugin({
       settings: {

--- a/tests/unit/providers/grok/GrokLaunchArgs.test.ts
+++ b/tests/unit/providers/grok/GrokLaunchArgs.test.ts
@@ -33,5 +33,11 @@ describe('GrokLaunchArgs', () => {
       'high',
       'stdio',
     ]);
+    expect(buildGrokAgentProcessArgs('xhigh')).toEqual([
+      'agent',
+      '--reasoning-effort',
+      'xhigh',
+      'stdio',
+    ]);
   });
 });

--- a/tests/unit/providers/grok/models.test.ts
+++ b/tests/unit/providers/grok/models.test.ts
@@ -9,6 +9,8 @@ import {
   GROK_SYNTHETIC_MODEL_ID,
   groupGrokDiscoveredModels,
   isGrokModelSelectionId,
+  isGrokNativeBuildModelId,
+  isGrokNativeModelId,
   resolveGrokBaseModelRawId,
   splitGrokModelLabel,
 } from '../../../../src/providers/grok/models';
@@ -21,6 +23,17 @@ describe('Grok Build model identity', () => {
     expect(decodeGrokModelId(GROK_SYNTHETIC_MODEL_ID)).toBeNull();
     expect(isGrokModelSelectionId('grok:anthropic/claude-sonnet-4')).toBe(true);
     expect(isGrokModelSelectionId('claude-sonnet-4')).toBe(false);
+  });
+
+  it('treats catalog Grok models as native xAI ids', () => {
+    expect(isGrokNativeModelId('grok-4.6')).toBe(true);
+    expect(isGrokNativeModelId('grok-4.5')).toBe(true);
+    expect(isGrokNativeModelId('grok-build')).toBe(true);
+    expect(isGrokNativeModelId('grok-composer-2.5-fast')).toBe(true);
+    expect(isGrokNativeModelId('anthropic/claude-sonnet-4')).toBe(false);
+    expect(isGrokNativeModelId('minimax-token-plan/minimax-m2')).toBe(false);
+    expect(isGrokNativeBuildModelId('grok-4.6')).toBe(false);
+    expect(isGrokNativeBuildModelId('grok-build')).toBe(true);
   });
 });
 
@@ -263,6 +276,45 @@ describe('grokChatUIConfig', () => {
     ]);
     expect(grokChatUIConfig.getDefaultReasoningValue(
       'grok:grok-build',
+      settings,
+    )).toBe('high');
+  });
+
+  it('exposes xhigh effort for catalog Grok models such as grok-4.6', () => {
+    const settings = {
+      model: 'grok:grok-4.6',
+      providerConfigs: {
+        grok: {
+          discoveredModels: [
+            { label: 'Grok 4.6', rawId: 'grok-4.6' },
+            { label: 'Grok 4.5', rawId: 'grok-4.5' },
+          ],
+          visibleModels: ['grok-4.6', 'grok-4.5'],
+          thinkingOptionsByModel: {},
+        },
+      },
+    };
+
+    expect(grokChatUIConfig.getReasoningOptions(
+      'grok:grok-4.6',
+      settings,
+    )).toEqual([
+      { label: 'Low', value: 'low' },
+      { label: 'Medium', value: 'medium' },
+      { label: 'High', value: 'high' },
+      { label: 'Extra high', value: 'xhigh' },
+    ]);
+    expect(grokChatUIConfig.getReasoningOptions(
+      'grok:grok-4.5',
+      settings,
+    )).toEqual([
+      { label: 'Low', value: 'low' },
+      { label: 'Medium', value: 'medium' },
+      { label: 'High', value: 'high' },
+      { label: 'Extra high', value: 'xhigh' },
+    ]);
+    expect(grokChatUIConfig.getDefaultReasoningValue(
+      'grok:grok-4.6',
       settings,
     )).toBe('high');
   });

--- a/tests/unit/providers/grok/models.test.ts
+++ b/tests/unit/providers/grok/models.test.ts
@@ -319,6 +319,43 @@ describe('grokChatUIConfig', () => {
     )).toBe('high');
   });
 
+  it('drops xhigh for a catalog model once Grok Build reports its own levels', () => {
+    const settings = {
+      model: 'grok:grok-4.5',
+      providerConfigs: {
+        grok: {
+          discoveredModels: [
+            { label: 'Grok 4.6', rawId: 'grok-4.6' },
+            { label: 'Grok 4.5', rawId: 'grok-4.5' },
+          ],
+          visibleModels: ['grok-4.6', 'grok-4.5'],
+          // What a live session/new reports: grok-4.5 has no xhigh, grok-4.6 does.
+          thinkingOptionsByModel: {
+            'grok-4.5': [
+              { label: 'Low', value: 'low' },
+              { label: 'Medium', value: 'medium' },
+              { label: 'High', value: 'high' },
+            ],
+            'grok-4.6': [
+              { label: 'Low', value: 'low' },
+              { label: 'Medium', value: 'medium' },
+              { label: 'High', value: 'high' },
+              { label: 'Extra high', value: 'xhigh' },
+            ],
+          },
+        },
+      },
+    };
+
+    // The reported list wins over the static one the picker falls back to
+    // before any session has run.
+    expect(grokChatUIConfig.getReasoningOptions('grok:grok-4.5', settings)
+      .map((option) => option.value)).toEqual(['low', 'medium', 'high']);
+    expect(grokChatUIConfig.getReasoningOptions('grok:grok-4.6', settings)
+      .map((option) => option.value)).toEqual(['low', 'medium', 'high', 'xhigh']);
+    expect(grokChatUIConfig.getDefaultReasoningValue('grok:grok-4.5', settings)).toBe('high');
+  });
+
   it('keeps at least three Grok Build effort choices before thought-level discovery finishes', () => {
     const settings = {
       model: 'grok:minimax-token-plan/minimax-m2',

--- a/tests/unit/providers/grok/models.test.ts
+++ b/tests/unit/providers/grok/models.test.ts
@@ -9,7 +9,6 @@ import {
   GROK_SYNTHETIC_MODEL_ID,
   groupGrokDiscoveredModels,
   isGrokModelSelectionId,
-  isGrokNativeBuildModelId,
   isGrokNativeModelId,
   resolveGrokBaseModelRawId,
   splitGrokModelLabel,
@@ -32,8 +31,13 @@ describe('Grok Build model identity', () => {
     expect(isGrokNativeModelId('grok-composer-2.5-fast')).toBe(true);
     expect(isGrokNativeModelId('anthropic/claude-sonnet-4')).toBe(false);
     expect(isGrokNativeModelId('minimax-token-plan/minimax-m2')).toBe(false);
-    expect(isGrokNativeBuildModelId('grok-4.6')).toBe(false);
-    expect(isGrokNativeBuildModelId('grok-build')).toBe(true);
+  });
+
+  it('recognises a native id whatever case the catalog reports it in', () => {
+    expect(isGrokNativeModelId('Grok-4.6')).toBe(true);
+    expect(isGrokNativeModelId('GROK-4.6')).toBe(true);
+    expect(isGrokNativeModelId('Grok')).toBe(true);
+    expect(isGrokNativeModelId('Anthropic/Claude-Sonnet-4')).toBe(false);
   });
 });
 
@@ -317,6 +321,16 @@ describe('grokChatUIConfig', () => {
       'grok:grok-4.6',
       settings,
     )).toBe('high');
+  });
+
+  it('offers the native levels for the bare Grok Build entry on a fresh vault', () => {
+    // Nothing discovered yet, so the model picker shows only the synthetic
+    // `grok` option - the state where a static list is all there is.
+    const settings = { model: 'grok', providerConfigs: { grok: {} } };
+
+    expect(grokChatUIConfig.getReasoningOptions('grok', settings)
+      .map((option) => option.value)).toEqual(['low', 'medium', 'high', 'xhigh']);
+    expect(grokChatUIConfig.getDefaultReasoningValue('grok', settings)).toBe('high');
   });
 
   it('drops xhigh for a catalog model once Grok Build reports its own levels', () => {

--- a/tests/unit/providers/grok/normalizeGrokAcpSessionState.test.ts
+++ b/tests/unit/providers/grok/normalizeGrokAcpSessionState.test.ts
@@ -139,6 +139,22 @@ describe('readGrokAcpModelThinkingOptions', () => {
     } as never)['grok-4.6'].map((variant) => variant.value)).toEqual(['low', 'high']);
   });
 
+  it('ignores a level list from a model that says it takes no reasoning effort', () => {
+    expect(readGrokAcpModelThinkingOptions({
+      availableModels: [
+        {
+          modelId: 'grok-code-fast-1',
+          name: 'Grok Code Fast 1',
+          _meta: {
+            supportsReasoningEffort: false,
+            reasoningEfforts: [{ id: 'high', value: 'high', label: 'High Effort' }],
+          },
+        },
+      ],
+      currentModelId: 'grok-code-fast-1',
+    } as never)).toEqual({});
+  });
+
   it('refuses a model id that would reach through the prototype', () => {
     const options = readGrokAcpModelThinkingOptions({
       availableModels: [

--- a/tests/unit/providers/grok/normalizeGrokAcpSessionState.test.ts
+++ b/tests/unit/providers/grok/normalizeGrokAcpSessionState.test.ts
@@ -1,4 +1,46 @@
-import { normalizeGrokAcpSessionModels } from '../../../../src/providers/grok/runtime/normalizeGrokAcpSessionState';
+import {
+  normalizeGrokAcpSessionModels,
+  readGrokAcpModelThinkingOptions,
+} from '../../../../src/providers/grok/runtime/normalizeGrokAcpSessionState';
+
+// Copied from a live `grok agent stdio` session/new response (Grok Build 1.0.5).
+// grok-4.6 accepts xhigh, grok-4.5 does not - the difference the picker cannot
+// derive from the model id.
+const LIVE_SESSION_MODELS = {
+  availableModels: [
+    {
+      modelId: 'grok-4.6',
+      name: 'Grok 4.6',
+      description: "SpaceXAI's latest frontier model",
+      _meta: {
+        totalContextTokens: 500000,
+        supportsReasoningEffort: true,
+        reasoningEffort: 'xhigh',
+        reasoningEfforts: [
+          { id: 'xhigh', value: 'xhigh', label: 'Extra High Effort', description: 'Highest effort and reasoning level', default: false },
+          { id: 'high', value: 'high', label: 'High Effort', description: 'Higher implementation quality with extensive reasoning', default: true },
+          { id: 'medium', value: 'medium', label: 'Medium Effort', description: 'Balanced effort with standard implementation and testing', default: false },
+          { id: 'low', value: 'low', label: 'Low Effort', description: 'Quick, fast implementations', default: false },
+        ],
+      },
+    },
+    {
+      modelId: 'grok-4.5',
+      name: 'Grok 4.5',
+      _meta: {
+        totalContextTokens: 500000,
+        supportsReasoningEffort: true,
+        reasoningEffort: 'high',
+        reasoningEfforts: [
+          { id: 'high', value: 'high', label: 'High Effort', description: 'Highest implementation quality with extensive reasoning', default: true },
+          { id: 'medium', value: 'medium', label: 'Medium Effort', description: 'Balanced effort with standard implementation and testing', default: false },
+          { id: 'low', value: 'low', label: 'Low Effort', description: 'Quick, fast implementations', default: false },
+        ],
+      },
+    },
+  ],
+  currentModelId: 'grok-4.6',
+};
 
 describe('normalizeGrokAcpSessionModels', () => {
   it('maps Grok ACP modelId fields onto the shared ACP id shape', () => {
@@ -34,5 +76,48 @@ describe('normalizeGrokAcpSessionModels', () => {
       ],
       currentModelId: 'grok-4.5',
     });
+  });
+});
+
+describe('readGrokAcpModelThinkingOptions', () => {
+  it('reads the reasoning levels the agent reports for every available model', () => {
+    const options = readGrokAcpModelThinkingOptions(LIVE_SESSION_MODELS as never);
+
+    expect(Object.keys(options)).toEqual(['grok-4.6', 'grok-4.5']);
+    // Normalized into the ascending order the picker renders, same as the
+    // static list it replaces.
+    expect(options['grok-4.6'].map((variant) => variant.value)).toEqual([
+      'low',
+      'medium',
+      'high',
+      'xhigh',
+    ]);
+    // The level the picker must not offer for this model.
+    expect(options['grok-4.5'].map((variant) => variant.value)).toEqual([
+      'low',
+      'medium',
+      'high',
+    ]);
+    expect(options['grok-4.5']).toContainEqual({
+      description: 'Highest implementation quality with extensive reasoning',
+      label: 'High Effort',
+      value: 'high',
+    });
+  });
+
+  it('skips a model that reports no reasoning levels', () => {
+    expect(readGrokAcpModelThinkingOptions({
+      availableModels: [
+        { modelId: 'grok-4.6', name: 'Grok 4.6' },
+        { modelId: 'anthropic/claude-sonnet-4', name: 'Claude Sonnet 4', _meta: {} },
+        { modelId: 'grok-4.5', name: 'Grok 4.5', _meta: { reasoningEfforts: 'high' } },
+      ],
+      currentModelId: 'grok-4.6',
+    } as never)).toEqual({});
+  });
+
+  it('returns nothing when the session reports no models', () => {
+    expect(readGrokAcpModelThinkingOptions(null)).toEqual({});
+    expect(readGrokAcpModelThinkingOptions(undefined)).toEqual({});
   });
 });

--- a/tests/unit/providers/grok/normalizeGrokAcpSessionState.test.ts
+++ b/tests/unit/providers/grok/normalizeGrokAcpSessionState.test.ts
@@ -120,4 +120,39 @@ describe('readGrokAcpModelThinkingOptions', () => {
     expect(readGrokAcpModelThinkingOptions(null)).toEqual({});
     expect(readGrokAcpModelThinkingOptions(undefined)).toEqual({});
   });
+
+  it('reads a level that names itself only through id', () => {
+    expect(readGrokAcpModelThinkingOptions({
+      availableModels: [
+        {
+          modelId: 'grok-4.6',
+          name: 'Grok 4.6',
+          _meta: {
+            reasoningEfforts: [
+              { id: 'high', label: 'High Effort' },
+              { id: 'low', label: 'Low Effort' },
+            ],
+          },
+        },
+      ],
+      currentModelId: 'grok-4.6',
+    } as never)['grok-4.6'].map((variant) => variant.value)).toEqual(['low', 'high']);
+  });
+
+  it('refuses a model id that would reach through the prototype', () => {
+    const options = readGrokAcpModelThinkingOptions({
+      availableModels: [
+        {
+          modelId: '__proto__',
+          name: 'Hostile',
+          _meta: { reasoningEfforts: [{ id: 'high', value: 'high', label: 'High' }] },
+        },
+      ],
+      currentModelId: 'grok-4.6',
+    } as never);
+
+    expect(Object.keys(options)).toEqual([]);
+    expect(Object.getPrototypeOf(options)).toBe(Object.prototype);
+    expect(({} as Record<string, unknown>).high).toBeUndefined();
+  });
 });


### PR DESCRIPTION
## Problem

Selecting Grok 4.6 in the Grimoire chat composer only offers **Low / Medium / High**. Grok Build and grok-4.6 also support **xhigh** (Extra high / Très élevé). That value already has i18n strings and is already accepted on the Grok launch path (`--reasoning-effort xhigh`); it just never appears in the picker for catalog models such as `grok-4.6`.

## Root Cause

`getSupportedThinkingOptionsForModel` only used the four-level native list (`GROK_NATIVE_THINKING_OPTIONS`, including `xhigh`) when `isGrokNativeBuildModelId()` matched. That helper is limited to `grok-build` and `grok-composer-*`.

The live catalog default is `grok-4.6` (and `grok-4.5`). Those ids fell through to `GROK_FALLBACK_THINKING_OPTIONS` (`low` / `medium` / `high`) whenever ACP had not yet discovered per-model thought levels — which is the usual case (`thinkingOptionsByModel` is empty).

Launch already forwarded `xhigh` via `normalizeGrokLaunchReasoningEffort`. The gap was the composer menu.

## Approach

Treat native xAI model ids (`grok-*` without a provider slash) as using the native thinking list, including `xhigh`. Third-party catalog models (`anthropic/...`, `minimax-token-plan/...`, …) still use the three-level fallback until ACP discovery fills `thinkingOptionsByModel`.

xAI documents that grok-4.6 accepts `xhigh` natively, and that grok-4.5 treats `xhigh` as `high`. That matches Grok Build CLI’s own fallback effort menu (`low` / `medium` / `high` / `xhigh`).

## Architecture

- [x] Provider-native behavior remains inside `src/providers/<provider>/`.
- [x] Shared code is provider-neutral and used by at least two providers, or the PR explains why it belongs there.
- [x] I checked sibling providers when changing a shared ACP or provider contract.

Architecture notes:

Grok-owned model identity and chat UI config only. No shared contract change. Launch already accepted `xhigh`; this PR only widens the picker for native Grok catalog ids.

## Security And Privacy

- [x] Provider/session/model data is treated as untrusted input.
- [x] Permission changes cannot silently widen persistent authorization.
- [x] Filesystem, process, credential, MCP, and external-path boundaries are unchanged or explained below.
- [x] Logs and fixtures contain no secrets, prompts, note contents, local paths, or unsanitized provider payloads.

Security notes:

No security boundary change. Effort is still a user-selected launch argument already allowlisted by `GROK_LAUNCH_REASONING_EFFORT_VALUES`.

## Verification

Automated commands run:

```text
npm run test -- --selectProjects unit
npx eslint src/providers/grok/models.ts src/providers/grok/ui/GrokChatUIConfig.ts tests/unit/providers/grok/models.test.ts --max-warnings=0
npx tsc --noEmit
```

Unit: 408 suites, 7167 tests passed (plus the new grok-4.6 picker cases).

Manual verification:

Not run in Obsidian. Reproduced from a vault using `grok:grok-4.6` with empty `thinkingOptionsByModel`, which is the path this PR covers.

## Generated Artifacts

- [x] `package-lock.json` matches `package.json` when dependencies change.
- [x] Generated root bundles, `dist/grimoire`, and local-only artifacts are not included.

`npm run build:release` was not run; this is a small provider UI change with no CSS, dependency, or generated-artifact updates.

## Review Checklist

- [x] The PR is focused on one coherent problem.
- [x] Behavior changes have focused regression tests.
- [x] Protocol tests use real structured payloads and error codes.
- [x] Documentation and user-facing copy are in English.
- [x] The PR description accurately distinguishes automated tests from manual verification.