### PR TITLE
fix(mimocode): stop replaying the whole transcript when a session fails to resume

### DIFF
--- a/src/providers/mimocode/runtime/MimocodeChatRuntime.ts
+++ b/src/providers/mimocode/runtime/MimocodeChatRuntime.ts
@@ -398,7 +398,17 @@ export class MimocodeChatRuntime implements ChatRuntime {
     // whole transcript (observed: ~8.4M plan-usage tokens on the first message
     // after an Obsidian restart, vs ~71k steady state). History bootstrap stays
     // reserved for a genuine cold resume where we never held a session id.
-    let shouldBootstrapHistory = previousMessages.length > 0 && !expectedSessionId;
+    //
+    // `sessionInvalidated` is what tells the two apart, because the session can
+    // be dropped before query() ever runs: tab warmup goes through the runtime
+    // command loader, which calls ensureReady() on the bound runtime, and a
+    // session/load RPC failure there clears sessionId and raises the flag.
+    // Without this guard query() would see a null session id, read it as a cold
+    // resume and replay the transcript anyway - which is the whole cost this is
+    // meant to remove, on the single path most likely to hit it.
+    let shouldBootstrapHistory = previousMessages.length > 0
+      && !expectedSessionId
+      && !this.sessionInvalidated;
 
     const lifecycleGeneration = this.lifecycleGeneration;
     if (!(await this.ensureReadyForQuery(lifecycleGeneration))) {

--- a/src/providers/mimocode/runtime/MimocodeChatRuntime.ts
+++ b/src/providers/mimocode/runtime/MimocodeChatRuntime.ts
@@ -393,8 +393,12 @@ export class MimocodeChatRuntime implements ChatRuntime {
   ): AsyncGenerator<StreamChunk> {
     const previousMessages = conversationHistory ?? [];
     const expectedSessionId = this.sessionId;
-    let shouldBootstrapHistory = previousMessages.length > 0
-      && (!expectedSessionId || this.sessionInvalidated);
+    // Owner decision: a lost or invalidated session must NOT auto-replay the
+    // conversation history into a fresh session. Doing so silently spends the
+    // whole transcript (observed: ~8.4M plan-usage tokens on the first message
+    // after an Obsidian restart, vs ~71k steady state). History bootstrap stays
+    // reserved for a genuine cold resume where we never held a session id.
+    let shouldBootstrapHistory = previousMessages.length > 0 && !expectedSessionId;
 
     const lifecycleGeneration = this.lifecycleGeneration;
     if (!(await this.ensureReadyForQuery(lifecycleGeneration))) {
@@ -410,9 +414,10 @@ export class MimocodeChatRuntime implements ChatRuntime {
     }
 
     const cwd = getVaultPath(this.plugin.app) ?? process.cwd();
-    if (expectedSessionId && !this.sessionId) {
-      shouldBootstrapHistory = previousMessages.length > 0;
-    }
+    // Intentionally NO history bootstrap here: if readiness dropped the session
+    // (session/load RPC failure, forced restart), the new session starts clean.
+    // The prior behaviour re-sent the entire transcript and burned the context
+    // window without the user asking. Recovery of prior context is manual.
 
     if (!this.sessionId) {
       const sessionId = await this.createSession(cwd);

--- a/src/providers/mimocode/runtime/MimocodeChatRuntime.ts
+++ b/src/providers/mimocode/runtime/MimocodeChatRuntime.ts
@@ -71,8 +71,8 @@ import {
   extractAcpSessionModelState,
   extractAcpSessionModeState,
   extractAcpSessionThoughtLevelState,
-  isAcpMissingSessionError,
   isAcpRetryableTransportClose,
+  JsonRpcErrorResponse,
   planAcpEnsureReadySessionPhase,
   resolveWorkspacePath,
   runAcpEnsureReadyForQuery,
@@ -1275,10 +1275,17 @@ export class MimocodeChatRuntime implements ChatRuntime {
       });
       return true;
     } catch (error) {
-      if (!isAcpMissingSessionError(error)) {
+      // Any session/load RPC failure means the persisted session is unusable.
+      // Clear the stale binding immediately so callers that invoke loadSession
+      // directly (not only through ensureReady) also get a clean state.
+      // Transport-level errors (closed pipe, spawn failure) are NOT
+      // JsonRpcErrorResponse and still propagate.
+      if (!(error instanceof JsonRpcErrorResponse)) {
         throw error;
       }
       this.lastSessionLoadError = error;
+      this.sessionInvalidated = true;
+      this.clearActiveSession({ preserveDatabasePath: true });
       return false;
     }
   }

--- a/tests/unit/providers/mimocode/MimocodeChatRuntime.test.ts
+++ b/tests/unit/providers/mimocode/MimocodeChatRuntime.test.ts
@@ -487,7 +487,7 @@ describe('MimocodeChatRuntime', () => {
     expect(runtime.consumeSessionInvalidation()).toBe(false);
   });
 
-  it('preserves the saved session binding when session/load fails transiently', async () => {
+  it('clears the session binding when session/load fails with any RPC error', async () => {
     const runtime = new MimocodeChatRuntime(createMockPlugin());
     runtime.syncConversationState({ sessionId: 'session-1' });
     const error = new JsonRpcErrorResponse('session/load', -32000, 'Authentication failed');
@@ -495,10 +495,14 @@ describe('MimocodeChatRuntime', () => {
       loadSession: jest.fn().mockRejectedValue(error),
     };
 
-    await expect((runtime as any).loadSession('session-1', '/vault')).rejects.toBe(error);
+    const result = await (runtime as any).loadSession('session-1', '/vault');
+    expect(result).toBe(false);
 
-    expect(runtime.getSessionId()).toBe('session-1');
-    expect(runtime.consumeSessionInvalidation()).toBe(false);
+    // Any session/load RPC error means the persisted binding is unusable —
+    // clear it so the next query creates a fresh session instead of retrying
+    // the stale id and burning context tokens on history bootstrap.
+    expect(runtime.getSessionId()).toBeNull();
+    expect(runtime.consumeSessionInvalidation()).toBe(true);
   });
 
   it('clears a stale database path when switching to a saved session without persisted provider state', async () => {

--- a/tests/unit/providers/mimocode/MimocodeChatRuntime.test.ts
+++ b/tests/unit/providers/mimocode/MimocodeChatRuntime.test.ts
@@ -273,6 +273,77 @@ describe('MimocodeChatRuntime', () => {
     expect(promptText).not.toContain('I will preserve the prose voice.');
   });
 
+  it('does not replay conversation history when warmup dropped the session before the turn', async () => {
+    const runtime = new MimocodeChatRuntime(createMockPlugin());
+    const prompt = jest.fn().mockResolvedValue({});
+
+    // Tab warmup ran first: the runtime command loader called ensureReady() on
+    // the bound runtime, session/load failed and loadSession()'s catch cleared
+    // the binding. query() therefore starts with no session id at all.
+    runtime.syncConversationState({ sessionId: 'session-1' });
+    (runtime as any).sessionId = null;
+    (runtime as any).loadedSessionId = null;
+    (runtime as any).sessionInvalidated = true;
+
+    jest.spyOn(runtime, 'ensureReady').mockResolvedValue(true);
+    (runtime as any).createSession = jest.fn().mockImplementation(async () => {
+      (runtime as any).sessionId = 'session-2';
+      return 'session-2';
+    });
+    (runtime as any).connection = { prompt };
+    (runtime as any).applySelectedMode = jest.fn().mockResolvedValue(undefined);
+    (runtime as any).applySelectedModel = jest.fn().mockResolvedValue(undefined);
+    (runtime as any).applySelectedEffort = jest.fn().mockResolvedValue(undefined);
+    (runtime as any).getActiveDisplayModel = jest.fn().mockReturnValue('mimocode:test-model');
+
+    const history = [
+      { id: 'user-previous', role: 'user' as const, content: 'Keep the language rich.', timestamp: 1 },
+      { id: 'assistant-previous', role: 'assistant' as const, content: 'I will preserve the prose voice.', timestamp: 2 },
+    ];
+    for await (const chunk of runtime.query(runtime.prepareTurn({ text: 'Continue the edit.' }), history)) {
+      void chunk;
+    }
+
+    expect(prompt).toHaveBeenCalledTimes(1);
+    const promptText = prompt.mock.calls[0][0].prompt.map((block: { text?: string }) => block.text ?? '').join('\n');
+    expect(promptText).toContain('Continue the edit.');
+    expect(promptText).not.toContain('Keep the language rich.');
+    expect(promptText).not.toContain('I will preserve the prose voice.');
+  });
+
+  it('still bootstraps history on a genuine cold resume that never held a session', async () => {
+    const runtime = new MimocodeChatRuntime(createMockPlugin());
+    const prompt = jest.fn().mockResolvedValue({});
+
+    // A conversation restored from disk with messages but no session id: nothing
+    // was lost here, so the transcript is the only context the agent can get.
+    runtime.syncConversationState({ sessionId: null });
+
+    jest.spyOn(runtime, 'ensureReady').mockResolvedValue(true);
+    (runtime as any).createSession = jest.fn().mockImplementation(async () => {
+      (runtime as any).sessionId = 'session-1';
+      return 'session-1';
+    });
+    (runtime as any).connection = { prompt };
+    (runtime as any).applySelectedMode = jest.fn().mockResolvedValue(undefined);
+    (runtime as any).applySelectedModel = jest.fn().mockResolvedValue(undefined);
+    (runtime as any).applySelectedEffort = jest.fn().mockResolvedValue(undefined);
+    (runtime as any).getActiveDisplayModel = jest.fn().mockReturnValue('mimocode:test-model');
+
+    const history = [
+      { id: 'user-previous', role: 'user' as const, content: 'Keep the language rich.', timestamp: 1 },
+      { id: 'assistant-previous', role: 'assistant' as const, content: 'I will preserve the prose voice.', timestamp: 2 },
+    ];
+    for await (const chunk of runtime.query(runtime.prepareTurn({ text: 'Continue the edit.' }), history)) {
+      void chunk;
+    }
+
+    expect(prompt).toHaveBeenCalledTimes(1);
+    const promptText = prompt.mock.calls[0][0].prompt.map((block: { text?: string }) => block.text ?? '').join('\n');
+    expect(promptText).toContain('Continue the edit.');
+    expect(promptText).toContain('Keep the language rich.');
+  });
+
   it('recovers when the ACP transport closes during initial readiness', async () => {
     const runtime = new MimocodeChatRuntime(createMockPlugin());
     const prompt = jest.fn().mockResolvedValue({});

--- a/tests/unit/providers/mimocode/MimocodeChatRuntime.test.ts
+++ b/tests/unit/providers/mimocode/MimocodeChatRuntime.test.ts
@@ -232,6 +232,47 @@ describe('MimocodeChatRuntime', () => {
     expect(chunks).toEqual([{ type: 'done' }]);
   });
 
+  it('does not replay conversation history when readiness drops the session', async () => {
+    const runtime = new MimocodeChatRuntime(createMockPlugin());
+    runtime.syncConversationState({ sessionId: 'session-1' });
+    const prompt = jest.fn().mockResolvedValue({});
+
+    // Simulate a session/load RPC failure during readiness: the stale binding is
+    // cleared exactly like loadSession()'s catch does.
+    jest.spyOn(runtime, 'ensureReady').mockImplementation(async () => {
+      (runtime as any).sessionId = null;
+      (runtime as any).loadedSessionId = null;
+      (runtime as any).sessionInvalidated = true;
+      return true;
+    });
+    (runtime as any).createSession = jest.fn().mockImplementation(async () => {
+      (runtime as any).sessionId = 'session-2';
+      return 'session-2';
+    });
+    (runtime as any).connection = { prompt };
+    (runtime as any).applySelectedMode = jest.fn().mockResolvedValue(undefined);
+    (runtime as any).applySelectedModel = jest.fn().mockResolvedValue(undefined);
+    (runtime as any).applySelectedEffort = jest.fn().mockResolvedValue(undefined);
+    (runtime as any).getActiveDisplayModel = jest.fn().mockReturnValue('mimocode:test-model');
+
+    const history = [
+      { id: 'user-previous', role: 'user' as const, content: 'Keep the language rich.', timestamp: 1 },
+      { id: 'assistant-previous', role: 'assistant' as const, content: 'I will preserve the prose voice.', timestamp: 2 },
+    ];
+    const chunks: unknown[] = [];
+    for await (const chunk of runtime.query(runtime.prepareTurn({ text: 'Continue the edit.' }), history)) {
+      chunks.push(chunk);
+    }
+    expect(chunks).toEqual([{ type: 'done' }]);
+
+    expect((runtime as any).createSession).toHaveBeenCalledTimes(1);
+    expect(prompt).toHaveBeenCalledTimes(1);
+    const promptText = prompt.mock.calls[0][0].prompt.map((block: { text?: string }) => block.text ?? '').join('\n');
+    expect(promptText).toContain('Continue the edit.');
+    expect(promptText).not.toContain('Keep the language rich.');
+    expect(promptText).not.toContain('I will preserve the prose voice.');
+  });
+
   it('recovers when the ACP transport closes during initial readiness', async () => {
     const runtime = new MimocodeChatRuntime(createMockPlugin());
     const prompt = jest.fn().mockResolvedValue({});


### PR DESCRIPTION
## Problem

The first message sent after an Obsidian restart, in a MiMoCode conversation
that had a persisted session, cost roughly 8.4M plan-usage credits against
~71k in the same conversation once it was running. Same short question, ten
seconds, zero tool calls.

What was being paid for was the transcript: `session/load` fails, Grimoire
opens a fresh session, and the fresh session was handed the entire prior
conversation as prompt text. Nothing tells the user this happened - the turn
simply costs what a whole transcript costs, once per failed resume.

The 8.4M figure is plan-usage **credits**, not tokens; MiMoCode's credit unit
is price-weighted and runs a few hundred times larger. The same first message
measures ~34k tokens. The unit does not change what the code was doing, but it
is worth naming so the magnitude is not mistaken for a token-accounting bug.

Fixes #

## Root Cause

Three defects in sequence.

**1. `loadSession()` only absorbed one error shape.** The catch narrowed on
`isAcpMissingSessionError`, so an auth failure, a database error or any other
JSON-RPC error propagated as an exception and left the stale `sessionId` in
place for the next turn to trip over.

**2. `query()` replayed unconditionally when readiness dropped the session.**

```ts
const expectedSessionId = this.sessionId;
let shouldBootstrapHistory = previousMessages.length > 0
  && (!expectedSessionId || this.sessionInvalidated);
...
if (expectedSessionId && !this.sessionId) {
  shouldBootstrapHistory = previousMessages.length > 0;   // unconditional
}
```

Both branches lead to a replay, and the second ignores why the session went
away.

**3. The session is usually gone before `query()` even starts.** This is the
part that makes the defect survive an obvious-looking fix.
`mimocodeTabWarmupPolicy.resolveMode()` always returns `'commands'`, so tab
warmup goes through `MimocodeRuntimeCommandLoader`. When the conversation
already has a session id, `canReuseRuntime` is true and the loader calls
`ensureReady()` on the **bound tab runtime** - before the user has typed
anything. A `session/load` failure there clears `sessionId` while the composer
is still empty. `query()` then starts with no session id at all, which at that
point is indistinguishable from a cold resume that never had one. So even
reserving bootstrap for `!expectedSessionId` still replays on the single path
an editor restart takes.

Protocol evidence from the plugin's debug log: `session.load_failed` carrying
`JsonRpcErrorResponse` code `-32603`, twice on the same session id, followed by
a 9.7s turn with zero tool calls.

## Approach

Three commits, one per defect above.

`81b481c` - the error class decides: a `JsonRpcErrorResponse` from
`session/load` clears the binding (`sessionId = null`,
`sessionInvalidated = true`) and returns false. Transport-level errors (closed
pipe, failed spawn) still propagate, because those say nothing about whether
the session is usable.

`05d3ea2` - the unconditional re-set in `query()` is removed. History bootstrap
is reserved for a cold resume.

`709cbca` - bootstrap additionally requires `!this.sessionInvalidated`.
That flag already means "we had a session and lost it", and it is the only
state that survives the warmup path with the answer in it. The previous code
used the same flag with the opposite sign, as a *reason* to replay.

Alternative considered and rejected: keeping the replay but asking first. That
is a better end state and needs a UI decision, so it is raised in the linked
issue rather than smuggled in here. The behaviour this PR ships is the
conservative half - a session dropped by a load failure starts clean, and
recovering the earlier context is the user's to do. Silently re-buying the
whole transcript is not a recovery anyone consented to.

Deliberately unchanged: the mid-turn retry after a transport close still
bootstraps when it lands in a different session, because that is one
interrupted turn being finished rather than a new conversation being invented.
A genuine cold resume still gets its history, and that case now has a test of
its own so the new guard cannot quietly swallow it.

## Architecture

- [x] Provider-native behavior remains inside `src/providers/<provider>/`.
- [x] Shared code is provider-neutral and used by at least two providers, or the PR explains why it belongs there.
- [x] I checked sibling providers when changing a shared ACP or provider contract.

Architecture notes:

Both changed files are under `src/providers/mimocode/`. No shared contract is
touched: `JsonRpcErrorResponse` and `isAcpMissingSessionError` are used as they
already exist in `src/providers/acp/`, and no signature changes.

Sibling check was run and the result is not clean.
`shouldBootstrapHistory` is computed identically in `KimicodeChatRuntime`
(391/409), `OpencodeChatRuntime` (391/409), `GeminiChatRuntime` (262/279),
`GrokChatRuntime` (521/542) and `QwenChatRuntime` (285/302), and
`KimicodeRuntimeCommandLoader` / `OpencodeRuntimeCommandLoader` are
line-for-line analogues of the MiMoCode loader, so the warmup half of the
mechanism applies to them as written. This PR stays on the one provider the
behaviour was reproduced and measured on; the class is filed as an issue rather
than fixed blind across five runtimes with their own session lifecycles and
their own tests.

## Security And Privacy

- [x] Provider/session/model data is treated as untrusted input.
- [x] Permission changes cannot silently widen persistent authorization.
- [x] Filesystem, process, credential, MCP, and external-path boundaries are unchanged or explained below.
- [x] Logs and fixtures contain no secrets, prompts, note contents, local paths, or unsanitized provider payloads.

Security notes:

No security boundary change. The failure behaviour narrows rather than widens:
a session that cannot be resumed is dropped and replaced instead of being kept
around in a stale state.

Worth naming as a privacy improvement rather than a neutral one. Prior to this
change, a resume failure silently re-sent the full contents of the
conversation - which in Obsidian routinely includes note text pulled in as
context - to a newly created remote session, with no prompt and no indication.
That now does not happen unless the conversation genuinely never had a session.

Added tests assert on locally constructed strings only; no fixtures, paths or
provider payloads were added.

## Verification

Automated commands run:

```text
npm run typecheck
npm run lint
npm run build:release
npx jest --testPathPatterns "MimocodeChatRuntime"
```

`typecheck`, `lint` and `build:release` exit 0; the release bundle was verified
to load and to open the view.

`tests/unit/providers/mimocode/MimocodeChatRuntime.test.ts`: 43 passed, 2
failed. The `main` baseline of the same file on the same machine is 40 passed,
2 failed - the two failures are the pre-existing Windows path-separator
assertions in `resolveSessionPath` (`/tmp` vs `D:\tmp`), unchanged by this
branch and measured in a scratch worktree at `0d57617`.

Three tests added: the readiness drop, the warmup drop, and the cold resume
that must still bootstrap.

One existing test changed meaning and is renamed, so it is not mistaken for
breakage: `preserves the saved session binding when session/load fails
transiently` -> `clears the session binding when session/load fails with any
RPC error`. That is the assertion for the first commit above, and it is the one
behavioural reversal in this PR: an RPC failure that used to keep the stale
binding and rethrow now clears it and returns false. Kimicode and Opencode
still carry the original assertion, deliberately - see the linked issue.

Full unit suite on Windows, this branch: 392 suites passed, 22 failed; 7422
tests passed, 36 failed, 8 skipped. The `main` baseline at `0d57617` on the
same machine: 392 passed, **the same 22** failed; 7419 passed, **the same 36**
failed, 8 skipped. The delta is exactly the three added tests.

Manual verification:

Windows 11, Obsidian, MiMoCode provider. The reproduction that produced the
8.4M figure and the `-32603` log entries was run against the affected build,
and the first two commits were run in the live vault afterwards. The third
commit is covered by automated tests only - reproducing it on demand requires
`session/load` to fail during warmup, which is not something the plugin can be
asked to do from the UI. Its failure mode was confirmed by test against the
installed build before the fix, not by hand afterwards.

## Generated Artifacts

- [x] `npm run build:release` recreates `dist/grimoire/main.js`, `manifest.json`, and `styles.css` from the submitted source.
- [x] `package-lock.json` matches `package.json` when dependencies change.
- [x] Generated root bundles, `dist/grimoire`, and local-only artifacts are not included.

No dependency change; `package.json` and `package-lock.json` are untouched. The
branch changes exactly two files.

## Review Checklist

- [x] The PR is focused on one coherent problem.
- [x] Behavior changes have focused regression tests.
- [x] Protocol tests use real structured payloads and error codes.
- [x] Documentation and user-facing copy are in English.
- [x] The PR description accurately distinguishes automated tests from manual verification.

Issue #99 