### PR TITLE
fix(providers): stop replaying the transcript into a session that replaced a lost one

### DIFF
--- a/src/providers/gemini/runtime/GeminiChatRuntime.ts
+++ b/src/providers/gemini/runtime/GeminiChatRuntime.ts
@@ -259,8 +259,16 @@ export class GeminiChatRuntime implements ChatRuntime {
   ): AsyncGenerator<StreamChunk> {
     const previousMessages = conversationHistory ?? [];
     const expectedSessionId = this.sessionId;
+    // A session that was dropped must not replay the whole transcript into its
+    // replacement: that silently spends the conversation the user already paid
+    // for, without asking. `sessionInvalidated` is the difference between "we
+    // had a session and lost it" and "there was never one", and it is the only
+    // form of that answer which survives a drop that happened before query()
+    // ran - ensureReady() is also reached from warmup, so a null session id by
+    // itself does not mean a cold resume.
     let shouldBootstrapHistory = previousMessages.length > 0
-      && (!expectedSessionId || this.sessionInvalidated);
+      && !expectedSessionId
+      && !this.sessionInvalidated;
 
     if (!(await this.ensureReady())) {
       yield { type: 'error', content: t('chat.ui.errors.provider.startFailed', { provider: ProviderRegistry.getProviderDisplayNameOrId('gemini') }) };
@@ -275,9 +283,9 @@ export class GeminiChatRuntime implements ChatRuntime {
     }
 
     const cwd = getVaultPath(this.plugin.app) ?? process.cwd();
-    if (expectedSessionId && !this.sessionId) {
-      shouldBootstrapHistory = previousMessages.length > 0;
-    }
+    // Intentionally no history bootstrap here: if readiness dropped the session
+    // (session/load failure, forced restart), the new session starts clean and
+    // recovering the earlier context is the user's to do.
 
     if (!this.sessionId) {
       const sessionId = await this.createSession(cwd);

--- a/src/providers/grok/runtime/GrokChatRuntime.ts
+++ b/src/providers/grok/runtime/GrokChatRuntime.ts
@@ -518,8 +518,16 @@ export class GrokChatRuntime implements ChatRuntime {
   ): AsyncGenerator<StreamChunk> {
     const previousMessages = conversationHistory ?? [];
     const expectedSessionId = this.sessionId;
+    // A session that was dropped must not replay the whole transcript into its
+    // replacement: that silently spends the conversation the user already paid
+    // for, without asking. `sessionInvalidated` is the difference between "we
+    // had a session and lost it" and "there was never one", and it is the only
+    // form of that answer which survives a drop that happened before query()
+    // ran - ensureReady() is also reached from warmup, so a null session id by
+    // itself does not mean a cold resume.
     let shouldBootstrapHistory = previousMessages.length > 0
-      && (!expectedSessionId || this.sessionInvalidated);
+      && !expectedSessionId
+      && !this.sessionInvalidated;
 
     if (!(await this.ensureReady())) {
       logGrokDebug(this.plugin, 'query.ensureReady.failed', {
@@ -538,9 +546,9 @@ export class GrokChatRuntime implements ChatRuntime {
     }
 
     const cwd = getVaultPath(this.plugin.app) ?? process.cwd();
-    if (expectedSessionId && !this.sessionId) {
-      shouldBootstrapHistory = previousMessages.length > 0;
-    }
+    // Intentionally no history bootstrap here: if readiness dropped the session
+    // (session/load failure, forced restart), the new session starts clean and
+    // recovering the earlier context is the user's to do.
 
     if (!this.sessionId) {
       const sessionId = await this.createSession(cwd);

--- a/src/providers/kimicode/runtime/KimicodeChatRuntime.ts
+++ b/src/providers/kimicode/runtime/KimicodeChatRuntime.ts
@@ -388,8 +388,16 @@ export class KimicodeChatRuntime implements ChatRuntime {
   ): AsyncGenerator<StreamChunk> {
     const previousMessages = conversationHistory ?? [];
     const expectedSessionId = this.sessionId;
+    // A session that was dropped must not replay the whole transcript into its
+    // replacement: that silently spends the conversation the user already paid
+    // for, without asking. `sessionInvalidated` is the difference between "we
+    // had a session and lost it" and "there was never one", and it is the only
+    // form of that answer which survives tab warmup - the runtime command
+    // loader calls ensureReady() on the bound runtime, so a null session id by
+    // itself does not mean a cold resume.
     let shouldBootstrapHistory = previousMessages.length > 0
-      && (!expectedSessionId || this.sessionInvalidated);
+      && !expectedSessionId
+      && !this.sessionInvalidated;
 
     const lifecycleGeneration = this.lifecycleGeneration;
     if (!(await this.ensureReadyForQuery(lifecycleGeneration))) {
@@ -405,9 +413,9 @@ export class KimicodeChatRuntime implements ChatRuntime {
     }
 
     const cwd = getVaultPath(this.plugin.app) ?? process.cwd();
-    if (expectedSessionId && !this.sessionId) {
-      shouldBootstrapHistory = previousMessages.length > 0;
-    }
+    // Intentionally no history bootstrap here: if readiness dropped the session
+    // (session/load failure, forced restart), the new session starts clean and
+    // recovering the earlier context is the user's to do.
 
     if (!this.sessionId) {
       const sessionId = await this.createSession(cwd);

--- a/src/providers/opencode/runtime/OpencodeChatRuntime.ts
+++ b/src/providers/opencode/runtime/OpencodeChatRuntime.ts
@@ -388,8 +388,16 @@ export class OpencodeChatRuntime implements ChatRuntime {
   ): AsyncGenerator<StreamChunk> {
     const previousMessages = conversationHistory ?? [];
     const expectedSessionId = this.sessionId;
+    // A session that was dropped must not replay the whole transcript into its
+    // replacement: that silently spends the conversation the user already paid
+    // for, without asking. `sessionInvalidated` is the difference between "we
+    // had a session and lost it" and "there was never one", and it is the only
+    // form of that answer which survives tab warmup - the runtime command
+    // loader calls ensureReady() on the bound runtime, so a null session id by
+    // itself does not mean a cold resume.
     let shouldBootstrapHistory = previousMessages.length > 0
-      && (!expectedSessionId || this.sessionInvalidated);
+      && !expectedSessionId
+      && !this.sessionInvalidated;
 
     const lifecycleGeneration = this.lifecycleGeneration;
     if (!(await this.ensureReadyForQuery(lifecycleGeneration))) {
@@ -405,9 +413,9 @@ export class OpencodeChatRuntime implements ChatRuntime {
     }
 
     const cwd = getVaultPath(this.plugin.app) ?? process.cwd();
-    if (expectedSessionId && !this.sessionId) {
-      shouldBootstrapHistory = previousMessages.length > 0;
-    }
+    // Intentionally no history bootstrap here: if readiness dropped the session
+    // (session/load failure, forced restart), the new session starts clean and
+    // recovering the earlier context is the user's to do.
 
     if (!this.sessionId) {
       const sessionId = await this.createSession(cwd);

--- a/src/providers/qwen/runtime/QwenChatRuntime.ts
+++ b/src/providers/qwen/runtime/QwenChatRuntime.ts
@@ -282,8 +282,16 @@ export class QwenChatRuntime implements ChatRuntime {
   ): AsyncGenerator<StreamChunk> {
     const previousMessages = conversationHistory ?? [];
     const expectedSessionId = this.sessionId;
+    // A session that was dropped must not replay the whole transcript into its
+    // replacement: that silently spends the conversation the user already paid
+    // for, without asking. `sessionInvalidated` is the difference between "we
+    // had a session and lost it" and "there was never one", and it is the only
+    // form of that answer which survives a drop that happened before query()
+    // ran - ensureReady() is also reached from warmup, so a null session id by
+    // itself does not mean a cold resume.
     let shouldBootstrapHistory = previousMessages.length > 0
-      && (!expectedSessionId || this.sessionInvalidated);
+      && !expectedSessionId
+      && !this.sessionInvalidated;
 
     if (!(await this.ensureReady())) {
       yield { type: 'error', content: t('chat.ui.errors.provider.startFailed', { provider: ProviderRegistry.getProviderDisplayNameOrId('qwen') }) };
@@ -298,9 +306,9 @@ export class QwenChatRuntime implements ChatRuntime {
     }
 
     const cwd = getVaultPath(this.plugin.app) ?? process.cwd();
-    if (expectedSessionId && !this.sessionId) {
-      shouldBootstrapHistory = previousMessages.length > 0;
-    }
+    // Intentionally no history bootstrap here: if readiness dropped the session
+    // (session/load failure, forced restart), the new session starts clean and
+    // recovering the earlier context is the user's to do.
 
     if (!this.sessionId) {
       const sessionId = await this.createSession(cwd);

--- a/tests/unit/providers/gemini/runtime/GeminiChatRuntime.test.ts
+++ b/tests/unit/providers/gemini/runtime/GeminiChatRuntime.test.ts
@@ -34,6 +34,84 @@ async function collect(generator: AsyncGenerator<StreamChunk>): Promise<StreamCh
 }
 
 describe('GeminiChatRuntime', () => {
+
+  it('does not replay conversation history when the session was dropped before the turn', async () => {
+    const runtime = new GeminiChatRuntime(createMockPlugin());
+    const prompt = jest.fn().mockResolvedValue({});
+
+    // The session was lost before this turn started: readiness ran earlier
+    // (tab warmup) and its session/load failed, clearing the binding while the
+    // composer was still empty. A null session id here is a lost session, not
+    // a conversation that never had one.
+    runtime.syncConversationState({ sessionId: 'session-1' });
+    (runtime as any).sessionId = null;
+    (runtime as any).loadedSessionId = null;
+    (runtime as any).sessionInvalidated = true;
+
+    jest.spyOn(runtime, 'ensureReady').mockResolvedValue(true);
+    (runtime as any).ensureReadyForQuery = jest.fn().mockResolvedValue(true);
+    (runtime as any).createSession = jest.fn().mockImplementation(async () => {
+      (runtime as any).sessionId = 'session-2';
+      return 'session-2';
+    });
+    (runtime as any).connection = { prompt };
+    (runtime as any).applySelectedMode = jest.fn().mockResolvedValue(undefined);
+    (runtime as any).applySelectedModel = jest.fn().mockResolvedValue(undefined);
+    (runtime as any).applySelectedEffort = jest.fn().mockResolvedValue(undefined);
+    (runtime as any).getActiveDisplayModel = jest.fn().mockReturnValue('gemini:test-model');
+    (runtime as any).getActiveModel = jest.fn().mockReturnValue('gemini:test-model');
+
+    const history = [
+      { id: 'user-previous', role: 'user' as const, content: 'Keep the language rich.', timestamp: 1 },
+      { id: 'assistant-previous', role: 'assistant' as const, content: 'I will preserve the prose voice.', timestamp: 2 },
+    ];
+    for await (const chunk of runtime.query(runtime.prepareTurn({ text: 'Continue the edit.' }), history)) {
+      void chunk;
+    }
+
+    expect(prompt).toHaveBeenCalledTimes(1);
+    const promptText = prompt.mock.calls[0][0].prompt
+      .map((block: { text?: string }) => block.text ?? '')
+      .join('\n');
+    expect(promptText).toContain('Continue the edit.');
+    expect(promptText).not.toContain('Keep the language rich.');
+    expect(promptText).not.toContain('I will preserve the prose voice.');
+  });
+
+  it('still bootstraps history on a cold resume that never held a session', async () => {
+    const runtime = new GeminiChatRuntime(createMockPlugin());
+    const prompt = jest.fn().mockResolvedValue({});
+
+    runtime.syncConversationState({ sessionId: null });
+
+    jest.spyOn(runtime, 'ensureReady').mockResolvedValue(true);
+    (runtime as any).ensureReadyForQuery = jest.fn().mockResolvedValue(true);
+    (runtime as any).createSession = jest.fn().mockImplementation(async () => {
+      (runtime as any).sessionId = 'session-1';
+      return 'session-1';
+    });
+    (runtime as any).connection = { prompt };
+    (runtime as any).applySelectedMode = jest.fn().mockResolvedValue(undefined);
+    (runtime as any).applySelectedModel = jest.fn().mockResolvedValue(undefined);
+    (runtime as any).applySelectedEffort = jest.fn().mockResolvedValue(undefined);
+    (runtime as any).getActiveDisplayModel = jest.fn().mockReturnValue('gemini:test-model');
+    (runtime as any).getActiveModel = jest.fn().mockReturnValue('gemini:test-model');
+
+    const history = [
+      { id: 'user-previous', role: 'user' as const, content: 'Keep the language rich.', timestamp: 1 },
+      { id: 'assistant-previous', role: 'assistant' as const, content: 'I will preserve the prose voice.', timestamp: 2 },
+    ];
+    for await (const chunk of runtime.query(runtime.prepareTurn({ text: 'Continue the edit.' }), history)) {
+      void chunk;
+    }
+
+    expect(prompt).toHaveBeenCalledTimes(1);
+    const promptText = prompt.mock.calls[0][0].prompt
+      .map((block: { text?: string }) => block.text ?? '')
+      .join('\n');
+    expect(promptText).toContain('Continue the edit.');
+    expect(promptText).toContain('Keep the language rich.');
+  });
   afterEach(async () => {
     jest.restoreAllMocks();
     await fs.rm('/tmp/grimoire-gemini-test-vault', { force: true, recursive: true });

--- a/tests/unit/providers/grok/GrokChatRuntime.test.ts
+++ b/tests/unit/providers/grok/GrokChatRuntime.test.ts
@@ -41,6 +41,84 @@ function createMockPlugin(overrides: Record<string, unknown> = {}): any {
 }
 
 describe('GrokChatRuntime', () => {
+
+  it('does not replay conversation history when the session was dropped before the turn', async () => {
+    const runtime = new GrokChatRuntime(createMockPlugin());
+    const prompt = jest.fn().mockResolvedValue({});
+
+    // The session was lost before this turn started: readiness ran earlier
+    // (tab warmup) and its session/load failed, clearing the binding while the
+    // composer was still empty. A null session id here is a lost session, not
+    // a conversation that never had one.
+    runtime.syncConversationState({ sessionId: 'session-1' });
+    (runtime as any).sessionId = null;
+    (runtime as any).loadedSessionId = null;
+    (runtime as any).sessionInvalidated = true;
+
+    jest.spyOn(runtime, 'ensureReady').mockResolvedValue(true);
+    (runtime as any).ensureReadyForQuery = jest.fn().mockResolvedValue(true);
+    (runtime as any).createSession = jest.fn().mockImplementation(async () => {
+      (runtime as any).sessionId = 'session-2';
+      return 'session-2';
+    });
+    (runtime as any).connection = { prompt };
+    (runtime as any).applySelectedMode = jest.fn().mockResolvedValue(undefined);
+    (runtime as any).applySelectedModel = jest.fn().mockResolvedValue(undefined);
+    (runtime as any).applySelectedEffort = jest.fn().mockResolvedValue(undefined);
+    (runtime as any).getActiveDisplayModel = jest.fn().mockReturnValue('grok:test-model');
+    (runtime as any).getActiveModel = jest.fn().mockReturnValue('grok:test-model');
+
+    const history = [
+      { id: 'user-previous', role: 'user' as const, content: 'Keep the language rich.', timestamp: 1 },
+      { id: 'assistant-previous', role: 'assistant' as const, content: 'I will preserve the prose voice.', timestamp: 2 },
+    ];
+    for await (const chunk of runtime.query(runtime.prepareTurn({ text: 'Continue the edit.' }), history)) {
+      void chunk;
+    }
+
+    expect(prompt).toHaveBeenCalledTimes(1);
+    const promptText = prompt.mock.calls[0][0].prompt
+      .map((block: { text?: string }) => block.text ?? '')
+      .join('\n');
+    expect(promptText).toContain('Continue the edit.');
+    expect(promptText).not.toContain('Keep the language rich.');
+    expect(promptText).not.toContain('I will preserve the prose voice.');
+  });
+
+  it('still bootstraps history on a cold resume that never held a session', async () => {
+    const runtime = new GrokChatRuntime(createMockPlugin());
+    const prompt = jest.fn().mockResolvedValue({});
+
+    runtime.syncConversationState({ sessionId: null });
+
+    jest.spyOn(runtime, 'ensureReady').mockResolvedValue(true);
+    (runtime as any).ensureReadyForQuery = jest.fn().mockResolvedValue(true);
+    (runtime as any).createSession = jest.fn().mockImplementation(async () => {
+      (runtime as any).sessionId = 'session-1';
+      return 'session-1';
+    });
+    (runtime as any).connection = { prompt };
+    (runtime as any).applySelectedMode = jest.fn().mockResolvedValue(undefined);
+    (runtime as any).applySelectedModel = jest.fn().mockResolvedValue(undefined);
+    (runtime as any).applySelectedEffort = jest.fn().mockResolvedValue(undefined);
+    (runtime as any).getActiveDisplayModel = jest.fn().mockReturnValue('grok:test-model');
+    (runtime as any).getActiveModel = jest.fn().mockReturnValue('grok:test-model');
+
+    const history = [
+      { id: 'user-previous', role: 'user' as const, content: 'Keep the language rich.', timestamp: 1 },
+      { id: 'assistant-previous', role: 'assistant' as const, content: 'I will preserve the prose voice.', timestamp: 2 },
+    ];
+    for await (const chunk of runtime.query(runtime.prepareTurn({ text: 'Continue the edit.' }), history)) {
+      void chunk;
+    }
+
+    expect(prompt).toHaveBeenCalledTimes(1);
+    const promptText = prompt.mock.calls[0][0].prompt
+      .map((block: { text?: string }) => block.text ?? '')
+      .join('\n');
+    expect(promptText).toContain('Continue the edit.');
+    expect(promptText).toContain('Keep the language rich.');
+  });
   beforeEach(() => {
     grokPlanUsageStore.reset();
   });

--- a/tests/unit/providers/kimicode/KimicodeChatRuntime.test.ts
+++ b/tests/unit/providers/kimicode/KimicodeChatRuntime.test.ts
@@ -32,6 +32,84 @@ function createMockPlugin(overrides: Record<string, unknown> = {}): any {
 }
 
 describe('KimicodeChatRuntime', () => {
+
+  it('does not replay conversation history when the session was dropped before the turn', async () => {
+    const runtime = new KimicodeChatRuntime(createMockPlugin());
+    const prompt = jest.fn().mockResolvedValue({});
+
+    // The session was lost before this turn started: readiness ran earlier
+    // (tab warmup) and its session/load failed, clearing the binding while the
+    // composer was still empty. A null session id here is a lost session, not
+    // a conversation that never had one.
+    runtime.syncConversationState({ sessionId: 'session-1' });
+    (runtime as any).sessionId = null;
+    (runtime as any).loadedSessionId = null;
+    (runtime as any).sessionInvalidated = true;
+
+    jest.spyOn(runtime, 'ensureReady').mockResolvedValue(true);
+    (runtime as any).ensureReadyForQuery = jest.fn().mockResolvedValue(true);
+    (runtime as any).createSession = jest.fn().mockImplementation(async () => {
+      (runtime as any).sessionId = 'session-2';
+      return 'session-2';
+    });
+    (runtime as any).connection = { prompt };
+    (runtime as any).applySelectedMode = jest.fn().mockResolvedValue(undefined);
+    (runtime as any).applySelectedModel = jest.fn().mockResolvedValue(undefined);
+    (runtime as any).applySelectedEffort = jest.fn().mockResolvedValue(undefined);
+    (runtime as any).getActiveDisplayModel = jest.fn().mockReturnValue('kimicode:test-model');
+    (runtime as any).getActiveModel = jest.fn().mockReturnValue('kimicode:test-model');
+
+    const history = [
+      { id: 'user-previous', role: 'user' as const, content: 'Keep the language rich.', timestamp: 1 },
+      { id: 'assistant-previous', role: 'assistant' as const, content: 'I will preserve the prose voice.', timestamp: 2 },
+    ];
+    for await (const chunk of runtime.query(runtime.prepareTurn({ text: 'Continue the edit.' }), history)) {
+      void chunk;
+    }
+
+    expect(prompt).toHaveBeenCalledTimes(1);
+    const promptText = prompt.mock.calls[0][0].prompt
+      .map((block: { text?: string }) => block.text ?? '')
+      .join('\n');
+    expect(promptText).toContain('Continue the edit.');
+    expect(promptText).not.toContain('Keep the language rich.');
+    expect(promptText).not.toContain('I will preserve the prose voice.');
+  });
+
+  it('still bootstraps history on a cold resume that never held a session', async () => {
+    const runtime = new KimicodeChatRuntime(createMockPlugin());
+    const prompt = jest.fn().mockResolvedValue({});
+
+    runtime.syncConversationState({ sessionId: null });
+
+    jest.spyOn(runtime, 'ensureReady').mockResolvedValue(true);
+    (runtime as any).ensureReadyForQuery = jest.fn().mockResolvedValue(true);
+    (runtime as any).createSession = jest.fn().mockImplementation(async () => {
+      (runtime as any).sessionId = 'session-1';
+      return 'session-1';
+    });
+    (runtime as any).connection = { prompt };
+    (runtime as any).applySelectedMode = jest.fn().mockResolvedValue(undefined);
+    (runtime as any).applySelectedModel = jest.fn().mockResolvedValue(undefined);
+    (runtime as any).applySelectedEffort = jest.fn().mockResolvedValue(undefined);
+    (runtime as any).getActiveDisplayModel = jest.fn().mockReturnValue('kimicode:test-model');
+    (runtime as any).getActiveModel = jest.fn().mockReturnValue('kimicode:test-model');
+
+    const history = [
+      { id: 'user-previous', role: 'user' as const, content: 'Keep the language rich.', timestamp: 1 },
+      { id: 'assistant-previous', role: 'assistant' as const, content: 'I will preserve the prose voice.', timestamp: 2 },
+    ];
+    for await (const chunk of runtime.query(runtime.prepareTurn({ text: 'Continue the edit.' }), history)) {
+      void chunk;
+    }
+
+    expect(prompt).toHaveBeenCalledTimes(1);
+    const promptText = prompt.mock.calls[0][0].prompt
+      .map((block: { text?: string }) => block.text ?? '')
+      .join('\n');
+    expect(promptText).toContain('Continue the edit.');
+    expect(promptText).toContain('Keep the language rich.');
+  });
   beforeEach(() => {
     kimicodePlanUsageStore.reset();
   });

--- a/tests/unit/providers/opencode/OpencodeChatRuntime.test.ts
+++ b/tests/unit/providers/opencode/OpencodeChatRuntime.test.ts
@@ -32,6 +32,84 @@ function createMockPlugin(overrides: Record<string, unknown> = {}): any {
 }
 
 describe('OpencodeChatRuntime', () => {
+
+  it('does not replay conversation history when the session was dropped before the turn', async () => {
+    const runtime = new OpencodeChatRuntime(createMockPlugin());
+    const prompt = jest.fn().mockResolvedValue({});
+
+    // The session was lost before this turn started: readiness ran earlier
+    // (tab warmup) and its session/load failed, clearing the binding while the
+    // composer was still empty. A null session id here is a lost session, not
+    // a conversation that never had one.
+    runtime.syncConversationState({ sessionId: 'session-1' });
+    (runtime as any).sessionId = null;
+    (runtime as any).loadedSessionId = null;
+    (runtime as any).sessionInvalidated = true;
+
+    jest.spyOn(runtime, 'ensureReady').mockResolvedValue(true);
+    (runtime as any).ensureReadyForQuery = jest.fn().mockResolvedValue(true);
+    (runtime as any).createSession = jest.fn().mockImplementation(async () => {
+      (runtime as any).sessionId = 'session-2';
+      return 'session-2';
+    });
+    (runtime as any).connection = { prompt };
+    (runtime as any).applySelectedMode = jest.fn().mockResolvedValue(undefined);
+    (runtime as any).applySelectedModel = jest.fn().mockResolvedValue(undefined);
+    (runtime as any).applySelectedEffort = jest.fn().mockResolvedValue(undefined);
+    (runtime as any).getActiveDisplayModel = jest.fn().mockReturnValue('opencode:test-model');
+    (runtime as any).getActiveModel = jest.fn().mockReturnValue('opencode:test-model');
+
+    const history = [
+      { id: 'user-previous', role: 'user' as const, content: 'Keep the language rich.', timestamp: 1 },
+      { id: 'assistant-previous', role: 'assistant' as const, content: 'I will preserve the prose voice.', timestamp: 2 },
+    ];
+    for await (const chunk of runtime.query(runtime.prepareTurn({ text: 'Continue the edit.' }), history)) {
+      void chunk;
+    }
+
+    expect(prompt).toHaveBeenCalledTimes(1);
+    const promptText = prompt.mock.calls[0][0].prompt
+      .map((block: { text?: string }) => block.text ?? '')
+      .join('\n');
+    expect(promptText).toContain('Continue the edit.');
+    expect(promptText).not.toContain('Keep the language rich.');
+    expect(promptText).not.toContain('I will preserve the prose voice.');
+  });
+
+  it('still bootstraps history on a cold resume that never held a session', async () => {
+    const runtime = new OpencodeChatRuntime(createMockPlugin());
+    const prompt = jest.fn().mockResolvedValue({});
+
+    runtime.syncConversationState({ sessionId: null });
+
+    jest.spyOn(runtime, 'ensureReady').mockResolvedValue(true);
+    (runtime as any).ensureReadyForQuery = jest.fn().mockResolvedValue(true);
+    (runtime as any).createSession = jest.fn().mockImplementation(async () => {
+      (runtime as any).sessionId = 'session-1';
+      return 'session-1';
+    });
+    (runtime as any).connection = { prompt };
+    (runtime as any).applySelectedMode = jest.fn().mockResolvedValue(undefined);
+    (runtime as any).applySelectedModel = jest.fn().mockResolvedValue(undefined);
+    (runtime as any).applySelectedEffort = jest.fn().mockResolvedValue(undefined);
+    (runtime as any).getActiveDisplayModel = jest.fn().mockReturnValue('opencode:test-model');
+    (runtime as any).getActiveModel = jest.fn().mockReturnValue('opencode:test-model');
+
+    const history = [
+      { id: 'user-previous', role: 'user' as const, content: 'Keep the language rich.', timestamp: 1 },
+      { id: 'assistant-previous', role: 'assistant' as const, content: 'I will preserve the prose voice.', timestamp: 2 },
+    ];
+    for await (const chunk of runtime.query(runtime.prepareTurn({ text: 'Continue the edit.' }), history)) {
+      void chunk;
+    }
+
+    expect(prompt).toHaveBeenCalledTimes(1);
+    const promptText = prompt.mock.calls[0][0].prompt
+      .map((block: { text?: string }) => block.text ?? '')
+      .join('\n');
+    expect(promptText).toContain('Continue the edit.');
+    expect(promptText).toContain('Keep the language rich.');
+  });
   beforeEach(() => {
     opencodePlanUsageStore.reset();
   });

--- a/tests/unit/providers/qwen/runtime/QwenChatRuntime.test.ts
+++ b/tests/unit/providers/qwen/runtime/QwenChatRuntime.test.ts
@@ -35,6 +35,84 @@ async function collect(generator: AsyncGenerator<StreamChunk>): Promise<StreamCh
 }
 
 describe('QwenChatRuntime', () => {
+
+  it('does not replay conversation history when the session was dropped before the turn', async () => {
+    const runtime = new QwenChatRuntime(createMockPlugin());
+    const prompt = jest.fn().mockResolvedValue({});
+
+    // The session was lost before this turn started: readiness ran earlier
+    // (tab warmup) and its session/load failed, clearing the binding while the
+    // composer was still empty. A null session id here is a lost session, not
+    // a conversation that never had one.
+    runtime.syncConversationState({ sessionId: 'session-1' });
+    (runtime as any).sessionId = null;
+    (runtime as any).loadedSessionId = null;
+    (runtime as any).sessionInvalidated = true;
+
+    jest.spyOn(runtime, 'ensureReady').mockResolvedValue(true);
+    (runtime as any).ensureReadyForQuery = jest.fn().mockResolvedValue(true);
+    (runtime as any).createSession = jest.fn().mockImplementation(async () => {
+      (runtime as any).sessionId = 'session-2';
+      return 'session-2';
+    });
+    (runtime as any).connection = { prompt };
+    (runtime as any).applySelectedMode = jest.fn().mockResolvedValue(undefined);
+    (runtime as any).applySelectedModel = jest.fn().mockResolvedValue(undefined);
+    (runtime as any).applySelectedEffort = jest.fn().mockResolvedValue(undefined);
+    (runtime as any).getActiveDisplayModel = jest.fn().mockReturnValue('qwen:test-model');
+    (runtime as any).getActiveModel = jest.fn().mockReturnValue('qwen:test-model');
+
+    const history = [
+      { id: 'user-previous', role: 'user' as const, content: 'Keep the language rich.', timestamp: 1 },
+      { id: 'assistant-previous', role: 'assistant' as const, content: 'I will preserve the prose voice.', timestamp: 2 },
+    ];
+    for await (const chunk of runtime.query(runtime.prepareTurn({ text: 'Continue the edit.' }), history)) {
+      void chunk;
+    }
+
+    expect(prompt).toHaveBeenCalledTimes(1);
+    const promptText = prompt.mock.calls[0][0].prompt
+      .map((block: { text?: string }) => block.text ?? '')
+      .join('\n');
+    expect(promptText).toContain('Continue the edit.');
+    expect(promptText).not.toContain('Keep the language rich.');
+    expect(promptText).not.toContain('I will preserve the prose voice.');
+  });
+
+  it('still bootstraps history on a cold resume that never held a session', async () => {
+    const runtime = new QwenChatRuntime(createMockPlugin());
+    const prompt = jest.fn().mockResolvedValue({});
+
+    runtime.syncConversationState({ sessionId: null });
+
+    jest.spyOn(runtime, 'ensureReady').mockResolvedValue(true);
+    (runtime as any).ensureReadyForQuery = jest.fn().mockResolvedValue(true);
+    (runtime as any).createSession = jest.fn().mockImplementation(async () => {
+      (runtime as any).sessionId = 'session-1';
+      return 'session-1';
+    });
+    (runtime as any).connection = { prompt };
+    (runtime as any).applySelectedMode = jest.fn().mockResolvedValue(undefined);
+    (runtime as any).applySelectedModel = jest.fn().mockResolvedValue(undefined);
+    (runtime as any).applySelectedEffort = jest.fn().mockResolvedValue(undefined);
+    (runtime as any).getActiveDisplayModel = jest.fn().mockReturnValue('qwen:test-model');
+    (runtime as any).getActiveModel = jest.fn().mockReturnValue('qwen:test-model');
+
+    const history = [
+      { id: 'user-previous', role: 'user' as const, content: 'Keep the language rich.', timestamp: 1 },
+      { id: 'assistant-previous', role: 'assistant' as const, content: 'I will preserve the prose voice.', timestamp: 2 },
+    ];
+    for await (const chunk of runtime.query(runtime.prepareTurn({ text: 'Continue the edit.' }), history)) {
+      void chunk;
+    }
+
+    expect(prompt).toHaveBeenCalledTimes(1);
+    const promptText = prompt.mock.calls[0][0].prompt
+      .map((block: { text?: string }) => block.text ?? '')
+      .join('\n');
+    expect(promptText).toContain('Continue the edit.');
+    expect(promptText).toContain('Keep the language rich.');
+  });
   afterEach(async () => {
     jest.restoreAllMocks();
     await fs.rm('/tmp/grimoire-qwen-test-vault', { force: true, recursive: true });


### PR DESCRIPTION
## Problem

The MiMoCode PR fixed a resume failure that silently re-sent an entire
conversation into the session that replaced the lost one - measured at roughly
8.4M plan-usage credits on the first message after an Obsidian restart, against
~71k in the same conversation once it was running.

That defect is not MiMoCode-specific. `KimicodeChatRuntime`,
`OpencodeChatRuntime`, `GeminiChatRuntime`, `GrokChatRuntime` and
`QwenChatRuntime` compute `shouldBootstrapHistory` the same way, so the same
restart spends the same transcript on five more providers.

Fixes #100 

## Root Cause

Identical in all five, at `query()`:

```ts
const expectedSessionId = this.sessionId;
let shouldBootstrapHistory = previousMessages.length > 0
  && (!expectedSessionId || this.sessionInvalidated);
...
const cwd = getVaultPath(this.plugin.app) ?? process.cwd();
if (expectedSessionId && !this.sessionId) {
  shouldBootstrapHistory = previousMessages.length > 0;   // unconditional
}
```

Both branches lead to a replay, and the second one ignores why the session
went away.

The half that makes an obvious-looking fix insufficient: the session is
usually gone before `query()` starts. Tab warmup reaches `ensureReady()` on the
**bound** runtime - through `KimicodeRuntimeCommandLoader` and
`OpencodeRuntimeCommandLoader`, which are line-for-line analogues of the
MiMoCode loader, and through the workspace services and command loader for the
other three - so a `session/load` failure clears the binding while the composer
is still empty. `query()` then starts with no session id, which at that point is
indistinguishable from a cold resume that never had one. Reserving bootstrap for
`!expectedSessionId` alone therefore still replays on the path an editor restart
takes.

All five already set `sessionInvalidated = true` next to the
`clearActiveSession()` that follows a failed resume, so the state needed to tell
the two apart is present in every runtime. It was simply being read with the
opposite sign - as a *reason* to replay.

## Approach

One change per runtime, matching the MiMoCode fix:

```ts
let shouldBootstrapHistory = previousMessages.length > 0
  && !expectedSessionId
  && !this.sessionInvalidated;
```

and the unconditional re-set after `getVaultPath` is removed.

A session dropped by a load failure or a forced restart starts clean, and
recovering the earlier context is the user's to do. A conversation restored from
disk that never held a session still gets its history.

**Deliberately not ported.** The MiMoCode PR also widened `loadSession()`'s
catch from `isAcpMissingSessionError` to any `JsonRpcErrorResponse`, clearing
the binding instead of rethrowing. Kimicode and Opencode carry an explicit test
for the opposite behaviour - `preserves the saved session binding when
session/load fails transiently` - so that is a deliberate decision by whoever
wrote it, not an oversight, and reversing it in five runtimes I cannot exercise
live is not something to slip into a history-replay fix. It is also not needed
for this one: with the guard in place a stale binding no longer produces a
silent replay, it produces a visible error. Worth deciding separately, and
raised in the linked issue.

## Architecture

- [x] Provider-native behavior remains inside `src/providers/<provider>/`.
- [x] Shared code is provider-neutral and used by at least two providers, or the PR explains why it belongs there.
- [x] I checked sibling providers when changing a shared ACP or provider contract.

Architecture notes:

Five runtime files and their five test files; nothing shared is touched and no
signature changes. The duplication is pre-existing - these runtimes are
near-identical by construction - and this PR follows it rather than starting a
refactor into a shared helper in the same change. That extraction is worth
doing and worth doing on its own.

Sibling check is what produced this PR: MiMoCode was fixed first, the pattern
was traced across the provider tree, and these five are the remainder. Claude,
Codex and Antigravity do not use this session-resume shape.

## Security And Privacy

- [x] Provider/session/model data is treated as untrusted input.
- [x] Permission changes cannot silently widen persistent authorization.
- [x] Filesystem, process, credential, MCP, and external-path boundaries are unchanged or explained below.
- [x] Logs and fixtures contain no secrets, prompts, note contents, local paths, or unsanitized provider payloads.

Security notes:

No security boundary change, and the same privacy improvement as the MiMoCode
fix, now on five more providers: a resume failure no longer re-sends the full
conversation - which in Obsidian routinely includes note text pulled in as
context - to a newly created remote session with no prompt and no indication.

Added tests assert on locally constructed strings only.

## Verification

Automated commands run:

```text
npm run typecheck
npm run lint
npm run build:release
npx jest --testPathPatterns "(KimicodeChatRuntime|OpencodeChatRuntime|GeminiChatRuntime|GrokChatRuntime|QwenChatRuntime)"
```

`typecheck`, `lint` and `build:release` exit 0; the release bundle was verified
to load and to open the view.

The five runtime suites, this branch: 191 passed, 14 failed. The `main`
baseline at `0d57617` on the same machine: 181 passed, **the same 14** failed.
The failures are the pre-existing Windows path-separator assertions; the delta
is exactly the ten added tests.

Two tests per runtime: the session dropped before the turn must not replay, and
the cold resume that never held a session must still bootstrap. The second
direction is there on purpose - a guard like this is much easier to over-tighten
than to under-tighten, and without it the regression would be silent.

Manual verification:

Not run. None of these five providers is installed here; the behaviour was
reproduced and measured on MiMoCode only, and this PR is the mechanical port of
that fix to runtimes that share the code shape. Reviewers with any of the five
configured can check it in one pass: open a conversation with history, restart
Obsidian so `session/load` fails, and confirm the first message afterwards no
longer carries the transcript.

## Generated Artifacts

- [x] `npm run build:release` recreates `dist/grimoire/main.js`, `manifest.json`, and `styles.css` from the submitted source.
- [x] `package-lock.json` matches `package.json` when dependencies change.
- [x] Generated root bundles, `dist/grimoire`, and local-only artifacts are not included.

No dependency change.

## Review Checklist

- [x] The PR is focused on one coherent problem.
- [x] Behavior changes have focused regression tests.
- [ ] Protocol tests use real structured payloads and error codes.
- [x] Documentation and user-facing copy are in English.
- [x] The PR description accurately distinguishes automated tests from manual verification.

No user-facing copy changes; no new i18n keys.

The protocol-tests box is left unchecked because the added tests do not
construct ACP payloads: the decision under test is taken before any request is
built, so they drive `query()` and assert on the prompt blocks it produces. The
existing protocol tests in these suites are untouched.

Issue #99 