### PR TITLE
fix(providers): seed a model catalog only under the key it came from

### DIFF
--- a/src/core/providers/ProviderModelCatalogRefreshCache.ts
+++ b/src/core/providers/ProviderModelCatalogRefreshCache.ts
@@ -1,3 +1,5 @@
+import { seedFingerprintMatches } from './catalogFingerprint';
+
 export interface ProviderModelCatalogRefreshRequest {
   fingerprint: string;
   force?: boolean;
@@ -20,6 +22,15 @@ interface PendingRefresh {
  * billable session. The TTL only paces retries after an attempt that found
  * nothing, so a missing or unauthenticated CLI is not re-spawned on every
  * dropdown open either.
+ *
+ * A seed speaks for a catalog this cache did not watch being discovered. Since
+ * a settled catalog never expires, a CLI or environment swapped while the
+ * plugin was not running would be adopted by the seed rather than detected,
+ * pinning the previous configuration's models for good. Callers that persist a
+ * digest of the key their list was discovered under pass it to `seed` and
+ * `applyDeferredSeed`, which turns that assumption into a check. Callers that
+ * record nothing keep the old behaviour rather than paying a CLI spawn to
+ * migrate.
  */
 export class ProviderModelCatalogRefreshCache {
   private freshFingerprint: string | null = null;
@@ -33,10 +44,22 @@ export class ProviderModelCatalogRefreshCache {
     private readonly now: () => number = () => Date.now(),
   ) {}
 
-  seed(fingerprint: string): void {
+  /**
+   * Marks a persisted catalog fresh under `fingerprint`.
+   *
+   * `recordedFingerprint` is the digest the catalog was discovered under, when
+   * the caller persists one. A digest that no longer describes `fingerprint`
+   * leaves the cache untouched and the catalog is rediscovered.
+   */
+  seed(fingerprint: string, recordedFingerprint?: string): boolean {
+    if (!seedFingerprintMatches(recordedFingerprint, fingerprint)) {
+      return false;
+    }
+
     this.refreshGeneration += 1;
     this.freshFingerprint = fingerprint;
     this.lastSuccessfulRefreshAt = this.now();
+    return true;
   }
 
   /**
@@ -61,7 +84,11 @@ export class ProviderModelCatalogRefreshCache {
    * window must still reach discovery, so the seed is dropped instead of being
    * filed under the new fingerprint.
    */
-  applyDeferredSeed(fingerprint: string, hasCachedModels: boolean): boolean {
+  applyDeferredSeed(
+    fingerprint: string,
+    hasCachedModels: boolean,
+    recordedFingerprint?: string,
+  ): boolean {
     const buildSeedFingerprint = this.deferredSeed;
     if (!buildSeedFingerprint) {
       return false;
@@ -72,8 +99,7 @@ export class ProviderModelCatalogRefreshCache {
       return false;
     }
 
-    this.seed(fingerprint);
-    return true;
+    return this.seed(fingerprint, recordedFingerprint);
   }
 
   isFresh(fingerprint: string, hasCachedModels: boolean): boolean {

--- a/src/core/providers/catalogFingerprint.ts
+++ b/src/core/providers/catalogFingerprint.ts
@@ -1,0 +1,29 @@
+/**
+ * FNV-1a over a model or command catalog cache key.
+ *
+ * Catalog keys embed the raw environment variables the CLI runs with, which
+ * can hold an API key, so only this digest is ever persisted next to a
+ * discovered list. The output must stay byte-identical across releases:
+ * catalogs persisted by earlier builds carry digests that later loads compare
+ * against.
+ */
+export function hashCatalogFingerprint(key: string): string {
+  let hash = 0x811c9dc5;
+  for (let index = 0; index < key.length; index += 1) {
+    hash ^= key.charCodeAt(index);
+    hash = Math.imul(hash, 0x01000193) >>> 0;
+  }
+  return hash.toString(16).padStart(8, '0');
+}
+
+/**
+ * Whether a persisted catalog may be trusted under the current cache key.
+ *
+ * A catalog persisted before the fingerprint existed carries no record of the
+ * key it came from, so it keeps the trust it always had rather than costing a
+ * CLI probe to migrate. Once a digest is recorded, the catalog is trusted only
+ * while the key still hashes to it.
+ */
+export function seedFingerprintMatches(recordedFingerprint: string | undefined, key: string): boolean {
+  return !recordedFingerprint || recordedFingerprint === hashCatalogFingerprint(key);
+}

--- a/src/providers/claude/app/ClaudeModelCatalog.ts
+++ b/src/providers/claude/app/ClaudeModelCatalog.ts
@@ -1,11 +1,14 @@
 import { requestUrl } from 'obsidian';
 
+import {
+  hashCatalogFingerprint,
+  seedFingerprintMatches,
+} from '../../../core/providers/catalogFingerprint';
 import type { ProviderModelCatalog } from '../../../core/providers/types';
 import type GrimoirePlugin from '../../../main';
 import {
   buildClaudeCatalogCacheKey,
   CLAUDE_EMPTY_DISCOVERY_RETRY_MS,
-  hashClaudeCatalogCacheKey,
 } from '../cli/claudeCatalogCache';
 import { probeRuntimeModels } from '../commands/probeRuntimeModels';
 import {
@@ -91,16 +94,6 @@ async function fetchClaudeModelsFromAnthropicApi(
   }
 
   return models;
-}
-
-/**
- * A catalog persisted before the fingerprint existed carries no record of the key
- * it came from, so the seed keeps extending it the same trust it always did. Once
- * a fingerprint is recorded, the seed only applies while it still matches.
- */
-function seedFingerprintMatches(persistedFingerprint: string, cacheKey: string): boolean {
-  return persistedFingerprint === ''
-    || persistedFingerprint === hashClaudeCatalogCacheKey(cacheKey);
 }
 
 export function createClaudeModelCatalog(plugin: GrimoirePlugin): ProviderModelCatalog {
@@ -235,7 +228,7 @@ export function createClaudeModelCatalog(plugin: GrimoirePlugin): ProviderModelC
           // "discovered under this exact configuration" from "assumed".
           updateClaudeProviderSettings(settings, {
             discoveredModels,
-            discoveredModelsFingerprint: hashClaudeCatalogCacheKey(cacheKey),
+            discoveredModelsFingerprint: hashCatalogFingerprint(cacheKey),
           });
           try {
             await plugin.saveSettings?.();

--- a/src/providers/claude/cli/claudeCatalogCache.ts
+++ b/src/providers/claude/cli/claudeCatalogCache.ts
@@ -37,16 +37,3 @@ export function buildClaudeCatalogCacheKey(
     respectProjectSettings: settings.respectProjectSettings,
   });
 }
-
-/**
- * FNV-1a over the cache key. The key embeds the raw environment variables,
- * which can hold an API key, so only the digest is ever persisted.
- */
-export function hashClaudeCatalogCacheKey(cacheKey: string): string {
-  let hash = 0x811c9dc5;
-  for (let index = 0; index < cacheKey.length; index += 1) {
-    hash ^= cacheKey.charCodeAt(index);
-    hash = Math.imul(hash, 0x01000193) >>> 0;
-  }
-  return hash.toString(16).padStart(8, '0');
-}

--- a/src/providers/claude/commands/ClaudeRuntimeCommandCacheStore.ts
+++ b/src/providers/claude/commands/ClaudeRuntimeCommandCacheStore.ts
@@ -1,9 +1,7 @@
+import { hashCatalogFingerprint } from '../../../core/providers/catalogFingerprint';
 import type { SlashCommand } from '../../../core/types';
 import type GrimoirePlugin from '../../../main';
-import {
-  buildClaudeCatalogCacheKey,
-  hashClaudeCatalogCacheKey,
-} from '../cli/claudeCatalogCache';
+import { buildClaudeCatalogCacheKey } from '../cli/claudeCatalogCache';
 import {
   type ClaudeProviderSettings,
   getClaudeProviderSettings,
@@ -57,7 +55,7 @@ export function createClaudeRuntimeCommandCacheStore(
     },
     currentFingerprint() {
       const cliPath = plugin.getResolvedProviderCliPath?.('claude') ?? '';
-      return hashClaudeCatalogCacheKey(buildClaudeCatalogCacheKey(readSettings(), cliPath));
+      return hashCatalogFingerprint(buildClaudeCatalogCacheKey(readSettings(), cliPath));
     },
     read() {
       const settings = readSettings();

--- a/src/providers/codex/app/CodexWorkspaceServices.ts
+++ b/src/providers/codex/app/CodexWorkspaceServices.ts
@@ -1,3 +1,4 @@
+import { hashCatalogFingerprint } from '../../../core/providers/catalogFingerprint';
 import type { ProviderCommandCatalog } from '../../../core/providers/commands/ProviderCommandCatalog';
 import { ProviderModelCatalogRefreshCache } from '../../../core/providers/ProviderModelCatalogRefreshCache';
 import { ProviderWorkspaceRegistry } from '../../../core/providers/ProviderWorkspaceRegistry';
@@ -14,6 +15,10 @@ import type GrimoirePlugin from '../../../main';
 import { getVaultPath } from '../../../utils/path';
 import { CodexAgentMentionProvider } from '../agents/CodexAgentMentionProvider';
 import { CodexSkillCatalog } from '../commands/CodexSkillCatalog';
+import {
+  buildCodexModelCatalogFingerprint,
+  resolveCodexModelCatalogFingerprint,
+} from '../modelCatalogFingerprint';
 import { updateCodexModelDiscoveryState } from '../modelDiscoveryState';
 import { CodexCliResolver } from '../runtime/CodexCliResolver';
 import { CodexModelListingService } from '../runtime/CodexModelListingService';
@@ -65,7 +70,10 @@ function createCodexModelCatalog(plugin: GrimoirePlugin): ProviderModelCatalog {
         initialEnvironmentVariables,
       ));
     } else {
-      refreshCache.seed(resolveCodexModelCatalogFingerprint(plugin, initialSettings));
+      refreshCache.seed(
+        resolveCodexModelCatalogFingerprint(plugin, initialSettings),
+        initialSettings.discoveredModelsFingerprint,
+      );
     }
   }
   return {
@@ -75,7 +83,12 @@ function createCodexModelCatalog(plugin: GrimoirePlugin): ProviderModelCatalog {
     async refreshModels({ force, settings }) {
       const currentSettings = getCodexProviderSettings(settings);
       const fingerprint = resolveCodexModelCatalogFingerprint(plugin, currentSettings);
-      if (refreshCache.applyDeferredSeed(fingerprint, currentSettings.discoveredModels.length > 0) && !force) {
+      const appliedDeferredSeed = refreshCache.applyDeferredSeed(
+        fingerprint,
+        currentSettings.discoveredModels.length > 0,
+        currentSettings.discoveredModelsFingerprint,
+      );
+      if (appliedDeferredSeed && !force) {
         plugin.recordDebugLog?.({
           data: {
             modelCount: currentSettings.discoveredModels.length,
@@ -130,7 +143,10 @@ function createCodexModelCatalog(plugin: GrimoirePlugin): ProviderModelCatalog {
           return false;
         }
 
-        const changed = updateCodexModelDiscoveryState(settings, { discoveredModels: models });
+        const changed = updateCodexModelDiscoveryState(settings, {
+          discoveredModels: models,
+          discoveredModelsFingerprint: hashCatalogFingerprint(fingerprint),
+        });
         if (changed) {
           await plugin.saveSettings?.();
         }
@@ -162,30 +178,6 @@ function createCodexModelCatalog(plugin: GrimoirePlugin): ProviderModelCatalog {
       });
     },
   };
-}
-
-function buildCodexModelCatalogFingerprint(
-  settings: ReturnType<typeof getCodexProviderSettings>,
-  cliPath: string,
-  environmentVariables: string,
-): string {
-  return JSON.stringify({
-    cliPath,
-    cliPathsByHost: settings.cliPathsByHost,
-    environmentHash: settings.environmentHash,
-    environmentVariables,
-  });
-}
-
-function resolveCodexModelCatalogFingerprint(
-  plugin: GrimoirePlugin,
-  settings: ReturnType<typeof getCodexProviderSettings>,
-): string {
-  return buildCodexModelCatalogFingerprint(
-    settings,
-    plugin.getResolvedProviderCliPath?.('codex') ?? settings.cliPath,
-    plugin.getActiveEnvironmentVariables?.('codex') ?? settings.environmentVariables,
-  );
 }
 
 export async function createCodexWorkspaceServices(

--- a/src/providers/codex/modelCatalogFingerprint.ts
+++ b/src/providers/codex/modelCatalogFingerprint.ts
@@ -1,0 +1,32 @@
+import type GrimoirePlugin from '../../main';
+import type { CodexProviderSettings } from './settings';
+
+/**
+ * The inputs that decide which models the Codex CLI can list: which binary runs
+ * and which environment it reads. The model catalog keys its refresh cache on
+ * this, and every discovery persists a digest of it so a later load can tell a
+ * list discovered under this configuration from one merely assumed to match.
+ */
+export function buildCodexModelCatalogFingerprint(
+  settings: CodexProviderSettings,
+  cliPath: string,
+  environmentVariables: string,
+): string {
+  return JSON.stringify({
+    cliPath,
+    cliPathsByHost: settings.cliPathsByHost,
+    environmentHash: settings.environmentHash,
+    environmentVariables,
+  });
+}
+
+export function resolveCodexModelCatalogFingerprint(
+  plugin: GrimoirePlugin,
+  settings: CodexProviderSettings,
+): string {
+  return buildCodexModelCatalogFingerprint(
+    settings,
+    plugin.getResolvedProviderCliPath?.('codex') ?? settings.cliPath,
+    plugin.getActiveEnvironmentVariables?.('codex') ?? settings.environmentVariables,
+  );
+}

--- a/src/providers/codex/modelDiscoveryState.ts
+++ b/src/providers/codex/modelDiscoveryState.ts
@@ -86,23 +86,47 @@ export function getCodexModelDiscoveryState(
   };
 }
 
+export interface CodexModelDiscoveryUpdates {
+  discoveredModels?: CodexDiscoveredModel[];
+  discoveredModelsFingerprint?: string;
+}
+
+/**
+ * Persists a discovery result and the digest of the configuration it ran under.
+ *
+ * Returns whether persisted discovery state changed, so the caller knows to
+ * save. A run that finds the same models under a new CLI still changes the
+ * digest, which is the point: without that write the next load would compare
+ * the previous configuration's digest and rediscover on every start.
+ */
 export function updateCodexModelDiscoveryState(
   settings: Record<string, unknown>,
-  updates: Partial<CodexModelDiscoveryState>,
+  updates: CodexModelDiscoveryUpdates,
 ): boolean {
   const state = ensureDiscoveryState(settings);
+  const config = getProviderConfig(settings, 'codex');
   const nextDiscoveredModels = 'discoveredModels' in updates
     ? normalizeCodexDiscoveredModels(updates.discoveredModels)
     : state.discoveredModels;
+  const currentFingerprint = typeof config.discoveredModelsFingerprint === 'string'
+    ? config.discoveredModelsFingerprint
+    : '';
+  const nextFingerprint = typeof updates.discoveredModelsFingerprint === 'string'
+    ? updates.discoveredModelsFingerprint
+    : currentFingerprint;
 
-  if (sameDiscoveredModels(state.discoveredModels, nextDiscoveredModels)) {
+  if (
+    sameDiscoveredModels(state.discoveredModels, nextDiscoveredModels)
+    && nextFingerprint === currentFingerprint
+  ) {
     return false;
   }
 
   state.discoveredModels = cloneDiscoveredModels(nextDiscoveredModels);
   setProviderConfig(settings, 'codex', {
-    ...getProviderConfig(settings, 'codex'),
+    ...config,
     discoveredModels: cloneDiscoveredModels(nextDiscoveredModels),
+    discoveredModelsFingerprint: nextFingerprint,
   });
   return true;
 }

--- a/src/providers/codex/runtime/CodexChatRuntime.ts
+++ b/src/providers/codex/runtime/CodexChatRuntime.ts
@@ -8,6 +8,7 @@ import {
   getOrchestratorModeInstructions,
   type SystemPromptSettings,
 } from '../../../core/prompt/mainAgent';
+import { hashCatalogFingerprint } from '../../../core/providers/catalogFingerprint';
 import { ProviderSettingsCoordinator } from '../../../core/providers/ProviderSettingsCoordinator';
 import type { ProviderCapabilities, ProviderId } from '../../../core/providers/types';
 import type { ChatRuntime } from '../../../core/runtime/ChatRuntime';
@@ -38,9 +39,11 @@ import {
   deriveCodexSessionsRootFromSessionPath,
   findCodexSessionFile,
 } from '../history/CodexHistoryStore';
+import { resolveCodexModelCatalogFingerprint } from '../modelCatalogFingerprint';
 import { updateCodexModelDiscoveryState } from '../modelDiscoveryState';
 import { encodeCodexTurn } from '../prompt/encodeCodexTurn';
 import {
+  getCodexProviderSettings,
   getEffectiveCodexReasoningSummary,
 } from '../settings';
 import {
@@ -856,10 +859,20 @@ export class CodexChatRuntime implements ChatRuntime {
         return;
       }
 
-      const changed = updateCodexModelDiscoveryState(
-        this.plugin.settings,
-        { discoveredModels: models },
-      );
+      // Records which configuration produced this list, so a later load can
+      // tell a list discovered under the current CLI from one merely assumed to
+      // match it. A run that finds the same models under a new CLI therefore
+      // still persists, and re-renders selectors once - identical options, but
+      // only when the CLI or environment actually changed.
+      const changed = updateCodexModelDiscoveryState(this.plugin.settings, {
+        discoveredModels: models,
+        discoveredModelsFingerprint: hashCatalogFingerprint(
+          resolveCodexModelCatalogFingerprint(
+            this.plugin,
+            getCodexProviderSettings(this.plugin.settings),
+          ),
+        ),
+      });
       if (changed) {
         await this.plugin.saveSettings();
         this.refreshModelSelectors();

--- a/src/providers/codex/settings.ts
+++ b/src/providers/codex/settings.ts
@@ -30,6 +30,12 @@ export interface CodexProviderSettings {
   cliPathsByHost: HostnameCliPaths;
   customModels: string;
   discoveredModels: CodexDiscoveredModel[];
+  /**
+   * Digest of the catalog cache key `discoveredModels` was discovered under.
+   * Written together with the list by discovery; any new writer must pass both,
+   * or a later load will trust a list the configuration no longer matches.
+   */
+  discoveredModelsFingerprint: string;
   reasoningSummary: CodexReasoningSummary;
   environmentVariables: string;
   environmentHash: string;
@@ -45,6 +51,7 @@ export const DEFAULT_CODEX_PROVIDER_SETTINGS: Readonly<CodexProviderSettings> = 
   cliPathsByHost: {},
   customModels: '',
   discoveredModels: [],
+  discoveredModelsFingerprint: '',
   reasoningSummary: 'detailed',
   environmentVariables: '',
   environmentHash: '',
@@ -143,6 +150,9 @@ export function getCodexProviderSettings(
     customModels: (config.customModels as string | undefined)
       ?? DEFAULT_CODEX_PROVIDER_SETTINGS.customModels,
     discoveredModels: normalizeCodexDiscoveredModels(config.discoveredModels),
+    discoveredModelsFingerprint: typeof config.discoveredModelsFingerprint === 'string'
+      ? config.discoveredModelsFingerprint
+      : DEFAULT_CODEX_PROVIDER_SETTINGS.discoveredModelsFingerprint,
     reasoningSummary: (config.reasoningSummary as CodexReasoningSummary | undefined)
       ?? (settings.codexReasoningSummary as CodexReasoningSummary | undefined)
       ?? DEFAULT_CODEX_PROVIDER_SETTINGS.reasoningSummary,
@@ -226,6 +236,7 @@ export function updateCodexProviderSettings(
     cliPathsByHost: next.cliPathsByHost,
     customModels: next.customModels,
     discoveredModels: next.discoveredModels,
+    discoveredModelsFingerprint: next.discoveredModelsFingerprint,
     reasoningSummary: next.reasoningSummary,
     environmentVariables: next.environmentVariables,
     environmentHash: next.environmentHash,

--- a/src/providers/gemini/app/GeminiWorkspaceServices.ts
+++ b/src/providers/gemini/app/GeminiWorkspaceServices.ts
@@ -13,6 +13,10 @@ import type { VaultFileAdapter } from '../../../core/storage/VaultFileAdapter';
 import type GrimoirePlugin from '../../../main';
 import { AcpMcpStorage } from '../../acp/mcp/AcpMcpStorage';
 import { GeminiCommandCatalog } from '../commands/GeminiCommandCatalog';
+import {
+  buildGeminiModelCatalogFingerprint,
+  resolveGeminiModelCatalogFingerprint,
+} from '../modelCatalogFingerprint';
 import { GeminiChatRuntime } from '../runtime/GeminiChatRuntime';
 import { GeminiCliResolver } from '../runtime/GeminiCliResolver';
 import { getGeminiProviderSettings } from '../settings';
@@ -41,29 +45,6 @@ const geminiTabWarmupPolicy: ProviderTabWarmupPolicy = {
 
 const MODEL_CATALOG_CACHE_TTL_MS = 10 * 60 * 1000;
 
-function buildGeminiModelCatalogFingerprint(
-  settings: ReturnType<typeof getGeminiProviderSettings>,
-  cliPath: string,
-  environmentVariables: string,
-): string {
-  return JSON.stringify({
-    cliPath,
-    cliPathsByHost: settings.cliPathsByHost,
-    environmentVariables,
-  });
-}
-
-function resolveGeminiModelCatalogFingerprint(
-  plugin: GrimoirePlugin,
-  settings: ReturnType<typeof getGeminiProviderSettings>,
-): string {
-  return buildGeminiModelCatalogFingerprint(
-    settings,
-    plugin.getResolvedProviderCliPath?.('gemini') ?? settings.cliPath,
-    plugin.getActiveEnvironmentVariables?.('gemini') ?? settings.environmentVariables,
-  );
-}
-
 function createGeminiModelCatalog(plugin: GrimoirePlugin): ProviderModelCatalog {
   const initialSettings = getGeminiProviderSettings(plugin.settings ?? {});
   const refreshCache = new ProviderModelCatalogRefreshCache(MODEL_CATALOG_CACHE_TTL_MS);
@@ -84,7 +65,10 @@ function createGeminiModelCatalog(plugin: GrimoirePlugin): ProviderModelCatalog 
         initialEnvironmentVariables,
       ));
     } else {
-      refreshCache.seed(resolveGeminiModelCatalogFingerprint(plugin, initialSettings));
+      refreshCache.seed(
+        resolveGeminiModelCatalogFingerprint(plugin, initialSettings),
+        initialSettings.discoveredModelsFingerprint,
+      );
     }
   }
 
@@ -98,7 +82,12 @@ function createGeminiModelCatalog(plugin: GrimoirePlugin): ProviderModelCatalog 
       const currentSettings = getGeminiProviderSettings(settings);
       const fingerprint = resolveGeminiModelCatalogFingerprint(plugin, currentSettings);
       const hasCachedModels = currentSettings.discoveredModels.length > 0;
-      if (refreshCache.applyDeferredSeed(fingerprint, hasCachedModels) && !force) {
+      const appliedDeferredSeed = refreshCache.applyDeferredSeed(
+        fingerprint,
+        hasCachedModels,
+        currentSettings.discoveredModelsFingerprint,
+      );
+      if (appliedDeferredSeed && !force) {
         plugin.recordDebugLog?.({
           data: {
             modelCount: currentSettings.discoveredModels.length,

--- a/src/providers/gemini/modelCatalogFingerprint.ts
+++ b/src/providers/gemini/modelCatalogFingerprint.ts
@@ -1,0 +1,31 @@
+import type GrimoirePlugin from '../../main';
+import type { GeminiProviderSettings } from './settings';
+
+/**
+ * The inputs that decide which models the Gemini CLI offers over ACP: which binary
+ * runs and which environment it reads. The model catalog keys its refresh cache
+ * on this, and every discovery persists a digest of it so a later load can tell
+ * a list discovered under this configuration from one merely assumed to match.
+ */
+export function buildGeminiModelCatalogFingerprint(
+  settings: GeminiProviderSettings,
+  cliPath: string,
+  environmentVariables: string,
+): string {
+  return JSON.stringify({
+    cliPath,
+    cliPathsByHost: settings.cliPathsByHost,
+    environmentVariables,
+  });
+}
+
+export function resolveGeminiModelCatalogFingerprint(
+  plugin: GrimoirePlugin,
+  settings: GeminiProviderSettings,
+): string {
+  return buildGeminiModelCatalogFingerprint(
+    settings,
+    plugin.getResolvedProviderCliPath?.('gemini') ?? settings.cliPath,
+    plugin.getActiveEnvironmentVariables?.('gemini') ?? settings.environmentVariables,
+  );
+}

--- a/src/providers/gemini/runtime/GeminiChatRuntime.ts
+++ b/src/providers/gemini/runtime/GeminiChatRuntime.ts
@@ -2,6 +2,7 @@ import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 
 import { applyOrchestratorModeInstructions } from '../../../core/prompt/mainAgent';
+import { hashCatalogFingerprint } from '../../../core/providers/catalogFingerprint';
 import { ProviderRegistry } from '../../../core/providers/ProviderRegistry';
 import { ProviderWorkspaceRegistry } from '../../../core/providers/ProviderWorkspaceRegistry';
 import type { ProviderCapabilities } from '../../../core/providers/types';
@@ -65,6 +66,7 @@ import {
 import { toAcpMcpServers } from '../../acp/mcp/toAcpMcpServers';
 import { geminiPlanUsageStore } from '../app/GeminiPlanUsageStore';
 import { GEMINI_PROVIDER_CAPABILITIES } from '../capabilities';
+import { resolveGeminiModelCatalogFingerprint } from '../modelCatalogFingerprint';
 import {
   decodeGeminiModelId,
   encodeGeminiModelId,
@@ -652,6 +654,16 @@ export class GeminiChatRuntime implements ChatRuntime {
         label: model.name || model.id,
         rawId: model.id,
       }));
+      // Records which configuration produced this list. The model catalog seeds
+      // its refresh cache from the persisted list on the next plugin load, and
+      // without this digest that seed would adopt a CLI swapped while Grimoire
+      // was not running instead of rediscovering under it.
+      updates.discoveredModelsFingerprint = hashCatalogFingerprint(
+        resolveGeminiModelCatalogFingerprint(
+          this.plugin,
+          getGeminiProviderSettings(this.plugin.settings),
+        ),
+      );
       updates.visibleModels = discoveredRawIds;
     }
 

--- a/src/providers/gemini/settings.ts
+++ b/src/providers/gemini/settings.ts
@@ -22,6 +22,12 @@ export interface GeminiMode {
 export interface PersistedGeminiProviderSettings {
   cliPath: string;
   cliPathsByHost: HostnameCliPaths;
+  /**
+   * Digest of the catalog cache key `discoveredModels` was discovered under.
+   * Written together with the list by ACP discovery; any new writer must pass
+   * both, or a later load will trust a list the configuration no longer matches.
+   */
+  discoveredModelsFingerprint: string;
   enabled: boolean;
   environmentHash: string;
   environmentVariables: string;
@@ -38,6 +44,7 @@ export interface GeminiProviderSettings extends PersistedGeminiProviderSettings 
 export const DEFAULT_GEMINI_PROVIDER_SETTINGS: Readonly<PersistedGeminiProviderSettings> = Object.freeze({
   cliPath: '',
   cliPathsByHost: {},
+  discoveredModelsFingerprint: '',
   enabled: false,
   environmentHash: '',
   environmentVariables: '',
@@ -176,6 +183,9 @@ export function getGeminiProviderSettings(settings: Record<string, unknown>): Ge
       ?? DEFAULT_GEMINI_PROVIDER_SETTINGS.cliPath,
     cliPathsByHost,
     discoveredModels: normalizeGeminiDiscoveredModels(config.discoveredModels),
+    discoveredModelsFingerprint: typeof config.discoveredModelsFingerprint === 'string'
+      ? config.discoveredModelsFingerprint
+      : DEFAULT_GEMINI_PROVIDER_SETTINGS.discoveredModelsFingerprint,
     enabled: (config.enabled as boolean | undefined)
       ?? DEFAULT_GEMINI_PROVIDER_SETTINGS.enabled,
     environmentHash: (config.environmentHash as string | undefined)
@@ -232,6 +242,9 @@ export function updateGeminiProviderSettings(
     cliPath: nextCliPath,
     cliPathsByHost: nextCliPathsByHost,
     discoveredModels: normalizeGeminiDiscoveredModels(updates.discoveredModels ?? current.discoveredModels),
+    discoveredModelsFingerprint: typeof updates.discoveredModelsFingerprint === 'string'
+      ? updates.discoveredModelsFingerprint
+      : current.discoveredModelsFingerprint,
     modelAliases: nextModelAliases,
     selectedMode: typeof updates.selectedMode === 'string'
       ? updates.selectedMode.trim()
@@ -244,6 +257,7 @@ export function updateGeminiProviderSettings(
     cliPath: next.cliPath,
     cliPathsByHost: next.cliPathsByHost,
     discoveredModels: next.discoveredModels,
+    discoveredModelsFingerprint: next.discoveredModelsFingerprint,
     enabled: next.enabled,
     environmentHash: next.environmentHash,
     environmentVariables: next.environmentVariables,

--- a/src/providers/kimicode/app/KimicodeWorkspaceServices.ts
+++ b/src/providers/kimicode/app/KimicodeWorkspaceServices.ts
@@ -41,11 +41,12 @@ const kimicodeTabWarmupPolicy: ProviderTabWarmupPolicy = {
 const MODEL_CATALOG_CACHE_TTL_MS = 10 * 60 * 1000;
 
 function createKimicodeModelCatalog(plugin: GrimoirePlugin): ProviderModelCatalog {
-  const initialSettings = getKimicodeProviderSettings(plugin.settings ?? {});
+  // Not seeded from the persisted settings. The discovered list lives in memory
+  // only, so anything present at construction came from a legacy persisted field
+  // or an earlier runtime in this process - neither discovered under a key this
+  // cache watched, and a seed would pin it for the rest of the process. The
+  // first refresh boots the runtime once and every later one reuses it.
   const refreshCache = new ProviderModelCatalogRefreshCache(MODEL_CATALOG_CACHE_TTL_MS);
-  if (initialSettings.discoveredModels.length > 0) {
-    refreshCache.seed(buildKimicodeModelCatalogCacheKey(initialSettings));
-  }
 
   return {
     isAvailable(settings) {

--- a/src/providers/mimocode/app/MimocodeWorkspaceServices.ts
+++ b/src/providers/mimocode/app/MimocodeWorkspaceServices.ts
@@ -41,11 +41,12 @@ const mimocodeTabWarmupPolicy: ProviderTabWarmupPolicy = {
 const MODEL_CATALOG_CACHE_TTL_MS = 10 * 60 * 1000;
 
 function createMimocodeModelCatalog(plugin: GrimoirePlugin): ProviderModelCatalog {
-  const initialSettings = getMimocodeProviderSettings(plugin.settings ?? {});
+  // Not seeded from the persisted settings. The discovered list lives in memory
+  // only, so anything present at construction came from a legacy persisted field
+  // or an earlier runtime in this process - neither discovered under a key this
+  // cache watched, and a seed would pin it for the rest of the process. The
+  // first refresh boots the runtime once and every later one reuses it.
   const refreshCache = new ProviderModelCatalogRefreshCache(MODEL_CATALOG_CACHE_TTL_MS);
-  if (initialSettings.discoveredModels.length > 0) {
-    refreshCache.seed(buildMimocodeModelCatalogCacheKey(initialSettings));
-  }
 
   return {
     isAvailable(settings) {

--- a/src/providers/opencode/app/OpencodeWorkspaceServices.ts
+++ b/src/providers/opencode/app/OpencodeWorkspaceServices.ts
@@ -41,11 +41,12 @@ const opencodeTabWarmupPolicy: ProviderTabWarmupPolicy = {
 const MODEL_CATALOG_CACHE_TTL_MS = 10 * 60 * 1000;
 
 function createOpencodeModelCatalog(plugin: GrimoirePlugin): ProviderModelCatalog {
-  const initialSettings = getOpencodeProviderSettings(plugin.settings ?? {});
+  // Not seeded from the persisted settings. The discovered list lives in memory
+  // only, so anything present at construction came from a legacy persisted field
+  // or an earlier runtime in this process - neither discovered under a key this
+  // cache watched, and a seed would pin it for the rest of the process. The
+  // first refresh boots the runtime once and every later one reuses it.
   const refreshCache = new ProviderModelCatalogRefreshCache(MODEL_CATALOG_CACHE_TTL_MS);
-  if (initialSettings.discoveredModels.length > 0) {
-    refreshCache.seed(buildOpencodeModelCatalogCacheKey(initialSettings));
-  }
 
   return {
     isAvailable(settings) {

--- a/src/providers/qwen/app/QwenWorkspaceServices.ts
+++ b/src/providers/qwen/app/QwenWorkspaceServices.ts
@@ -13,6 +13,10 @@ import type { VaultFileAdapter } from '../../../core/storage/VaultFileAdapter';
 import type GrimoirePlugin from '../../../main';
 import { AcpMcpStorage } from '../../acp/mcp/AcpMcpStorage';
 import { QwenCommandCatalog } from '../commands/QwenCommandCatalog';
+import {
+  buildQwenModelCatalogFingerprint,
+  resolveQwenModelCatalogFingerprint,
+} from '../modelCatalogFingerprint';
 import { QwenChatRuntime } from '../runtime/QwenChatRuntime';
 import { QwenCliResolver } from '../runtime/QwenCliResolver';
 import { getQwenProviderSettings } from '../settings';
@@ -41,29 +45,6 @@ const qwenTabWarmupPolicy: ProviderTabWarmupPolicy = {
 
 const MODEL_CATALOG_CACHE_TTL_MS = 10 * 60 * 1000;
 
-function buildQwenModelCatalogFingerprint(
-  settings: ReturnType<typeof getQwenProviderSettings>,
-  cliPath: string,
-  environmentVariables: string,
-): string {
-  return JSON.stringify({
-    cliPath,
-    cliPathsByHost: settings.cliPathsByHost,
-    environmentVariables,
-  });
-}
-
-function resolveQwenModelCatalogFingerprint(
-  plugin: GrimoirePlugin,
-  settings: ReturnType<typeof getQwenProviderSettings>,
-): string {
-  return buildQwenModelCatalogFingerprint(
-    settings,
-    plugin.getResolvedProviderCliPath?.('qwen') ?? settings.cliPath,
-    plugin.getActiveEnvironmentVariables?.('qwen') ?? settings.environmentVariables,
-  );
-}
-
 function createQwenModelCatalog(plugin: GrimoirePlugin): ProviderModelCatalog {
   const initialSettings = getQwenProviderSettings(plugin.settings ?? {});
   const refreshCache = new ProviderModelCatalogRefreshCache(MODEL_CATALOG_CACHE_TTL_MS);
@@ -84,7 +65,10 @@ function createQwenModelCatalog(plugin: GrimoirePlugin): ProviderModelCatalog {
         initialEnvironmentVariables,
       ));
     } else {
-      refreshCache.seed(resolveQwenModelCatalogFingerprint(plugin, initialSettings));
+      refreshCache.seed(
+        resolveQwenModelCatalogFingerprint(plugin, initialSettings),
+        initialSettings.discoveredModelsFingerprint,
+      );
     }
   }
 
@@ -98,7 +82,12 @@ function createQwenModelCatalog(plugin: GrimoirePlugin): ProviderModelCatalog {
       const currentSettings = getQwenProviderSettings(settings);
       const fingerprint = resolveQwenModelCatalogFingerprint(plugin, currentSettings);
       const hasCachedModels = currentSettings.discoveredModels.length > 0;
-      if (refreshCache.applyDeferredSeed(fingerprint, hasCachedModels) && !force) {
+      const appliedDeferredSeed = refreshCache.applyDeferredSeed(
+        fingerprint,
+        hasCachedModels,
+        currentSettings.discoveredModelsFingerprint,
+      );
+      if (appliedDeferredSeed && !force) {
         plugin.recordDebugLog?.({
           data: {
             modelCount: currentSettings.discoveredModels.length,

--- a/src/providers/qwen/modelCatalogFingerprint.ts
+++ b/src/providers/qwen/modelCatalogFingerprint.ts
@@ -1,0 +1,31 @@
+import type GrimoirePlugin from '../../main';
+import type { QwenProviderSettings } from './settings';
+
+/**
+ * The inputs that decide which models the Qwen CLI offers over ACP: which binary
+ * runs and which environment it reads. The model catalog keys its refresh cache
+ * on this, and every discovery persists a digest of it so a later load can tell
+ * a list discovered under this configuration from one merely assumed to match.
+ */
+export function buildQwenModelCatalogFingerprint(
+  settings: QwenProviderSettings,
+  cliPath: string,
+  environmentVariables: string,
+): string {
+  return JSON.stringify({
+    cliPath,
+    cliPathsByHost: settings.cliPathsByHost,
+    environmentVariables,
+  });
+}
+
+export function resolveQwenModelCatalogFingerprint(
+  plugin: GrimoirePlugin,
+  settings: QwenProviderSettings,
+): string {
+  return buildQwenModelCatalogFingerprint(
+    settings,
+    plugin.getResolvedProviderCliPath?.('qwen') ?? settings.cliPath,
+    plugin.getActiveEnvironmentVariables?.('qwen') ?? settings.environmentVariables,
+  );
+}

--- a/src/providers/qwen/runtime/QwenChatRuntime.ts
+++ b/src/providers/qwen/runtime/QwenChatRuntime.ts
@@ -2,6 +2,7 @@ import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 
 import { applyOrchestratorModeInstructions } from '../../../core/prompt/mainAgent';
+import { hashCatalogFingerprint } from '../../../core/providers/catalogFingerprint';
 import { ProviderRegistry } from '../../../core/providers/ProviderRegistry';
 import { ProviderWorkspaceRegistry } from '../../../core/providers/ProviderWorkspaceRegistry';
 import type { ProviderCapabilities } from '../../../core/providers/types';
@@ -65,6 +66,7 @@ import {
 import { toAcpMcpServers } from '../../acp/mcp/toAcpMcpServers';
 import { qwenPlanUsageStore } from '../app/QwenPlanUsageStore';
 import { QWEN_PROVIDER_CAPABILITIES } from '../capabilities';
+import { resolveQwenModelCatalogFingerprint } from '../modelCatalogFingerprint';
 import {
   decodeQwenModelId,
   encodeQwenModelId,
@@ -738,6 +740,16 @@ export class QwenChatRuntime implements ChatRuntime {
         label: model.name || model.id,
         rawId: model.id,
       }));
+      // Records which configuration produced this list. The model catalog seeds
+      // its refresh cache from the persisted list on the next plugin load, and
+      // without this digest that seed would adopt a CLI swapped while Grimoire
+      // was not running instead of rediscovering under it.
+      updates.discoveredModelsFingerprint = hashCatalogFingerprint(
+        resolveQwenModelCatalogFingerprint(
+          this.plugin,
+          getQwenProviderSettings(this.plugin.settings),
+        ),
+      );
       updates.visibleModels = discoveredRawIds;
     }
 

--- a/src/providers/qwen/settings.ts
+++ b/src/providers/qwen/settings.ts
@@ -22,6 +22,12 @@ export interface QwenMode {
 export interface PersistedQwenProviderSettings {
   cliPath: string;
   cliPathsByHost: HostnameCliPaths;
+  /**
+   * Digest of the catalog cache key `discoveredModels` was discovered under.
+   * Written together with the list by ACP discovery; any new writer must pass
+   * both, or a later load will trust a list the configuration no longer matches.
+   */
+  discoveredModelsFingerprint: string;
   enabled: boolean;
   environmentHash: string;
   environmentVariables: string;
@@ -42,6 +48,7 @@ export interface QwenProviderSettings extends PersistedQwenProviderSettings {
 export const DEFAULT_QWEN_PROVIDER_SETTINGS: Readonly<PersistedQwenProviderSettings> = Object.freeze({
   cliPath: '',
   cliPathsByHost: {},
+  discoveredModelsFingerprint: '',
   enabled: false,
   environmentHash: '',
   environmentVariables: '',
@@ -187,6 +194,9 @@ export function getQwenProviderSettings(settings: Record<string, unknown>): Qwen
       ?? DEFAULT_QWEN_PROVIDER_SETTINGS.cliPath,
     cliPathsByHost,
     discoveredModels: normalizeQwenDiscoveredModels(config.discoveredModels),
+    discoveredModelsFingerprint: typeof config.discoveredModelsFingerprint === 'string'
+      ? config.discoveredModelsFingerprint
+      : DEFAULT_QWEN_PROVIDER_SETTINGS.discoveredModelsFingerprint,
     enabled: (config.enabled as boolean | undefined)
       ?? DEFAULT_QWEN_PROVIDER_SETTINGS.enabled,
     environmentHash: (config.environmentHash as string | undefined)
@@ -244,6 +254,9 @@ export function updateQwenProviderSettings(
     cliPath: nextCliPath,
     cliPathsByHost: nextCliPathsByHost,
     discoveredModels: normalizeQwenDiscoveredModels(updates.discoveredModels ?? current.discoveredModels),
+    discoveredModelsFingerprint: typeof updates.discoveredModelsFingerprint === 'string'
+      ? updates.discoveredModelsFingerprint
+      : current.discoveredModelsFingerprint,
     effortLevel: normalizeQwenEffortLevel(updates.effortLevel ?? current.effortLevel),
     modelAliases: nextModelAliases,
     selectedMode: typeof updates.selectedMode === 'string'
@@ -257,6 +270,7 @@ export function updateQwenProviderSettings(
     cliPath: next.cliPath,
     cliPathsByHost: next.cliPathsByHost,
     discoveredModels: next.discoveredModels,
+    discoveredModelsFingerprint: next.discoveredModelsFingerprint,
     enabled: next.enabled,
     environmentHash: next.environmentHash,
     environmentVariables: next.environmentVariables,

--- a/tests/unit/core/providers/ProviderModelCatalogRefreshCache.test.ts
+++ b/tests/unit/core/providers/ProviderModelCatalogRefreshCache.test.ts
@@ -1,3 +1,4 @@
+import { hashCatalogFingerprint } from '@/core/providers/catalogFingerprint';
 import { ProviderModelCatalogRefreshCache } from '@/core/providers/ProviderModelCatalogRefreshCache';
 
 describe('ProviderModelCatalogRefreshCache', () => {
@@ -112,6 +113,77 @@ describe('ProviderModelCatalogRefreshCache', () => {
 
     expect(cache.applyDeferredSeed('cli-a:env-a', false)).toBe(false);
     expect(cache.applyDeferredSeed('cli-a:env-a', true)).toBe(false);
+  });
+
+  it('seeds while the recorded fingerprint still describes the current key', async () => {
+    const load = jest.fn().mockResolvedValue(true);
+    const cache = new ProviderModelCatalogRefreshCache(1_000, () => 100);
+
+    expect(cache.seed('cli-a:env-a', hashCatalogFingerprint('cli-a:env-a'))).toBe(true);
+    await expect(cache.refresh({
+      fingerprint: 'cli-a:env-a',
+      hasCachedModels: true,
+      load,
+    })).resolves.toBe(false);
+    expect(load).not.toHaveBeenCalled();
+  });
+
+  it('drops a seed whose recorded fingerprint belongs to a different key', async () => {
+    const load = jest.fn().mockResolvedValue(true);
+    const cache = new ProviderModelCatalogRefreshCache(1_000, () => 100);
+
+    expect(cache.seed('cli-b:env-a', hashCatalogFingerprint('cli-a:env-a'))).toBe(false);
+    await expect(cache.refresh({
+      fingerprint: 'cli-b:env-a',
+      hasCachedModels: true,
+      load,
+    })).resolves.toBe(true);
+    expect(load).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps trusting a seed recorded before the fingerprint existed', async () => {
+    const load = jest.fn().mockResolvedValue(true);
+    const cache = new ProviderModelCatalogRefreshCache(1_000, () => 100);
+
+    expect(cache.seed('cli-a:env-a', '')).toBe(true);
+    await expect(cache.refresh({
+      fingerprint: 'cli-a:env-a',
+      hasCachedModels: true,
+      load,
+    })).resolves.toBe(false);
+    expect(load).not.toHaveBeenCalled();
+  });
+
+  it('applies a deferred seed whose recorded fingerprint matches', async () => {
+    const load = jest.fn().mockResolvedValue(true);
+    const cache = new ProviderModelCatalogRefreshCache(1_000, () => 100);
+    cache.seedOnFirstRefresh(() => 'cli-a:env-a');
+
+    expect(cache.applyDeferredSeed('cli-a:env-a', true, hashCatalogFingerprint('cli-a:env-a')))
+      .toBe(true);
+    await expect(cache.refresh({
+      fingerprint: 'cli-a:env-a',
+      hasCachedModels: true,
+      load,
+    })).resolves.toBe(false);
+    expect(load).not.toHaveBeenCalled();
+  });
+
+  it('drops a deferred seed whose recorded fingerprint belongs to a different key', async () => {
+    const load = jest.fn().mockResolvedValue(true);
+    const cache = new ProviderModelCatalogRefreshCache(1_000, () => 100);
+    cache.seedOnFirstRefresh(() => 'cli-a:env-a');
+
+    expect(cache.applyDeferredSeed('cli-a:env-a', true, hashCatalogFingerprint('cli-a:env-b')))
+      .toBe(false);
+    expect(cache.applyDeferredSeed('cli-a:env-a', true, hashCatalogFingerprint('cli-a:env-a')))
+      .toBe(false);
+    await expect(cache.refresh({
+      fingerprint: 'cli-a:env-a',
+      hasCachedModels: true,
+      load,
+    })).resolves.toBe(true);
+    expect(load).toHaveBeenCalledTimes(1);
   });
 
   it('keeps a settled catalog fresh past the TTL until its fingerprint changes', async () => {

--- a/tests/unit/core/providers/catalogFingerprint.test.ts
+++ b/tests/unit/core/providers/catalogFingerprint.test.ts
@@ -1,0 +1,27 @@
+import { hashCatalogFingerprint, seedFingerprintMatches } from '@/core/providers/catalogFingerprint';
+
+describe('catalogFingerprint', () => {
+  it('hashes a key to eight lowercase hex characters', () => {
+    expect(hashCatalogFingerprint('{"cliPath":"/usr/local/bin/codex"}')).toMatch(/^[0-9a-f]{8}$/);
+  });
+
+  it('keeps the digest Claude persisted before the helper moved to core', () => {
+    // Standard FNV-1a 32-bit vectors. Persisted fingerprints are compared
+    // against this output, so any drift here would silently re-probe every
+    // existing install.
+    expect(hashCatalogFingerprint('')).toBe('811c9dc5');
+    expect(hashCatalogFingerprint('a')).toBe('e40c292c');
+  });
+
+  it('trusts a catalog recorded before the fingerprint existed', () => {
+    expect(seedFingerprintMatches('', 'cli-a:env-a')).toBe(true);
+    expect(seedFingerprintMatches(undefined, 'cli-a:env-a')).toBe(true);
+  });
+
+  it('matches only the key whose digest was recorded', () => {
+    const recorded = hashCatalogFingerprint('cli-a:env-a');
+
+    expect(seedFingerprintMatches(recorded, 'cli-a:env-a')).toBe(true);
+    expect(seedFingerprintMatches(recorded, 'cli-b:env-a')).toBe(false);
+  });
+});

--- a/tests/unit/providers/codex/app/CodexWorkspaceServices.test.ts
+++ b/tests/unit/providers/codex/app/CodexWorkspaceServices.test.ts
@@ -1,6 +1,9 @@
+import { hashCatalogFingerprint } from '@/core/providers/catalogFingerprint';
 import { createCodexWorkspaceServices } from '@/providers/codex/app/CodexWorkspaceServices';
+import { resolveCodexModelCatalogFingerprint } from '@/providers/codex/modelCatalogFingerprint';
 import { getCodexModelDiscoveryState } from '@/providers/codex/modelDiscoveryState';
 import { CodexModelListingService } from '@/providers/codex/runtime/CodexModelListingService';
+import { getCodexProviderSettings } from '@/providers/codex/settings';
 import { codexChatUIConfig } from '@/providers/codex/ui/CodexChatUIConfig';
 
 function createStubAdapter() {
@@ -216,6 +219,174 @@ describe('createCodexWorkspaceServices', () => {
     activeEnvironment = 'OPENAI_API_KEY=new';
     await services.modelCatalog?.refreshModels({ plugin: plugin as any, settings: settings });
 
+    expect(listModelsSpy).toHaveBeenCalledTimes(1);
+  });
+  it('records the fingerprint of the listing that produced the persisted models', async () => {
+    jest
+      .spyOn(CodexModelListingService.prototype, 'listModels')
+      .mockResolvedValue([{ id: 'gpt-5.6', label: 'GPT-5.6' }]);
+    const settings = { providerConfigs: { codex: { enabled: true } } };
+    const plugin = {
+      app: { vault: { adapter: { basePath: '/repo' } } },
+      getResolvedProviderCliPath: () => '/usr/local/bin/codex',
+      saveSettings: jest.fn().mockResolvedValue(undefined),
+      settings,
+    };
+
+    const services = await createCodexWorkspaceServices(
+      plugin as any,
+      createStubAdapter() as any,
+      createStubAdapter() as any,
+    );
+    await services.modelCatalog?.refreshModels({ plugin: plugin as any, settings });
+
+    expect((settings.providerConfigs.codex as any).discoveredModelsFingerprint).toBe(
+      hashCatalogFingerprint(
+        resolveCodexModelCatalogFingerprint(plugin as any, getCodexProviderSettings(settings)),
+      ),
+    );
+    expect(plugin.saveSettings).toHaveBeenCalledTimes(1);
+  });
+
+  it('relists when the CLI path changed while the plugin was not running', async () => {
+    const listModelsSpy = jest
+      .spyOn(CodexModelListingService.prototype, 'listModels')
+      .mockResolvedValue([{ id: 'gpt-5.6', label: 'GPT-5.6' }]);
+    const settings = {
+      providerConfigs: {
+        codex: {
+          discoveredModels: [{ id: 'gpt-5.5', label: 'GPT-5.5' }],
+          discoveredModelsFingerprint: hashCatalogFingerprint(
+            resolveCodexModelCatalogFingerprint(
+              { getResolvedProviderCliPath: () => '/usr/local/bin/codex' } as any,
+              getCodexProviderSettings({ providerConfigs: { codex: { enabled: true } } }),
+            ),
+          ),
+          enabled: true,
+        },
+      },
+    };
+    const plugin = {
+      app: { vault: { adapter: { basePath: '/repo' } } },
+      getResolvedProviderCliPath: () => '/opt/homebrew/bin/codex',
+      saveSettings: jest.fn().mockResolvedValue(undefined),
+      settings,
+    };
+
+    const services = await createCodexWorkspaceServices(
+      plugin as any,
+      createStubAdapter() as any,
+      createStubAdapter() as any,
+    );
+    await services.modelCatalog?.refreshModels({ plugin: plugin as any, settings });
+
+    expect(listModelsSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('relists when the CLI path changed and the resolver only arrives after construction', async () => {
+    const listModelsSpy = jest
+      .spyOn(CodexModelListingService.prototype, 'listModels')
+      .mockResolvedValue([{ id: 'gpt-5.6', label: 'GPT-5.6' }]);
+    const settings = {
+      providerConfigs: {
+        codex: {
+          discoveredModels: [{ id: 'gpt-5.5', label: 'GPT-5.5' }],
+          discoveredModelsFingerprint: hashCatalogFingerprint(
+            resolveCodexModelCatalogFingerprint(
+              { getResolvedProviderCliPath: () => '/usr/local/bin/codex' } as any,
+              getCodexProviderSettings({ providerConfigs: { codex: { enabled: true } } }),
+            ),
+          ),
+          enabled: true,
+        },
+      },
+    };
+    let resolvedCliPath: string | null = null;
+    const plugin = {
+      app: { vault: { adapter: { basePath: '/repo' } } },
+      getResolvedProviderCliPath: () => resolvedCliPath,
+      saveSettings: jest.fn().mockResolvedValue(undefined),
+      settings,
+    };
+
+    const services = await createCodexWorkspaceServices(
+      plugin as any,
+      createStubAdapter() as any,
+      createStubAdapter() as any,
+    );
+    resolvedCliPath = '/opt/homebrew/bin/codex';
+    await services.modelCatalog?.refreshModels({ plugin: plugin as any, settings });
+
+    expect(listModelsSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps trusting a catalog persisted before the fingerprint existed', async () => {
+    const listModelsSpy = jest
+      .spyOn(CodexModelListingService.prototype, 'listModels')
+      .mockResolvedValue([{ id: 'gpt-5.6', label: 'GPT-5.6' }]);
+    const settings = {
+      providerConfigs: {
+        codex: {
+          discoveredModels: [{ id: 'gpt-5.5', label: 'GPT-5.5' }],
+          enabled: true,
+        },
+      },
+    };
+    const plugin = {
+      app: { vault: { adapter: { basePath: '/repo' } } },
+      getResolvedProviderCliPath: () => '/usr/local/bin/codex',
+      saveSettings: jest.fn().mockResolvedValue(undefined),
+      settings,
+    };
+
+    const services = await createCodexWorkspaceServices(
+      plugin as any,
+      createStubAdapter() as any,
+      createStubAdapter() as any,
+    );
+    const changed = await services.modelCatalog?.refreshModels({ plugin: plugin as any, settings });
+
+    expect(changed).toBe(false);
+    expect(listModelsSpy).not.toHaveBeenCalled();
+    expect(plugin.saveSettings).not.toHaveBeenCalled();
+  });
+
+  it('re-records the fingerprint when the CLI changed but the list did not', async () => {
+    const listModelsSpy = jest
+      .spyOn(CodexModelListingService.prototype, 'listModels')
+      .mockResolvedValue([{ id: 'gpt-5.5', label: 'GPT-5.5' }]);
+    const settings = {
+      providerConfigs: {
+        codex: {
+          discoveredModels: [{ id: 'gpt-5.5', label: 'GPT-5.5' }],
+          discoveredModelsFingerprint: 'deadbeef',
+          enabled: true,
+        },
+      },
+    };
+    const plugin = {
+      app: { vault: { adapter: { basePath: '/repo' } } },
+      getResolvedProviderCliPath: () => '/opt/homebrew/bin/codex',
+      saveSettings: jest.fn().mockResolvedValue(undefined),
+      settings,
+    };
+
+    const services = await createCodexWorkspaceServices(
+      plugin as any,
+      createStubAdapter() as any,
+      createStubAdapter() as any,
+    );
+    await services.modelCatalog?.refreshModels({ plugin: plugin as any, settings });
+
+    expect(listModelsSpy).toHaveBeenCalledTimes(1);
+    expect(plugin.saveSettings).toHaveBeenCalledTimes(1);
+    expect((settings.providerConfigs.codex as any).discoveredModelsFingerprint).toBe(
+      hashCatalogFingerprint(
+        resolveCodexModelCatalogFingerprint(plugin as any, getCodexProviderSettings(settings)),
+      ),
+    );
+
+    await services.modelCatalog?.refreshModels({ plugin: plugin as any, settings });
     expect(listModelsSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/tests/unit/providers/codex/runtime/CodexChatRuntime.test.ts
+++ b/tests/unit/providers/codex/runtime/CodexChatRuntime.test.ts
@@ -4,8 +4,11 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 
+import { hashCatalogFingerprint } from '@/core/providers/catalogFingerprint';
 import type { PreparedChatTurn } from '@/core/runtime/types';
 import type { StreamChunk } from '@/core/types/chat';
+import { resolveCodexModelCatalogFingerprint } from '@/providers/codex/modelCatalogFingerprint';
+import { getCodexProviderSettings } from '@/providers/codex/settings';
 import { CODEX_SPARK_MODEL, DEFAULT_CODEX_PRIMARY_MODEL } from '@/providers/codex/types/models';
 import { codexChatUIConfig } from '@/providers/codex/ui/CodexChatUIConfig';
 
@@ -538,6 +541,157 @@ describe('CodexChatRuntime', () => {
         'gpt-5.4',
       ]);
       expect(refreshModelSelector).toHaveBeenCalledTimes(1);
+    });
+
+    it('records the fingerprint of the discovery that produced the model list', async () => {
+      const plugin = createMockPlugin();
+      plugin.getAllViews = jest.fn().mockReturnValue([]);
+      runtime = new CodexChatRuntime(plugin);
+      mockTransportRequest.mockImplementation(buildRequestHandler({
+        'model/list': () => ({
+          data: [
+            {
+              id: 'gpt-5.5',
+              model: 'gpt-5.5',
+              displayName: 'GPT-5.5',
+              description: 'Frontier model.',
+              hidden: false,
+              isDefault: true,
+              supportedReasoningEfforts: [],
+              defaultReasoningEffort: 'medium',
+              inputModalities: [],
+              supportsPersonality: false,
+              additionalSpeedTiers: [],
+              serviceTiers: [],
+              defaultServiceTier: null,
+              upgrade: null,
+              upgradeInfo: null,
+              availabilityNux: null,
+            },
+          ],
+          nextCursor: null,
+        }),
+      }));
+
+      await runtime.ensureReady();
+
+      expect(plugin.settings.providerConfigs.codex.discoveredModelsFingerprint).toBe(
+        hashCatalogFingerprint(
+          resolveCodexModelCatalogFingerprint(plugin, getCodexProviderSettings(plugin.settings)),
+        ),
+      );
+    });
+
+    it('refreshes only the fingerprint when the CLI changed but the list did not', async () => {
+      const plugin = createMockPlugin({
+        providerConfigs: {
+          codex: {
+            discoveredModels: [
+              { id: 'gpt-5.5', label: 'GPT-5.5', description: 'Frontier model.', isDefault: true },
+            ],
+            discoveredModelsFingerprint: 'deadbeef',
+          },
+        },
+      });
+      plugin.getAllViews = jest.fn().mockReturnValue([]);
+      runtime = new CodexChatRuntime(plugin);
+      mockTransportRequest.mockImplementation(buildRequestHandler({
+        'model/list': () => ({
+          data: [
+            {
+              id: 'gpt-5.5',
+              model: 'gpt-5.5',
+              displayName: 'GPT-5.5',
+              description: 'Frontier model.',
+              hidden: false,
+              isDefault: true,
+              supportedReasoningEfforts: [],
+              defaultReasoningEffort: 'medium',
+              inputModalities: [],
+              supportsPersonality: false,
+              additionalSpeedTiers: [],
+              serviceTiers: [],
+              defaultServiceTier: null,
+              upgrade: null,
+              upgradeInfo: null,
+              availabilityNux: null,
+            },
+          ],
+          nextCursor: null,
+        }),
+      }));
+
+      await runtime.ensureReady();
+
+      expect(plugin.saveSettings).toHaveBeenCalledTimes(1);
+      expect(plugin.settings.providerConfigs.codex.discoveredModelsFingerprint).toBe(
+        hashCatalogFingerprint(
+          resolveCodexModelCatalogFingerprint(plugin, getCodexProviderSettings(plugin.settings)),
+        ),
+      );
+    });
+
+    it('does not save when the list and its fingerprint are unchanged', async () => {
+      const settingsForFingerprint = {
+        providerConfigs: {
+          codex: {
+            cliPath: '',
+          },
+        },
+      };
+      const recordedFingerprint = hashCatalogFingerprint(
+        resolveCodexModelCatalogFingerprint(
+          {
+            getActiveEnvironmentVariables: () =>
+              'OPENAI_API_KEY=test-key\nOPENAI_BASE_URL=https://example.test/v1',
+            getResolvedProviderCliPath: () => '/usr/local/bin/codex',
+          } as any,
+          getCodexProviderSettings(settingsForFingerprint),
+        ),
+      );
+      const refreshModelSelector = jest.fn();
+      const plugin = createMockPlugin({
+        providerConfigs: {
+          codex: {
+            discoveredModels: [
+              { id: 'gpt-5.5', label: 'GPT-5.5', description: 'Frontier model.', isDefault: true },
+            ],
+            discoveredModelsFingerprint: recordedFingerprint,
+          },
+        },
+      });
+      plugin.getAllViews = jest.fn().mockReturnValue([{ refreshModelSelector }]);
+      runtime = new CodexChatRuntime(plugin);
+      mockTransportRequest.mockImplementation(buildRequestHandler({
+        'model/list': () => ({
+          data: [
+            {
+              id: 'gpt-5.5',
+              model: 'gpt-5.5',
+              displayName: 'GPT-5.5',
+              description: 'Frontier model.',
+              hidden: false,
+              isDefault: true,
+              supportedReasoningEfforts: [],
+              defaultReasoningEffort: 'medium',
+              inputModalities: [],
+              supportsPersonality: false,
+              additionalSpeedTiers: [],
+              serviceTiers: [],
+              defaultServiceTier: null,
+              upgrade: null,
+              upgradeInfo: null,
+              availabilityNux: null,
+            },
+          ],
+          nextCursor: null,
+        }),
+      }));
+
+      await runtime.ensureReady();
+
+      expect(plugin.saveSettings).not.toHaveBeenCalled();
+      expect(refreshModelSelector).not.toHaveBeenCalled();
     });
 
     it('does not rebuild when config has not changed', async () => {

--- a/tests/unit/providers/codex/settings.test.ts
+++ b/tests/unit/providers/codex/settings.test.ts
@@ -34,6 +34,28 @@ describe('codex settings', () => {
     expect(settings.wslDistroOverride).toBe(DEFAULT_CODEX_PROVIDER_SETTINGS.wslDistroOverride);
   });
 
+  it('defaults the discovery fingerprint to an empty string and ignores a non-string', () => {
+    expect(getCodexProviderSettings({}).discoveredModelsFingerprint).toBe('');
+    expect(getCodexProviderSettings({
+      providerConfigs: { codex: { discoveredModelsFingerprint: 42 } },
+    }).discoveredModelsFingerprint).toBe('');
+  });
+
+  it('keeps the discovery fingerprint when unrelated settings are updated', () => {
+    const settings: Record<string, unknown> = {
+      providerConfigs: {
+        codex: {
+          discoveredModels: [{ id: 'gpt-5.5', label: 'GPT-5.5' }],
+          discoveredModelsFingerprint: 'abc12345',
+        },
+      },
+    };
+
+    updateCodexProviderSettings(settings, { environmentHash: 'OPENAI_API_KEY=new' });
+
+    expect(getCodexProviderSettings(settings).discoveredModelsFingerprint).toBe('abc12345');
+  });
+
   it('normalizes invalid installationMethod and wslDistroOverride values', () => {
     const settings = getCodexProviderSettings({
       providerConfigs: {

--- a/tests/unit/providers/gemini/GeminiWorkspaceServices.test.ts
+++ b/tests/unit/providers/gemini/GeminiWorkspaceServices.test.ts
@@ -1,5 +1,17 @@
+import { hashCatalogFingerprint } from '@/core/providers/catalogFingerprint';
 import { createGeminiWorkspaceServices } from '@/providers/gemini/app/GeminiWorkspaceServices';
+import { resolveGeminiModelCatalogFingerprint } from '@/providers/gemini/modelCatalogFingerprint';
 import { GeminiChatRuntime } from '@/providers/gemini/runtime/GeminiChatRuntime';
+import { getGeminiProviderSettings } from '@/providers/gemini/settings';
+
+function recordedFingerprintFor(cliPath: string): string {
+  return hashCatalogFingerprint(
+    resolveGeminiModelCatalogFingerprint(
+      { getResolvedProviderCliPath: () => cliPath } as any,
+      getGeminiProviderSettings({ providerConfigs: { gemini: { enabled: true } } }),
+    ),
+  );
+}
 
 describe('createGeminiWorkspaceServices', () => {
   afterEach(() => {
@@ -13,7 +25,7 @@ describe('createGeminiWorkspaceServices', () => {
     expect(services.usageProvider).toBeDefined();
   });
 
-  it('skips discovery while a seeded catalog stays fresh so opening the model dropdown does not boot the CLI', async () => {
+  it('keeps trusting a catalog persisted before the fingerprint existed', async () => {
     const ensureReady = jest.spyOn(GeminiChatRuntime.prototype, 'ensureReady');
     const cleanup = jest.spyOn(GeminiChatRuntime.prototype, 'cleanup').mockImplementation(() => {});
     const settings = {
@@ -152,6 +164,84 @@ describe('createGeminiWorkspaceServices', () => {
     expect(ensureReady).not.toHaveBeenCalled();
 
     await services.modelCatalog?.refreshModels({ force: true, plugin: plugin as any, settings: settings });
+
+    expect(ensureReady).toHaveBeenCalledTimes(1);
+  });
+  it('seeds a catalog whose recorded fingerprint still matches the resolved CLI', async () => {
+    const ensureReady = jest.spyOn(GeminiChatRuntime.prototype, 'ensureReady');
+    jest.spyOn(GeminiChatRuntime.prototype, 'cleanup').mockImplementation(() => {});
+    const settings = {
+      providerConfigs: {
+        gemini: {
+          discoveredModels: [{ label: 'Gemini 2.5 Pro', rawId: 'gemini-2.5-pro' }],
+          discoveredModelsFingerprint: recordedFingerprintFor('/usr/local/bin/gemini'),
+          enabled: true,
+        },
+      },
+    };
+    const plugin = {
+      getResolvedProviderCliPath: () => '/usr/local/bin/gemini',
+      settings,
+    };
+
+    const services = await createGeminiWorkspaceServices(plugin as any, {} as any);
+    const changed = await services.modelCatalog?.refreshModels({
+      plugin: plugin as any,
+      settings: settings,
+    });
+
+    expect(changed).toBe(false);
+    expect(ensureReady).not.toHaveBeenCalled();
+  });
+
+  it('rediscovers when the CLI path changed while the plugin was not running', async () => {
+    const ensureReady = jest
+      .spyOn(GeminiChatRuntime.prototype, 'ensureReady')
+      .mockResolvedValue(true);
+    jest.spyOn(GeminiChatRuntime.prototype, 'cleanup').mockImplementation(() => {});
+    const settings = {
+      providerConfigs: {
+        gemini: {
+          discoveredModels: [{ label: 'Gemini 2.5 Pro', rawId: 'gemini-2.5-pro' }],
+          discoveredModelsFingerprint: recordedFingerprintFor('/usr/local/bin/gemini'),
+          enabled: true,
+        },
+      },
+    };
+    const plugin = {
+      getResolvedProviderCliPath: () => '/opt/homebrew/bin/gemini',
+      settings,
+    };
+
+    const services = await createGeminiWorkspaceServices(plugin as any, {} as any);
+    await services.modelCatalog?.refreshModels({ plugin: plugin as any, settings: settings });
+
+    expect(ensureReady).toHaveBeenCalledTimes(1);
+  });
+
+  it('rediscovers a changed CLI even when the resolver only arrives after construction', async () => {
+    const ensureReady = jest
+      .spyOn(GeminiChatRuntime.prototype, 'ensureReady')
+      .mockResolvedValue(true);
+    jest.spyOn(GeminiChatRuntime.prototype, 'cleanup').mockImplementation(() => {});
+    const settings = {
+      providerConfigs: {
+        gemini: {
+          discoveredModels: [{ label: 'Gemini 2.5 Pro', rawId: 'gemini-2.5-pro' }],
+          discoveredModelsFingerprint: recordedFingerprintFor('/usr/local/bin/gemini'),
+          enabled: true,
+        },
+      },
+    };
+    let resolvedCliPath: string | null = null;
+    const plugin = {
+      getResolvedProviderCliPath: () => resolvedCliPath,
+      settings,
+    };
+
+    const services = await createGeminiWorkspaceServices(plugin as any, {} as any);
+    resolvedCliPath = '/opt/homebrew/bin/gemini';
+    await services.modelCatalog?.refreshModels({ plugin: plugin as any, settings: settings });
 
     expect(ensureReady).toHaveBeenCalledTimes(1);
   });

--- a/tests/unit/providers/gemini/runtime/GeminiChatRuntime.test.ts
+++ b/tests/unit/providers/gemini/runtime/GeminiChatRuntime.test.ts
@@ -1,7 +1,9 @@
 import * as fs from 'node:fs/promises';
 
+import { hashCatalogFingerprint } from '@/core/providers/catalogFingerprint';
 import type { StreamChunk } from '@/core/types';
 import type { AcpContentBlock } from '@/providers/acp';
+import { resolveGeminiModelCatalogFingerprint } from '@/providers/gemini/modelCatalogFingerprint';
 import { GeminiChatRuntime } from '@/providers/gemini/runtime/GeminiChatRuntime';
 import { getGeminiProviderSettings, updateGeminiProviderSettings } from '@/providers/gemini/settings';
 
@@ -86,6 +88,24 @@ describe('GeminiChatRuntime', () => {
       'gemini-2.5-pro',
       'gemini-2.5-flash',
     ]);
+  });
+
+  it('records the fingerprint of the discovery that produced the model list', () => {
+    const plugin = createMockPlugin();
+    const runtime = new GeminiChatRuntime(plugin);
+
+    (runtime as any).syncSessionDiscovery({
+      models: {
+        availableModels: [{ id: 'gemini-2.5-pro', name: 'Gemini 2.5 Pro' }],
+        currentModelId: 'gemini-2.5-pro',
+      },
+    });
+
+    expect(getGeminiProviderSettings(plugin.settings).discoveredModelsFingerprint).toBe(
+      hashCatalogFingerprint(
+        resolveGeminiModelCatalogFingerprint(plugin, getGeminiProviderSettings(plugin.settings)),
+      ),
+    );
   });
 
   it('replaces a stale visible model cache with the latest ACP catalog', () => {

--- a/tests/unit/providers/gemini/settings.test.ts
+++ b/tests/unit/providers/gemini/settings.test.ts
@@ -5,6 +5,24 @@ import {
 } from '@/providers/gemini/settings';
 
 describe('Gemini provider settings', () => {
+  it('defaults the discovery fingerprint to an empty string and ignores a non-string', () => {
+    expect(getGeminiProviderSettings({}).discoveredModelsFingerprint).toBe('');
+    expect(getGeminiProviderSettings({
+      providerConfigs: { gemini: { discoveredModelsFingerprint: 42 } },
+    }).discoveredModelsFingerprint).toBe('');
+  });
+
+  it('round-trips the discovery fingerprint and keeps it across unrelated updates', () => {
+    const settings: Record<string, unknown> = {};
+    updateGeminiProviderSettings(settings, { discoveredModelsFingerprint: 'abc12345' });
+
+    expect((settings as any).providerConfigs.gemini.discoveredModelsFingerprint).toBe('abc12345');
+
+    updateGeminiProviderSettings(settings, { environmentHash: 'API_KEY=new' });
+
+    expect(getGeminiProviderSettings(settings).discoveredModelsFingerprint).toBe('abc12345');
+  });
+
   it('is disabled by default and falls back to gemini from PATH', () => {
     const settings = getGeminiProviderSettings({});
 

--- a/tests/unit/providers/kimicode/KimicodeWorkspaceServices.test.ts
+++ b/tests/unit/providers/kimicode/KimicodeWorkspaceServices.test.ts
@@ -53,20 +53,84 @@ describe('createKimicodeWorkspaceServices', () => {
     ]);
   });
 
-  it('uses cached Kimi Code discovered models without warming the runtime again', async () => {
+  it('boots the runtime once and then reuses the discovered models for the rest of the process', async () => {
     const settings: Record<string, unknown> = {};
-    updateKimicodeProviderSettings(settings, {
-      discoveredModels: [{ label: 'OpenAI/GPT-5.6', rawId: 'openai/gpt-5.6' }],
-      enabled: true,
-      visibleModels: ['openai/gpt-5.6'],
-    });
+    updateKimicodeProviderSettings(settings, { enabled: true });
     const plugin = {
       recordDebugLog: jest.fn(),
       settings,
       saveSettings: jest.fn().mockResolvedValue(undefined),
     };
-    const ensureReadySpy = jest.spyOn(KimicodeChatRuntime.prototype, 'ensureReady');
-    const cleanupSpy = jest.spyOn(KimicodeChatRuntime.prototype, 'cleanup');
+    const ensureReadySpy = jest
+      .spyOn(KimicodeChatRuntime.prototype, 'ensureReady')
+      .mockImplementation(async function ensureReady(this: KimicodeChatRuntime) {
+        updateKimicodeProviderSettings((this as any).plugin.settings, {
+          discoveredModels: [{ label: 'OpenAI/GPT-5.6', rawId: 'openai/gpt-5.6' }],
+          visibleModels: ['openai/gpt-5.6'],
+        });
+        return true;
+      });
+    const cleanupSpy = jest.spyOn(KimicodeChatRuntime.prototype, 'cleanup').mockImplementation(() => undefined);
+    const vaultAdapter = {
+      delete: jest.fn(),
+      ensureFolder: jest.fn(),
+      exists: jest.fn().mockResolvedValue(false),
+      listFiles: jest.fn().mockResolvedValue([]),
+      read: jest.fn(),
+      write: jest.fn(),
+    };
+
+    const services = await createKimicodeWorkspaceServices(plugin as any, vaultAdapter as any);
+    const discovered = await services.modelCatalog?.refreshModels({
+      plugin: plugin as any,
+      settings,
+    });
+    const reused = await services.modelCatalog?.refreshModels({
+      plugin: plugin as any,
+      settings,
+    });
+
+    expect(discovered).toBe(true);
+    expect(reused).toBe(false);
+    expect(ensureReadySpy).toHaveBeenCalledTimes(1);
+    expect(cleanupSpy).toHaveBeenCalledTimes(1);
+    expect(plugin.recordDebugLog).toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({
+        modelCount: 1,
+        providerId: 'kimicode',
+        reason: 'cache_fresh',
+      }),
+      event: 'modelCatalog.refresh.skipped',
+      level: 'debug',
+      scope: 'provider.kimicode',
+    }));
+  });
+
+  it('rediscovers a list carried over from a legacy persisted field instead of pinning it', async () => {
+    const settings: Record<string, unknown> = {
+      providerConfigs: {
+        kimicode: {
+          discoveredModels: [{ label: 'OpenAI/GPT-5.5', rawId: 'openai/gpt-5.5' }],
+          enabled: true,
+          visibleModels: ['openai/gpt-5.5'],
+        },
+      },
+    };
+    const plugin = {
+      recordDebugLog: jest.fn(),
+      settings,
+      saveSettings: jest.fn().mockResolvedValue(undefined),
+    };
+    const ensureReadySpy = jest
+      .spyOn(KimicodeChatRuntime.prototype, 'ensureReady')
+      .mockImplementation(async function ensureReady(this: KimicodeChatRuntime) {
+        updateKimicodeProviderSettings((this as any).plugin.settings, {
+          discoveredModels: [{ label: 'OpenAI/GPT-5.6', rawId: 'openai/gpt-5.6' }],
+          visibleModels: ['openai/gpt-5.6'],
+        });
+        return true;
+      });
+    jest.spyOn(KimicodeChatRuntime.prototype, 'cleanup').mockImplementation(() => undefined);
     const vaultAdapter = {
       delete: jest.fn(),
       ensureFolder: jest.fn(),
@@ -82,18 +146,10 @@ describe('createKimicodeWorkspaceServices', () => {
       settings,
     });
 
-    expect(changed).toBe(false);
-    expect(ensureReadySpy).not.toHaveBeenCalled();
-    expect(cleanupSpy).not.toHaveBeenCalled();
-    expect(plugin.recordDebugLog).toHaveBeenCalledWith(expect.objectContaining({
-      data: expect.objectContaining({
-        modelCount: 1,
-        providerId: 'kimicode',
-        reason: 'cache_fresh',
-      }),
-      event: 'modelCatalog.refresh.skipped',
-      level: 'debug',
-      scope: 'provider.kimicode',
-    }));
+    expect(changed).toBe(true);
+    expect(ensureReadySpy).toHaveBeenCalledTimes(1);
+    expect(getKimicodeProviderSettings(settings).discoveredModels).toEqual([
+      { label: 'OpenAI/GPT-5.6', rawId: 'openai/gpt-5.6' },
+    ]);
   });
 });

--- a/tests/unit/providers/mimocode/MimocodeWorkspaceServices.test.ts
+++ b/tests/unit/providers/mimocode/MimocodeWorkspaceServices.test.ts
@@ -53,20 +53,84 @@ describe('createMimocodeWorkspaceServices', () => {
     ]);
   });
 
-  it('uses cached MiMoCode discovered models without warming the runtime again', async () => {
+  it('boots the runtime once and then reuses the discovered models for the rest of the process', async () => {
     const settings: Record<string, unknown> = {};
-    updateMimocodeProviderSettings(settings, {
-      discoveredModels: [{ label: 'OpenAI/GPT-5.6', rawId: 'openai/gpt-5.6' }],
-      enabled: true,
-      visibleModels: ['openai/gpt-5.6'],
-    });
+    updateMimocodeProviderSettings(settings, { enabled: true });
     const plugin = {
       recordDebugLog: jest.fn(),
       settings,
       saveSettings: jest.fn().mockResolvedValue(undefined),
     };
-    const ensureReadySpy = jest.spyOn(MimocodeChatRuntime.prototype, 'ensureReady');
-    const cleanupSpy = jest.spyOn(MimocodeChatRuntime.prototype, 'cleanup');
+    const ensureReadySpy = jest
+      .spyOn(MimocodeChatRuntime.prototype, 'ensureReady')
+      .mockImplementation(async function ensureReady(this: MimocodeChatRuntime) {
+        updateMimocodeProviderSettings((this as any).plugin.settings, {
+          discoveredModels: [{ label: 'OpenAI/GPT-5.6', rawId: 'openai/gpt-5.6' }],
+          visibleModels: ['openai/gpt-5.6'],
+        });
+        return true;
+      });
+    const cleanupSpy = jest.spyOn(MimocodeChatRuntime.prototype, 'cleanup').mockImplementation(() => undefined);
+    const vaultAdapter = {
+      delete: jest.fn(),
+      ensureFolder: jest.fn(),
+      exists: jest.fn().mockResolvedValue(false),
+      listFiles: jest.fn().mockResolvedValue([]),
+      read: jest.fn(),
+      write: jest.fn(),
+    };
+
+    const services = await createMimocodeWorkspaceServices(plugin as any, vaultAdapter as any);
+    const discovered = await services.modelCatalog?.refreshModels({
+      plugin: plugin as any,
+      settings,
+    });
+    const reused = await services.modelCatalog?.refreshModels({
+      plugin: plugin as any,
+      settings,
+    });
+
+    expect(discovered).toBe(true);
+    expect(reused).toBe(false);
+    expect(ensureReadySpy).toHaveBeenCalledTimes(1);
+    expect(cleanupSpy).toHaveBeenCalledTimes(1);
+    expect(plugin.recordDebugLog).toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({
+        modelCount: 1,
+        providerId: 'mimocode',
+        reason: 'cache_fresh',
+      }),
+      event: 'modelCatalog.refresh.skipped',
+      level: 'debug',
+      scope: 'provider.mimocode',
+    }));
+  });
+
+  it('rediscovers a list carried over from a legacy persisted field instead of pinning it', async () => {
+    const settings: Record<string, unknown> = {
+      providerConfigs: {
+        mimocode: {
+          discoveredModels: [{ label: 'OpenAI/GPT-5.5', rawId: 'openai/gpt-5.5' }],
+          enabled: true,
+          visibleModels: ['openai/gpt-5.5'],
+        },
+      },
+    };
+    const plugin = {
+      recordDebugLog: jest.fn(),
+      settings,
+      saveSettings: jest.fn().mockResolvedValue(undefined),
+    };
+    const ensureReadySpy = jest
+      .spyOn(MimocodeChatRuntime.prototype, 'ensureReady')
+      .mockImplementation(async function ensureReady(this: MimocodeChatRuntime) {
+        updateMimocodeProviderSettings((this as any).plugin.settings, {
+          discoveredModels: [{ label: 'OpenAI/GPT-5.6', rawId: 'openai/gpt-5.6' }],
+          visibleModels: ['openai/gpt-5.6'],
+        });
+        return true;
+      });
+    jest.spyOn(MimocodeChatRuntime.prototype, 'cleanup').mockImplementation(() => undefined);
     const vaultAdapter = {
       delete: jest.fn(),
       ensureFolder: jest.fn(),
@@ -82,18 +146,10 @@ describe('createMimocodeWorkspaceServices', () => {
       settings,
     });
 
-    expect(changed).toBe(false);
-    expect(ensureReadySpy).not.toHaveBeenCalled();
-    expect(cleanupSpy).not.toHaveBeenCalled();
-    expect(plugin.recordDebugLog).toHaveBeenCalledWith(expect.objectContaining({
-      data: expect.objectContaining({
-        modelCount: 1,
-        providerId: 'mimocode',
-        reason: 'cache_fresh',
-      }),
-      event: 'modelCatalog.refresh.skipped',
-      level: 'debug',
-      scope: 'provider.mimocode',
-    }));
+    expect(changed).toBe(true);
+    expect(ensureReadySpy).toHaveBeenCalledTimes(1);
+    expect(getMimocodeProviderSettings(settings).discoveredModels).toEqual([
+      { label: 'OpenAI/GPT-5.6', rawId: 'openai/gpt-5.6' },
+    ]);
   });
 });

--- a/tests/unit/providers/opencode/OpencodeWorkspaceServices.test.ts
+++ b/tests/unit/providers/opencode/OpencodeWorkspaceServices.test.ts
@@ -53,20 +53,84 @@ describe('createOpencodeWorkspaceServices', () => {
     ]);
   });
 
-  it('uses cached OpenCode discovered models without warming the runtime again', async () => {
+  it('boots the runtime once and then reuses the discovered models for the rest of the process', async () => {
     const settings: Record<string, unknown> = {};
-    updateOpencodeProviderSettings(settings, {
-      discoveredModels: [{ label: 'OpenAI/GPT-5.6', rawId: 'openai/gpt-5.6' }],
-      enabled: true,
-      visibleModels: ['openai/gpt-5.6'],
-    });
+    updateOpencodeProviderSettings(settings, { enabled: true });
     const plugin = {
       recordDebugLog: jest.fn(),
       settings,
       saveSettings: jest.fn().mockResolvedValue(undefined),
     };
-    const ensureReadySpy = jest.spyOn(OpencodeChatRuntime.prototype, 'ensureReady');
-    const cleanupSpy = jest.spyOn(OpencodeChatRuntime.prototype, 'cleanup');
+    const ensureReadySpy = jest
+      .spyOn(OpencodeChatRuntime.prototype, 'ensureReady')
+      .mockImplementation(async function ensureReady(this: OpencodeChatRuntime) {
+        updateOpencodeProviderSettings((this as any).plugin.settings, {
+          discoveredModels: [{ label: 'OpenAI/GPT-5.6', rawId: 'openai/gpt-5.6' }],
+          visibleModels: ['openai/gpt-5.6'],
+        });
+        return true;
+      });
+    const cleanupSpy = jest.spyOn(OpencodeChatRuntime.prototype, 'cleanup').mockImplementation(() => undefined);
+    const vaultAdapter = {
+      delete: jest.fn(),
+      ensureFolder: jest.fn(),
+      exists: jest.fn().mockResolvedValue(false),
+      listFiles: jest.fn().mockResolvedValue([]),
+      read: jest.fn(),
+      write: jest.fn(),
+    };
+
+    const services = await createOpencodeWorkspaceServices(plugin as any, vaultAdapter as any);
+    const discovered = await services.modelCatalog?.refreshModels({
+      plugin: plugin as any,
+      settings,
+    });
+    const reused = await services.modelCatalog?.refreshModels({
+      plugin: plugin as any,
+      settings,
+    });
+
+    expect(discovered).toBe(true);
+    expect(reused).toBe(false);
+    expect(ensureReadySpy).toHaveBeenCalledTimes(1);
+    expect(cleanupSpy).toHaveBeenCalledTimes(1);
+    expect(plugin.recordDebugLog).toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({
+        modelCount: 1,
+        providerId: 'opencode',
+        reason: 'cache_fresh',
+      }),
+      event: 'modelCatalog.refresh.skipped',
+      level: 'debug',
+      scope: 'provider.opencode',
+    }));
+  });
+
+  it('rediscovers a list carried over from a legacy persisted field instead of pinning it', async () => {
+    const settings: Record<string, unknown> = {
+      providerConfigs: {
+        opencode: {
+          discoveredModels: [{ label: 'OpenAI/GPT-5.5', rawId: 'openai/gpt-5.5' }],
+          enabled: true,
+          visibleModels: ['openai/gpt-5.5'],
+        },
+      },
+    };
+    const plugin = {
+      recordDebugLog: jest.fn(),
+      settings,
+      saveSettings: jest.fn().mockResolvedValue(undefined),
+    };
+    const ensureReadySpy = jest
+      .spyOn(OpencodeChatRuntime.prototype, 'ensureReady')
+      .mockImplementation(async function ensureReady(this: OpencodeChatRuntime) {
+        updateOpencodeProviderSettings((this as any).plugin.settings, {
+          discoveredModels: [{ label: 'OpenAI/GPT-5.6', rawId: 'openai/gpt-5.6' }],
+          visibleModels: ['openai/gpt-5.6'],
+        });
+        return true;
+      });
+    jest.spyOn(OpencodeChatRuntime.prototype, 'cleanup').mockImplementation(() => undefined);
     const vaultAdapter = {
       delete: jest.fn(),
       ensureFolder: jest.fn(),
@@ -82,18 +146,10 @@ describe('createOpencodeWorkspaceServices', () => {
       settings,
     });
 
-    expect(changed).toBe(false);
-    expect(ensureReadySpy).not.toHaveBeenCalled();
-    expect(cleanupSpy).not.toHaveBeenCalled();
-    expect(plugin.recordDebugLog).toHaveBeenCalledWith(expect.objectContaining({
-      data: expect.objectContaining({
-        modelCount: 1,
-        providerId: 'opencode',
-        reason: 'cache_fresh',
-      }),
-      event: 'modelCatalog.refresh.skipped',
-      level: 'debug',
-      scope: 'provider.opencode',
-    }));
+    expect(changed).toBe(true);
+    expect(ensureReadySpy).toHaveBeenCalledTimes(1);
+    expect(getOpencodeProviderSettings(settings).discoveredModels).toEqual([
+      { label: 'OpenAI/GPT-5.6', rawId: 'openai/gpt-5.6' },
+    ]);
   });
 });

--- a/tests/unit/providers/qwen/QwenWorkspaceServices.test.ts
+++ b/tests/unit/providers/qwen/QwenWorkspaceServices.test.ts
@@ -1,5 +1,17 @@
+import { hashCatalogFingerprint } from '@/core/providers/catalogFingerprint';
 import { createQwenWorkspaceServices } from '@/providers/qwen/app/QwenWorkspaceServices';
+import { resolveQwenModelCatalogFingerprint } from '@/providers/qwen/modelCatalogFingerprint';
 import { QwenChatRuntime } from '@/providers/qwen/runtime/QwenChatRuntime';
+import { getQwenProviderSettings } from '@/providers/qwen/settings';
+
+function recordedFingerprintFor(cliPath: string): string {
+  return hashCatalogFingerprint(
+    resolveQwenModelCatalogFingerprint(
+      { getResolvedProviderCliPath: () => cliPath } as any,
+      getQwenProviderSettings({ providerConfigs: { qwen: { enabled: true } } }),
+    ),
+  );
+}
 
 describe('createQwenWorkspaceServices', () => {
   afterEach(() => {
@@ -13,7 +25,7 @@ describe('createQwenWorkspaceServices', () => {
     expect(services.usageProvider).toBeDefined();
   });
 
-  it('skips discovery while a seeded catalog stays fresh so opening the model dropdown does not boot the CLI', async () => {
+  it('keeps trusting a catalog persisted before the fingerprint existed', async () => {
     const ensureReady = jest.spyOn(QwenChatRuntime.prototype, 'ensureReady');
     const cleanup = jest.spyOn(QwenChatRuntime.prototype, 'cleanup').mockImplementation(() => {});
     const settings = {
@@ -124,6 +136,84 @@ describe('createQwenWorkspaceServices', () => {
     const services = await createQwenWorkspaceServices(plugin as any, {} as any);
     resolvedCliPath = '/usr/local/bin/qwen';
     activeEnvironment = 'QWEN_API_KEY=new';
+    await services.modelCatalog?.refreshModels({ plugin: plugin as any, settings: settings });
+
+    expect(ensureReady).toHaveBeenCalledTimes(1);
+  });
+  it('seeds a catalog whose recorded fingerprint still matches the resolved CLI', async () => {
+    const ensureReady = jest.spyOn(QwenChatRuntime.prototype, 'ensureReady');
+    jest.spyOn(QwenChatRuntime.prototype, 'cleanup').mockImplementation(() => {});
+    const settings = {
+      providerConfigs: {
+        qwen: {
+          discoveredModels: [{ label: 'Qwen3 Coder', rawId: 'qwen3-coder-plus' }],
+          discoveredModelsFingerprint: recordedFingerprintFor('/usr/local/bin/qwen'),
+          enabled: true,
+        },
+      },
+    };
+    const plugin = {
+      getResolvedProviderCliPath: () => '/usr/local/bin/qwen',
+      settings,
+    };
+
+    const services = await createQwenWorkspaceServices(plugin as any, {} as any);
+    const changed = await services.modelCatalog?.refreshModels({
+      plugin: plugin as any,
+      settings: settings,
+    });
+
+    expect(changed).toBe(false);
+    expect(ensureReady).not.toHaveBeenCalled();
+  });
+
+  it('rediscovers when the CLI path changed while the plugin was not running', async () => {
+    const ensureReady = jest
+      .spyOn(QwenChatRuntime.prototype, 'ensureReady')
+      .mockResolvedValue(true);
+    jest.spyOn(QwenChatRuntime.prototype, 'cleanup').mockImplementation(() => {});
+    const settings = {
+      providerConfigs: {
+        qwen: {
+          discoveredModels: [{ label: 'Qwen3 Coder', rawId: 'qwen3-coder-plus' }],
+          discoveredModelsFingerprint: recordedFingerprintFor('/usr/local/bin/qwen'),
+          enabled: true,
+        },
+      },
+    };
+    const plugin = {
+      getResolvedProviderCliPath: () => '/opt/homebrew/bin/qwen',
+      settings,
+    };
+
+    const services = await createQwenWorkspaceServices(plugin as any, {} as any);
+    await services.modelCatalog?.refreshModels({ plugin: plugin as any, settings: settings });
+
+    expect(ensureReady).toHaveBeenCalledTimes(1);
+  });
+
+  it('rediscovers a changed CLI even when the resolver only arrives after construction', async () => {
+    const ensureReady = jest
+      .spyOn(QwenChatRuntime.prototype, 'ensureReady')
+      .mockResolvedValue(true);
+    jest.spyOn(QwenChatRuntime.prototype, 'cleanup').mockImplementation(() => {});
+    const settings = {
+      providerConfigs: {
+        qwen: {
+          discoveredModels: [{ label: 'Qwen3 Coder', rawId: 'qwen3-coder-plus' }],
+          discoveredModelsFingerprint: recordedFingerprintFor('/usr/local/bin/qwen'),
+          enabled: true,
+        },
+      },
+    };
+    let resolvedCliPath: string | null = null;
+    const plugin = {
+      getResolvedProviderCliPath: () => resolvedCliPath,
+      settings,
+    };
+
+    const services = await createQwenWorkspaceServices(plugin as any, {} as any);
+    resolvedCliPath = '/opt/homebrew/bin/qwen';
     await services.modelCatalog?.refreshModels({ plugin: plugin as any, settings: settings });
 
     expect(ensureReady).toHaveBeenCalledTimes(1);

--- a/tests/unit/providers/qwen/runtime/QwenChatRuntime.test.ts
+++ b/tests/unit/providers/qwen/runtime/QwenChatRuntime.test.ts
@@ -1,8 +1,10 @@
 import * as fs from 'node:fs/promises';
 
+import { hashCatalogFingerprint } from '@/core/providers/catalogFingerprint';
 import { ProviderWorkspaceRegistry } from '@/core/providers/ProviderWorkspaceRegistry';
 import type { StreamChunk } from '@/core/types';
 import type { AcpContentBlock } from '@/providers/acp';
+import { resolveQwenModelCatalogFingerprint } from '@/providers/qwen/modelCatalogFingerprint';
 import { QwenChatRuntime } from '@/providers/qwen/runtime/QwenChatRuntime';
 import { getQwenProviderSettings, updateQwenProviderSettings } from '@/providers/qwen/settings';
 
@@ -96,6 +98,24 @@ describe('QwenChatRuntime', () => {
       'qwen-2.5-pro',
       'qwen-2.5-flash',
     ]);
+  });
+
+  it('records the fingerprint of the discovery that produced the model list', () => {
+    const plugin = createMockPlugin();
+    const runtime = new QwenChatRuntime(plugin);
+
+    (runtime as any).syncSessionDiscovery({
+      models: {
+        availableModels: [{ id: 'qwen-2.5-pro', name: 'Qwen 2.5 Pro' }],
+        currentModelId: 'qwen-2.5-pro',
+      },
+    });
+
+    expect(getQwenProviderSettings(plugin.settings).discoveredModelsFingerprint).toBe(
+      hashCatalogFingerprint(
+        resolveQwenModelCatalogFingerprint(plugin, getQwenProviderSettings(plugin.settings)),
+      ),
+    );
   });
 
   it('replaces a stale visible model cache with the latest ACP catalog', () => {

--- a/tests/unit/providers/qwen/settings.test.ts
+++ b/tests/unit/providers/qwen/settings.test.ts
@@ -5,6 +5,24 @@ import {
 } from '@/providers/qwen/settings';
 
 describe('Qwen provider settings', () => {
+  it('defaults the discovery fingerprint to an empty string and ignores a non-string', () => {
+    expect(getQwenProviderSettings({}).discoveredModelsFingerprint).toBe('');
+    expect(getQwenProviderSettings({
+      providerConfigs: { qwen: { discoveredModelsFingerprint: 42 } },
+    }).discoveredModelsFingerprint).toBe('');
+  });
+
+  it('round-trips the discovery fingerprint and keeps it across unrelated updates', () => {
+    const settings: Record<string, unknown> = {};
+    updateQwenProviderSettings(settings, { discoveredModelsFingerprint: 'abc12345' });
+
+    expect((settings as any).providerConfigs.qwen.discoveredModelsFingerprint).toBe('abc12345');
+
+    updateQwenProviderSettings(settings, { environmentHash: 'API_KEY=new' });
+
+    expect(getQwenProviderSettings(settings).discoveredModelsFingerprint).toBe('abc12345');
+  });
+
   it('is disabled by default and falls back to qwen from PATH', () => {
     const settings = getQwenProviderSettings({});
 


### PR DESCRIPTION
Closes #98.

## The defect

`ProviderModelCatalogRefreshCache.seed()` marked a persisted `discoveredModels` list fresh under the key computed by *this* load, with nothing recording the key the list actually came from. The TTL did not bound it — `isFresh` short-circuits the age check whenever the catalog is non-empty:

```ts
return hasCachedModels || this.now() - this.lastSuccessfulRefreshAt < this.ttlMs;
```

So the seed was permanent, not a ten-minute window. Change the CLI while Obsidian is closed and both construction and lookup read the new CLI: the keys agree with each other, the seed applies, discovery is suppressed, and the previous CLI's models stay pinned indefinitely.

## The fix

The check lives once in the shared cache. `seed(fingerprint, recordedFingerprint?)` and `applyDeferredSeed(fingerprint, hasCachedModels, recordedFingerprint?)` apply only while the recorded digest still describes the current key. An absent digest keeps today's behaviour, so no existing install pays a CLI spawn to migrate; such a catalog gains its baseline at the next real discovery.

The FNV-1a digest moved from `claudeCatalogCache` to `src/core/providers/catalogFingerprint.ts`, now that two providers need it. Pinned FNV-1a vectors guard the digests Claude has already persisted; the Claude suites pass untouched.

**Codex, Gemini, Qwen** persist `discoveredModels`, so they gain `discoveredModelsFingerprint`, written by whoever writes the list — the catalog's own listing for Codex, `syncSessionDiscovery` for the ACP pair, plus Codex's runtime discovery path. It is written on **every** successful discovery, not only when the list changes: a new CLI offering the same models must still re-record, or the next load compares the previous digest and rediscovers on every start. `updateCodexModelDiscoveryState` therefore reports a digest-only change as changed, because the caller has to save it. Nothing is written when neither list nor digest moved.

**OpenCode, MiMoCode, Kimi Code** lose the eager seed instead of gaining a digest. Their discovered list is memory-only (Symbol state; a legacy persisted field is copied into memory and stripped on the first settings update), so the seed could only ever speak for a list this cache never watched being discovered — and then pinned it for the rest of the process. There is nothing to compare a digest against after a reload. Without the seed, the first refresh boots the runtime once per process and every later one reuses it.

## Verification

- `npm run test -- --selectProjects unit` — 7291 passed; `--selectProjects integration` — 216 passed; `npm run typecheck`; `npm run lint`; `npm run build:release` all green.
- Each new fingerprint test was confirmed to fail with the digest argument or the digest write removed, then pass again with it restored.

## Not covered (follow-up)

OpenCode/MiMoCode/Kimi Code key on `settings.cliPath` rather than `getResolvedProviderCliPath`, so a binary found via PATH is invisible to the key. And no provider's key notices a binary replaced at the same path (`brew upgrade`) — only Claude fingerprints the binary itself.

https://claude.ai/code/session_01TDYHm4Ggxppte2w94Bdtak