### PR TITLE
fix(acp): ask the agent whether a session is gone instead of guessing

### DIFF
--- a/src/providers/acp/acpSessionResume.ts
+++ b/src/providers/acp/acpSessionResume.ts
@@ -32,17 +32,29 @@ export interface AcpSessionLoadFailureContext {
 
 export interface AcpPersistedSessionUpdateInput {
   conversationDatabasePath?: string | null;
+  /** What the conversation already recorded, so the marker survives a save. */
+  conversationSessionDropped?: boolean;
   currentDatabasePath?: string | null;
   sessionId: string | null;
   sessionInvalidated: boolean;
 }
 
-const MISSING_SESSION_REASON_PATTERN = /^(?:invalid[_ -]?session(?:[_ -]?id)?|missing[_ -]?session|session[_ -]?(?:missing|not[_ -]?found|unknown))$/i;
+/**
+ * `session`, as the CLIs actually spell it: plural in "no previous sessions",
+ * camel-cased in "Unknown sessionId". A bare `\bsession\b` matches neither.
+ */
+const SESSION_TOKEN = String.raw`session(?:s|[_ -]?ids?|[_ -]?id)?`;
+const GONE_TOKEN = String.raw`(?:does not exist|missing|not[_ -]?found|unknown|no previous|expired|no longer (?:exists|available))`;
+
+const MISSING_SESSION_REASON_PATTERN = new RegExp(
+  String.raw`^(?:invalid[_ -]?${SESSION_TOKEN}|missing[_ -]?${SESSION_TOKEN}|${SESSION_TOKEN}[_ -]?(?:missing|not[_ -]?found|unknown|expired))$`,
+  'i',
+);
 const MISSING_SESSION_MESSAGE_PATTERNS = [
-  /\bsession\b.{0,80}\b(?:does not exist|missing|not found|unknown)\b/i,
-  /\b(?:missing|no|unknown)\b.{0,40}\bsession\b/i,
-  /\bcould not find\b.{0,40}\bsession\b/i,
-  /\binvalid session(?: id)?\b/i,
+  new RegExp(String.raw`\b${SESSION_TOKEN}\b.{0,80}\b${GONE_TOKEN}\b`, 'i'),
+  new RegExp(String.raw`\b(?:missing|no|unknown|not[_ -]?found)\b.{0,40}\b${SESSION_TOKEN}\b`, 'i'),
+  new RegExp(String.raw`\bcould not find\b.{0,40}\b${SESSION_TOKEN}\b`, 'i'),
+  new RegExp(String.raw`\binvalid ${SESSION_TOKEN}\b`, 'i'),
 ];
 
 /**
@@ -63,6 +75,62 @@ export function isAcpMissingSessionError(error: unknown): boolean {
     return MISSING_SESSION_REASON_PATTERN.test(normalized)
       || MISSING_SESSION_MESSAGE_PATTERNS.some(pattern => pattern.test(normalized));
   });
+}
+
+export interface AcpSessionListing {
+  sessions?: Array<{ sessionId?: string | null } | null> | null;
+}
+
+export interface AcpSessionGoneProbe {
+  /** The error `session/load` rejected with. */
+  error: unknown;
+  /** Asks the agent which sessions it still has. */
+  listSessions: () => Promise<AcpSessionListing>;
+  /** The session id the failed load was for. */
+  sessionId: string;
+}
+
+/**
+ * Whether a failed `session/load` means the session is gone.
+ *
+ * Error text alone cannot answer this. Every managed CLI we ship against
+ * reports a missing session as a generic internal error - OpenCode and MiMoCode
+ * as a bare `-32603 Internal error`, with nothing in `data` to key on - so the
+ * message patterns above recognise none of them. Reading the wrong answer out
+ * of that text is expensive in both directions: treat a live session as gone
+ * and the conversation silently loses its context, treat a gone session as live
+ * and every turn retries a dead id.
+ *
+ * So we ask instead. `session/list` is part of the same ACP surface and the
+ * agent has already answered on this connection, which is what makes the extra
+ * round trip safe to spend here: it only happens on a load that already failed.
+ * An agent without the method, or one that fails to answer, leaves us where we
+ * started - the binding is kept and the original error propagates, so a
+ * recoverable failure stays recoverable.
+ */
+export async function isAcpSessionGone(probe: AcpSessionGoneProbe): Promise<boolean> {
+  if (isAcpMissingSessionError(probe.error)) {
+    return true;
+  }
+  // A transport failure says nothing about the session, and there is no live
+  // connection left to ask on.
+  if (!(probe.error instanceof JsonRpcErrorResponse)) {
+    return false;
+  }
+
+  let listing: AcpSessionListing;
+  try {
+    listing = await probe.listSessions();
+  } catch {
+    return false;
+  }
+
+  const sessions = listing?.sessions;
+  if (!Array.isArray(sessions)) {
+    return false;
+  }
+
+  return !sessions.some(entry => entry?.sessionId === probe.sessionId);
 }
 
 function collectDiagnosticStrings(...values: unknown[]): string[] {
@@ -126,22 +194,29 @@ export function buildAcpPersistedSessionFields(
   input: AcpPersistedSessionUpdateInput,
 ): {
   databasePath?: string;
+  sessionDropped: boolean;
   sessionId: string | null;
 } {
   const databasePath = input.currentDatabasePath
     ?? input.conversationDatabasePath
     ?? null;
+  const sessionId = input.sessionInvalidated && !input.sessionId
+    ? null
+    : input.sessionId;
 
-  if (input.sessionInvalidated && !input.sessionId) {
-    return {
-      ...(databasePath ? { databasePath } : {}),
-      sessionId: null,
-    };
-  }
+  // "We had a session and lost it" has to outlive the runtime that learned it.
+  // The in-memory flag is consumed by the first save, and saves happen on tab
+  // close and on quit - so without a persisted marker a drop that nobody
+  // answered yet reads as a first-ever send on the next launch, and the whole
+  // transcript gets replayed into a fresh session. The marker clears itself the
+  // moment a real session id is persisted again.
+  const sessionDropped = !sessionId
+    && (input.sessionInvalidated || input.conversationSessionDropped === true);
 
   return {
     ...(databasePath ? { databasePath } : {}),
-    sessionId: input.sessionId,
+    sessionDropped,
+    sessionId,
   };
 }
 

--- a/src/providers/kimicode/AGENTS.md
+++ b/src/providers/kimicode/AGENTS.md
@@ -18,5 +18,6 @@
 
 ## Session resume
 
-- Persist both `sessionId` and `providerState.databasePath` after turns.
-- Invalidate only when `session/load` explicitly reports a missing session. Preserve `databasePath`; propagate transport, authentication, and configuration errors without clearing the binding.
+- Persist `sessionId`, `providerState.databasePath`, and `providerState.sessionDropped` after turns.
+- On `session/load` failure, decide with `isAcpSessionGone`: it asks the agent through `session/list` rather than reading the answer out of the error text, which Kimi Code does not put there. A session the agent no longer lists is soft-failed into a fresh one; anything else - transport, authentication, configuration, or an agent that cannot list - propagates with the binding intact. Preserve `databasePath`.
+- A dropped session is recorded in `providerState.sessionDropped` and read back on load, because the in-memory flag is consumed by the first save. Never replay the transcript into a replacement session: history bootstrap is for a cold resume that never held a session id.

--- a/src/providers/kimicode/runtime/KimicodeChatRuntime.ts
+++ b/src/providers/kimicode/runtime/KimicodeChatRuntime.ts
@@ -71,8 +71,8 @@ import {
   extractAcpSessionModelState,
   extractAcpSessionModeState,
   extractAcpSessionThoughtLevelState,
-  isAcpMissingSessionError,
   isAcpRetryableTransportClose,
+  isAcpSessionGone,
   planAcpEnsureReadySessionPhase,
   resolveWorkspacePath,
   runAcpEnsureReadyForQuery,
@@ -244,6 +244,9 @@ export class KimicodeChatRuntime implements ChatRuntime {
     }
     this.sessionId = nextSessionId;
     const state = getKimicodeState(conversation?.providerState);
+    if (!nextSessionId && state.sessionDropped) {
+      this.sessionInvalidated = true;
+    }
     if (state.databasePath) {
       this.currentDatabasePath = state.databasePath;
       return;
@@ -388,8 +391,15 @@ export class KimicodeChatRuntime implements ChatRuntime {
   ): AsyncGenerator<StreamChunk> {
     const previousMessages = conversationHistory ?? [];
     const expectedSessionId = this.sessionId;
+    // A session that was dropped must not have the transcript replayed into its
+    // replacement: that silently re-buys the whole conversation, once per failed
+    // resume, without anyone asking. Bootstrap is for a genuine cold resume -
+    // one where no session was ever held. `sessionInvalidated` is what tells the
+    // two apart, and it is restored from the conversation, because the drop
+    // usually happens during warmup, before query() runs at all.
     let shouldBootstrapHistory = previousMessages.length > 0
-      && (!expectedSessionId || this.sessionInvalidated);
+      && !expectedSessionId
+      && !this.sessionInvalidated;
 
     const lifecycleGeneration = this.lifecycleGeneration;
     if (!(await this.ensureReadyForQuery(lifecycleGeneration))) {
@@ -405,9 +415,9 @@ export class KimicodeChatRuntime implements ChatRuntime {
     }
 
     const cwd = getVaultPath(this.plugin.app) ?? process.cwd();
-    if (expectedSessionId && !this.sessionId) {
-      shouldBootstrapHistory = previousMessages.length > 0;
-    }
+    // Deliberately no bootstrap here: if readiness dropped the session, the
+    // replacement starts clean and recovering the earlier context is the user's
+    // call, not a purchase we make for them.
 
     if (!this.sessionId) {
       const sessionId = await this.createSession(cwd);
@@ -643,16 +653,21 @@ export class KimicodeChatRuntime implements ChatRuntime {
       : null;
     const fields = buildAcpPersistedSessionFields({
       conversationDatabasePath: existingState?.databasePath,
+      conversationSessionDropped: existingState?.sessionDropped,
       currentDatabasePath: this.currentDatabasePath,
       sessionId: this.sessionId,
       sessionInvalidated: params.sessionInvalidated,
     });
     const providerState: KimicodeProviderState = {
       ...(fields.databasePath ? { databasePath: fields.databasePath } : {}),
+      ...(fields.sessionDropped ? { sessionDropped: true } : {}),
     };
+    // An empty object would leave the stored state untouched, so a marker that
+    // has just cleared still has to be written out.
+    const mustClearMarker = existingState?.sessionDropped === true && !fields.sessionDropped;
     return {
       updates: {
-        providerState: Object.keys(providerState).length > 0
+        providerState: Object.keys(providerState).length > 0 || mustClearMarker
           ? providerState as Record<string, unknown>
           : undefined,
         sessionId: fields.sessionId,
@@ -1219,13 +1234,14 @@ export class KimicodeChatRuntime implements ChatRuntime {
   }
 
   private async loadSession(sessionId: string, cwd: string): Promise<boolean> {
-    if (!this.connection) {
+    const connection = this.connection;
+    if (!connection) {
       return false;
     }
 
     try {
       this.setSupportedCommands([]);
-      const response = await this.connection.loadSession({
+      const response = await connection.loadSession({
         cwd,
         mcpServers: this.getMcpServers(),
         sessionId,
@@ -1245,7 +1261,16 @@ export class KimicodeChatRuntime implements ChatRuntime {
       });
       return true;
     } catch (error) {
-      if (!isAcpMissingSessionError(error)) {
+      // Ask the agent whether the session still exists instead of reading the
+      // answer out of the error text - none of the managed CLIs put it there.
+      // A session that is genuinely gone is soft-failed into a fresh one; an
+      // auth or configuration failure keeps the binding and surfaces.
+      const sessionGone = await isAcpSessionGone({
+        error,
+        listSessions: () => connection.listSessions(),
+        sessionId,
+      });
+      if (!sessionGone) {
         throw error;
       }
       this.lastSessionLoadError = error;

--- a/src/providers/kimicode/types/index.ts
+++ b/src/providers/kimicode/types/index.ts
@@ -1,5 +1,11 @@
 export interface KimicodeProviderState {
   databasePath?: string;
+  /**
+   * Set when a saved session failed to load and no replacement was persisted.
+   * Read back on the next load so a dropped session is not mistaken for a
+   * conversation that never had one.
+   */
+  sessionDropped?: boolean;
 }
 
 export function getKimicodeState(

--- a/src/providers/mimocode/AGENTS.md
+++ b/src/providers/mimocode/AGENTS.md
@@ -18,5 +18,6 @@
 
 ## Session resume
 
-- Persist both `sessionId` and `providerState.databasePath` after turns.
-- Invalidate only when `session/load` explicitly reports a missing session. Preserve `databasePath`; propagate transport, authentication, and configuration errors without clearing the binding.
+- Persist `sessionId`, `providerState.databasePath`, and `providerState.sessionDropped` after turns.
+- On `session/load` failure, decide with `isAcpSessionGone`: it asks the agent through `session/list` rather than reading the answer out of the error text, which MiMoCode does not put there. A session the agent no longer lists is soft-failed into a fresh one; anything else - transport, authentication, configuration, or an agent that cannot list - propagates with the binding intact. Preserve `databasePath`.
+- A dropped session is recorded in `providerState.sessionDropped` and read back on load, because the in-memory flag is consumed by the first save. Never replay the transcript into a replacement session: history bootstrap is for a cold resume that never held a session id.

--- a/src/providers/mimocode/runtime/MimocodeChatRuntime.ts
+++ b/src/providers/mimocode/runtime/MimocodeChatRuntime.ts
@@ -71,8 +71,8 @@ import {
   extractAcpSessionModelState,
   extractAcpSessionModeState,
   extractAcpSessionThoughtLevelState,
-  isAcpMissingSessionError,
   isAcpRetryableTransportClose,
+  isAcpSessionGone,
   planAcpEnsureReadySessionPhase,
   resolveWorkspacePath,
   runAcpEnsureReadyForQuery,
@@ -249,6 +249,9 @@ export class MimocodeChatRuntime implements ChatRuntime {
     }
     this.sessionId = nextSessionId;
     const state = getMimocodeState(conversation?.providerState);
+    if (!nextSessionId && state.sessionDropped) {
+      this.sessionInvalidated = true;
+    }
     if (state.databasePath) {
       this.currentDatabasePath = state.databasePath;
       return;
@@ -393,8 +396,15 @@ export class MimocodeChatRuntime implements ChatRuntime {
   ): AsyncGenerator<StreamChunk> {
     const previousMessages = conversationHistory ?? [];
     const expectedSessionId = this.sessionId;
+    // A session that was dropped must not have the transcript replayed into its
+    // replacement: that silently re-buys the whole conversation, once per failed
+    // resume, without anyone asking. Bootstrap is for a genuine cold resume -
+    // one where no session was ever held. `sessionInvalidated` is what tells the
+    // two apart, and it is restored from the conversation, because the drop
+    // usually happens during warmup, before query() runs at all.
     let shouldBootstrapHistory = previousMessages.length > 0
-      && (!expectedSessionId || this.sessionInvalidated);
+      && !expectedSessionId
+      && !this.sessionInvalidated;
 
     const lifecycleGeneration = this.lifecycleGeneration;
     if (!(await this.ensureReadyForQuery(lifecycleGeneration))) {
@@ -410,9 +420,9 @@ export class MimocodeChatRuntime implements ChatRuntime {
     }
 
     const cwd = getVaultPath(this.plugin.app) ?? process.cwd();
-    if (expectedSessionId && !this.sessionId) {
-      shouldBootstrapHistory = previousMessages.length > 0;
-    }
+    // Deliberately no bootstrap here: if readiness dropped the session, the
+    // replacement starts clean and recovering the earlier context is the user's
+    // call, not a purchase we make for them.
 
     if (!this.sessionId) {
       const sessionId = await this.createSession(cwd);
@@ -673,16 +683,21 @@ export class MimocodeChatRuntime implements ChatRuntime {
       : null;
     const fields = buildAcpPersistedSessionFields({
       conversationDatabasePath: existingState?.databasePath,
+      conversationSessionDropped: existingState?.sessionDropped,
       currentDatabasePath: this.currentDatabasePath,
       sessionId: this.sessionId,
       sessionInvalidated: params.sessionInvalidated,
     });
     const providerState: MimocodeProviderState = {
       ...(fields.databasePath ? { databasePath: fields.databasePath } : {}),
+      ...(fields.sessionDropped ? { sessionDropped: true } : {}),
     };
+    // An empty object would leave the stored state untouched, so a marker that
+    // has just cleared still has to be written out.
+    const mustClearMarker = existingState?.sessionDropped === true && !fields.sessionDropped;
     return {
       updates: {
-        providerState: Object.keys(providerState).length > 0
+        providerState: Object.keys(providerState).length > 0 || mustClearMarker
           ? providerState as Record<string, unknown>
           : undefined,
         sessionId: fields.sessionId,
@@ -1249,13 +1264,14 @@ export class MimocodeChatRuntime implements ChatRuntime {
   }
 
   private async loadSession(sessionId: string, cwd: string): Promise<boolean> {
-    if (!this.connection) {
+    const connection = this.connection;
+    if (!connection) {
       return false;
     }
 
     try {
       this.setSupportedCommands([]);
-      const response = await this.connection.loadSession({
+      const response = await connection.loadSession({
         cwd,
         mcpServers: this.getMcpServers(),
         sessionId,
@@ -1275,7 +1291,16 @@ export class MimocodeChatRuntime implements ChatRuntime {
       });
       return true;
     } catch (error) {
-      if (!isAcpMissingSessionError(error)) {
+      // Ask the agent whether the session still exists instead of reading the
+      // answer out of the error text - none of the managed CLIs put it there.
+      // A session that is genuinely gone is soft-failed into a fresh one; an
+      // auth or configuration failure keeps the binding and surfaces.
+      const sessionGone = await isAcpSessionGone({
+        error,
+        listSessions: () => connection.listSessions(),
+        sessionId,
+      });
+      if (!sessionGone) {
         throw error;
       }
       this.lastSessionLoadError = error;

--- a/src/providers/mimocode/types/index.ts
+++ b/src/providers/mimocode/types/index.ts
@@ -1,5 +1,11 @@
 export interface MimocodeProviderState {
   databasePath?: string;
+  /**
+   * Set when a saved session failed to load and no replacement was persisted.
+   * Read back on the next load so a dropped session is not mistaken for a
+   * conversation that never had one.
+   */
+  sessionDropped?: boolean;
 }
 
 export function getMimocodeState(

--- a/src/providers/opencode/AGENTS.md
+++ b/src/providers/opencode/AGENTS.md
@@ -18,6 +18,7 @@
 
 ## Session resume
 
-- Persist both `sessionId` and `providerState.databasePath` after turns.
-- On ACP `session/load`, invalidate only when the JSON-RPC response explicitly says the session is missing. Log the missing session via debug and **keep** `databasePath` so SQLite hydrate and `OPENCODE_DB` still resolve. Transport, authentication, and configuration errors must propagate without clearing the live or persisted binding.
+- Persist `sessionId`, `providerState.databasePath`, and `providerState.sessionDropped` after turns.
+- On ACP `session/load` failure, decide with `isAcpSessionGone`: it asks the agent through `session/list` rather than reading the answer out of the error text, which OpenCode does not put there. A session the agent no longer lists is soft-failed into a fresh one; anything else - transport, authentication, configuration, or an agent that cannot list - propagates with the live and persisted binding intact. Log the failure via debug and **keep** `databasePath` so SQLite hydrate and `OPENCODE_DB` still resolve.
+- A dropped session is recorded in `providerState.sessionDropped` and read back on load, because the in-memory flag is consumed by the first save. Never replay the transcript into a replacement session: history bootstrap is for a cold resume that never held a session id.
 - Use shared helpers in `src/providers/acp/acpSessionResume.ts` rather than inventing a fourth wipe policy.

--- a/src/providers/opencode/runtime/OpencodeChatRuntime.ts
+++ b/src/providers/opencode/runtime/OpencodeChatRuntime.ts
@@ -71,8 +71,8 @@ import {
   extractAcpSessionModelState,
   extractAcpSessionModeState,
   extractAcpSessionThoughtLevelState,
-  isAcpMissingSessionError,
   isAcpRetryableTransportClose,
+  isAcpSessionGone,
   planAcpEnsureReadySessionPhase,
   resolveWorkspacePath,
   runAcpEnsureReadyForQuery,
@@ -244,6 +244,9 @@ export class OpencodeChatRuntime implements ChatRuntime {
     }
     this.sessionId = nextSessionId;
     const state = getOpencodeState(conversation?.providerState);
+    if (!nextSessionId && state.sessionDropped) {
+      this.sessionInvalidated = true;
+    }
     if (state.databasePath) {
       this.currentDatabasePath = state.databasePath;
       return;
@@ -388,8 +391,15 @@ export class OpencodeChatRuntime implements ChatRuntime {
   ): AsyncGenerator<StreamChunk> {
     const previousMessages = conversationHistory ?? [];
     const expectedSessionId = this.sessionId;
+    // A session that was dropped must not have the transcript replayed into its
+    // replacement: that silently re-buys the whole conversation, once per failed
+    // resume, without anyone asking. Bootstrap is for a genuine cold resume -
+    // one where no session was ever held. `sessionInvalidated` is what tells the
+    // two apart, and it is restored from the conversation, because the drop
+    // usually happens during warmup, before query() runs at all.
     let shouldBootstrapHistory = previousMessages.length > 0
-      && (!expectedSessionId || this.sessionInvalidated);
+      && !expectedSessionId
+      && !this.sessionInvalidated;
 
     const lifecycleGeneration = this.lifecycleGeneration;
     if (!(await this.ensureReadyForQuery(lifecycleGeneration))) {
@@ -405,9 +415,9 @@ export class OpencodeChatRuntime implements ChatRuntime {
     }
 
     const cwd = getVaultPath(this.plugin.app) ?? process.cwd();
-    if (expectedSessionId && !this.sessionId) {
-      shouldBootstrapHistory = previousMessages.length > 0;
-    }
+    // Deliberately no bootstrap here: if readiness dropped the session, the
+    // replacement starts clean and recovering the earlier context is the user's
+    // call, not a purchase we make for them.
 
     if (!this.sessionId) {
       const sessionId = await this.createSession(cwd);
@@ -643,16 +653,21 @@ export class OpencodeChatRuntime implements ChatRuntime {
       : null;
     const fields = buildAcpPersistedSessionFields({
       conversationDatabasePath: existingState?.databasePath,
+      conversationSessionDropped: existingState?.sessionDropped,
       currentDatabasePath: this.currentDatabasePath,
       sessionId: this.sessionId,
       sessionInvalidated: params.sessionInvalidated,
     });
     const providerState: OpencodeProviderState = {
       ...(fields.databasePath ? { databasePath: fields.databasePath } : {}),
+      ...(fields.sessionDropped ? { sessionDropped: true } : {}),
     };
+    // An empty object would leave the stored state untouched, so a marker that
+    // has just cleared still has to be written out.
+    const mustClearMarker = existingState?.sessionDropped === true && !fields.sessionDropped;
     return {
       updates: {
-        providerState: Object.keys(providerState).length > 0
+        providerState: Object.keys(providerState).length > 0 || mustClearMarker
           ? providerState as Record<string, unknown>
           : undefined,
         sessionId: fields.sessionId,
@@ -1218,13 +1233,14 @@ export class OpencodeChatRuntime implements ChatRuntime {
   }
 
   private async loadSession(sessionId: string, cwd: string): Promise<boolean> {
-    if (!this.connection) {
+    const connection = this.connection;
+    if (!connection) {
       return false;
     }
 
     try {
       this.setSupportedCommands([]);
-      const response = await this.connection.loadSession({
+      const response = await connection.loadSession({
         cwd,
         mcpServers: this.getMcpServers(),
         sessionId,
@@ -1244,7 +1260,16 @@ export class OpencodeChatRuntime implements ChatRuntime {
       });
       return true;
     } catch (error) {
-      if (!isAcpMissingSessionError(error)) {
+      // Ask the agent whether the session still exists instead of reading the
+      // answer out of the error text - none of the managed CLIs put it there.
+      // A session that is genuinely gone is soft-failed into a fresh one; an
+      // auth or configuration failure keeps the binding and surfaces.
+      const sessionGone = await isAcpSessionGone({
+        error,
+        listSessions: () => connection.listSessions(),
+        sessionId,
+      });
+      if (!sessionGone) {
         throw error;
       }
       this.lastSessionLoadError = error;

--- a/src/providers/opencode/types/index.ts
+++ b/src/providers/opencode/types/index.ts
@@ -1,5 +1,11 @@
 export interface OpencodeProviderState {
   databasePath?: string;
+  /**
+   * Set when a saved session failed to load and no replacement was persisted.
+   * Read back on the next load so a dropped session is not mistaken for a
+   * conversation that never had one.
+   */
+  sessionDropped?: boolean;
 }
 
 export function getOpencodeState(

--- a/tests/unit/providers/acp/acpSessionResume.test.ts
+++ b/tests/unit/providers/acp/acpSessionResume.test.ts
@@ -4,6 +4,7 @@ import {
   buildAcpSessionLoadFailureDebugEvent,
   clearAcpManagedSessionState,
   isAcpMissingSessionError,
+  isAcpSessionGone,
   markAcpSessionLoadFailed,
 } from '@/providers/acp/acpSessionResume';
 
@@ -50,6 +51,7 @@ describe('acpSessionResume', () => {
       sessionInvalidated: true,
     })).toEqual({
       databasePath: '/old/opencode.db',
+      sessionDropped: true,
       sessionId: null,
     });
 
@@ -60,8 +62,102 @@ describe('acpSessionResume', () => {
       sessionInvalidated: false,
     })).toEqual({
       databasePath: '/new/opencode.db',
+      sessionDropped: false,
       sessionId: 'session-2',
     });
+  });
+
+  describe('isAcpSessionGone', () => {
+    // Captured from the shipped CLIs by loading a session id they never had.
+    // None of them says so in the error, which is the whole reason the listing
+    // is consulted; they are kept verbatim so a CLI that starts answering
+    // properly shows up here as a change.
+    const REAL_LOAD_FAILURES: Array<[string, JsonRpcErrorResponse]> = [
+      ['MiMoCode 0.1.13', new JsonRpcErrorResponse('session/load', -32603, 'Internal error', {})],
+      ['OpenCode 1.18.18', new JsonRpcErrorResponse(
+        'session/load',
+        -32603,
+        'Internal error: OpenCode service failure',
+        { service: 'session' },
+      )],
+    ];
+
+    it.each(REAL_LOAD_FAILURES)('asks the agent when %s does not say why the load failed', async (_label, error) => {
+      expect(isAcpMissingSessionError(error)).toBe(false);
+
+      await expect(isAcpSessionGone({
+        error,
+        listSessions: async () => ({ sessions: [{ sessionId: 'other-session' }] }),
+        sessionId: 'session-1',
+      })).resolves.toBe(true);
+
+      await expect(isAcpSessionGone({
+        error,
+        listSessions: async () => ({ sessions: [{ sessionId: 'session-1' }] }),
+        sessionId: 'session-1',
+      })).resolves.toBe(false);
+    });
+
+    it('recognises a session the agent does name, without spending a listing', async () => {
+      const listSessions = jest.fn();
+
+      await expect(isAcpSessionGone({
+        error: new JsonRpcErrorResponse('session/load', -32602, 'Invalid params: Unknown sessionId: session-1', {}),
+        listSessions,
+        sessionId: 'session-1',
+      })).resolves.toBe(true);
+      expect(listSessions).not.toHaveBeenCalled();
+    });
+
+    it('keeps the binding when the agent cannot list sessions', async () => {
+      await expect(isAcpSessionGone({
+        error: new JsonRpcErrorResponse('session/load', -32000, 'Authentication failed'),
+        listSessions: async () => { throw new JsonRpcErrorResponse('session/list', -32601, 'Method not found'); },
+        sessionId: 'session-1',
+      })).resolves.toBe(false);
+    });
+
+    it('keeps the binding when the failure was not the agent answering', async () => {
+      const listSessions = jest.fn();
+
+      await expect(isAcpSessionGone({
+        error: new Error('write EPIPE'),
+        listSessions,
+        sessionId: 'session-1',
+      })).resolves.toBe(false);
+      expect(listSessions).not.toHaveBeenCalled();
+    });
+  });
+
+  it('carries a dropped session across saves until a replacement is persisted', () => {
+    // The first save consumes the in-memory flag, so every later save reports
+    // false; the marker has to keep the answer until a real session lands.
+    const afterDrop = buildAcpPersistedSessionFields({
+      conversationDatabasePath: '/old/opencode.db',
+      currentDatabasePath: null,
+      sessionId: null,
+      sessionInvalidated: true,
+    });
+    expect(afterDrop.sessionDropped).toBe(true);
+
+    const afterSecondSave = buildAcpPersistedSessionFields({
+      conversationDatabasePath: '/old/opencode.db',
+      conversationSessionDropped: afterDrop.sessionDropped,
+      currentDatabasePath: null,
+      sessionId: null,
+      sessionInvalidated: false,
+    });
+    expect(afterSecondSave.sessionDropped).toBe(true);
+
+    const afterReplacement = buildAcpPersistedSessionFields({
+      conversationDatabasePath: '/old/opencode.db',
+      conversationSessionDropped: true,
+      currentDatabasePath: null,
+      sessionId: 'session-2',
+      sessionInvalidated: false,
+    });
+    expect(afterReplacement.sessionDropped).toBe(false);
+    expect(afterReplacement.sessionId).toBe('session-2');
   });
 
   it('builds a structured debug event for session load failures', () => {

--- a/tests/unit/providers/kimicode/KimicodeChatRuntime.test.ts
+++ b/tests/unit/providers/kimicode/KimicodeChatRuntime.test.ts
@@ -389,6 +389,152 @@ describe('KimicodeChatRuntime', () => {
     expect(runtime.consumeSessionInvalidation()).toBe(false);
   });
 
+  it('does not replay the transcript when readiness drops the session', async () => {
+    const runtime = new KimicodeChatRuntime(createMockPlugin());
+    runtime.syncConversationState({ sessionId: 'session-1' });
+    const prompt = jest.fn().mockResolvedValue({});
+
+    // Readiness hits a session/load failure and soft-fails, exactly as
+    // handleSessionLoadFailure leaves things.
+    jest.spyOn(runtime, 'ensureReady').mockImplementation(async () => {
+      (runtime as any).sessionId = null;
+      (runtime as any).loadedSessionId = null;
+      (runtime as any).sessionInvalidated = true;
+      return true;
+    });
+    (runtime as any).createSession = jest.fn().mockImplementation(async () => {
+      (runtime as any).sessionId = 'session-2';
+      return 'session-2';
+    });
+    (runtime as any).connection = { prompt };
+    (runtime as any).applySelectedMode = jest.fn().mockResolvedValue(undefined);
+    (runtime as any).applySelectedModel = jest.fn().mockResolvedValue(undefined);
+    (runtime as any).applySelectedEffort = jest.fn().mockResolvedValue(undefined);
+    (runtime as any).getActiveDisplayModel = jest.fn().mockReturnValue('kimicode:test-model');
+
+    const history = [
+      { id: 'user-previous', role: 'user' as const, content: 'Keep the language rich.', timestamp: 1 },
+      { id: 'assistant-previous', role: 'assistant' as const, content: 'I will preserve the prose voice.', timestamp: 2 },
+    ];
+    const chunks: unknown[] = [];
+    for await (const chunk of runtime.query(runtime.prepareTurn({ text: 'Continue the edit.' }), history)) {
+      chunks.push(chunk);
+    }
+    expect(chunks).toEqual([{ type: 'done' }]);
+
+    expect(prompt).toHaveBeenCalledTimes(1);
+    const promptText = prompt.mock.calls[0][0].prompt
+      .map((block: { text?: string }) => block.text ?? '').join('\n');
+    expect(promptText).toContain('Continue the edit.');
+    expect(promptText).not.toContain('Keep the language rich.');
+  });
+
+  it('still withholds the transcript after the drop has survived a reload', async () => {
+    const runtime = new KimicodeChatRuntime(createMockPlugin());
+    const prompt = jest.fn().mockResolvedValue({});
+
+    // A fresh process: the drop happened last time and only the conversation
+    // remembers it. Without that memory this reads as a first-ever send.
+    runtime.syncConversationState({
+      providerState: { sessionDropped: true },
+      sessionId: null,
+    });
+
+    jest.spyOn(runtime, 'ensureReady').mockResolvedValue(true);
+    (runtime as any).createSession = jest.fn().mockImplementation(async () => {
+      (runtime as any).sessionId = 'session-2';
+      return 'session-2';
+    });
+    (runtime as any).connection = { prompt };
+    (runtime as any).applySelectedMode = jest.fn().mockResolvedValue(undefined);
+    (runtime as any).applySelectedModel = jest.fn().mockResolvedValue(undefined);
+    (runtime as any).applySelectedEffort = jest.fn().mockResolvedValue(undefined);
+    (runtime as any).getActiveDisplayModel = jest.fn().mockReturnValue('kimicode:test-model');
+
+    const history = [
+      { id: 'user-previous', role: 'user' as const, content: 'Keep the language rich.', timestamp: 1 },
+    ];
+    const chunks: unknown[] = [];
+    for await (const chunk of runtime.query(runtime.prepareTurn({ text: 'Continue the edit.' }), history)) {
+      chunks.push(chunk);
+    }
+    expect(chunks).toEqual([{ type: 'done' }]);
+
+    expect(prompt).toHaveBeenCalledTimes(1);
+    const promptText = prompt.mock.calls[0][0].prompt
+      .map((block: { text?: string }) => block.text ?? '').join('\n');
+    expect(promptText).not.toContain('Keep the language rich.');
+  });
+
+  it('still replays the transcript for a genuine cold resume', async () => {
+    const runtime = new KimicodeChatRuntime(createMockPlugin());
+    const prompt = jest.fn().mockResolvedValue({});
+
+    runtime.syncConversationState({ sessionId: null });
+    jest.spyOn(runtime, 'ensureReady').mockResolvedValue(true);
+    (runtime as any).createSession = jest.fn().mockImplementation(async () => {
+      (runtime as any).sessionId = 'session-2';
+      return 'session-2';
+    });
+    (runtime as any).connection = { prompt };
+    (runtime as any).applySelectedMode = jest.fn().mockResolvedValue(undefined);
+    (runtime as any).applySelectedModel = jest.fn().mockResolvedValue(undefined);
+    (runtime as any).applySelectedEffort = jest.fn().mockResolvedValue(undefined);
+    (runtime as any).getActiveDisplayModel = jest.fn().mockReturnValue('kimicode:test-model');
+
+    const history = [
+      { id: 'user-previous', role: 'user' as const, content: 'Keep the language rich.', timestamp: 1 },
+    ];
+    const chunks: unknown[] = [];
+    for await (const chunk of runtime.query(runtime.prepareTurn({ text: 'Continue the edit.' }), history)) {
+      chunks.push(chunk);
+    }
+    expect(chunks).toEqual([{ type: 'done' }]);
+
+    const promptText = prompt.mock.calls[0][0].prompt
+      .map((block: { text?: string }) => block.text ?? '').join('\n');
+    expect(promptText).toContain('Keep the language rich.');
+  });
+
+  it('keeps the binding when the agent still lists the session it failed to load', async () => {
+    const runtime = new KimicodeChatRuntime(createMockPlugin());
+    runtime.syncConversationState({ sessionId: 'session-1' });
+    const error = new JsonRpcErrorResponse('session/load', -32603, 'Internal error', {});
+    (runtime as any).connection = {
+      listSessions: jest.fn().mockResolvedValue({ sessions: [{ sessionId: 'session-1' }] }),
+      loadSession: jest.fn().mockRejectedValue(error),
+    };
+
+    await expect((runtime as any).loadSession('session-1', '/vault')).rejects.toBe(error);
+
+    expect(runtime.getSessionId()).toBe('session-1');
+    expect(runtime.consumeSessionInvalidation()).toBe(false);
+  });
+
+  it('soft-fails a session the agent no longer lists, whatever the error said', async () => {
+    const runtime = new KimicodeChatRuntime(createMockPlugin());
+    runtime.syncConversationState({ sessionId: 'session-1' });
+    (runtime as any).connection = {
+      listSessions: jest.fn().mockResolvedValue({ sessions: [{ sessionId: 'session-9' }] }),
+      loadSession: jest.fn().mockRejectedValue(
+        new JsonRpcErrorResponse('session/load', -32603, 'Internal error', {}),
+      ),
+    };
+
+    await expect((runtime as any).loadSession('session-1', '/vault')).resolves.toBe(false);
+  });
+
+  it('restores a dropped session from the conversation so a reload does not replay the transcript', () => {
+    const runtime = new KimicodeChatRuntime(createMockPlugin());
+
+    runtime.syncConversationState({
+      providerState: { sessionDropped: true },
+      sessionId: null,
+    });
+
+    expect(runtime.consumeSessionInvalidation()).toBe(true);
+  });
+
   it('preserves the saved session binding when session/load fails transiently', async () => {
     const runtime = new KimicodeChatRuntime(createMockPlugin());
     runtime.syncConversationState({ sessionId: 'session-1' });

--- a/tests/unit/providers/mimocode/MimocodeChatRuntime.test.ts
+++ b/tests/unit/providers/mimocode/MimocodeChatRuntime.test.ts
@@ -487,6 +487,152 @@ describe('MimocodeChatRuntime', () => {
     expect(runtime.consumeSessionInvalidation()).toBe(false);
   });
 
+  it('does not replay the transcript when readiness drops the session', async () => {
+    const runtime = new MimocodeChatRuntime(createMockPlugin());
+    runtime.syncConversationState({ sessionId: 'session-1' });
+    const prompt = jest.fn().mockResolvedValue({});
+
+    // Readiness hits a session/load failure and soft-fails, exactly as
+    // handleSessionLoadFailure leaves things.
+    jest.spyOn(runtime, 'ensureReady').mockImplementation(async () => {
+      (runtime as any).sessionId = null;
+      (runtime as any).loadedSessionId = null;
+      (runtime as any).sessionInvalidated = true;
+      return true;
+    });
+    (runtime as any).createSession = jest.fn().mockImplementation(async () => {
+      (runtime as any).sessionId = 'session-2';
+      return 'session-2';
+    });
+    (runtime as any).connection = { prompt };
+    (runtime as any).applySelectedMode = jest.fn().mockResolvedValue(undefined);
+    (runtime as any).applySelectedModel = jest.fn().mockResolvedValue(undefined);
+    (runtime as any).applySelectedEffort = jest.fn().mockResolvedValue(undefined);
+    (runtime as any).getActiveDisplayModel = jest.fn().mockReturnValue('mimocode:test-model');
+
+    const history = [
+      { id: 'user-previous', role: 'user' as const, content: 'Keep the language rich.', timestamp: 1 },
+      { id: 'assistant-previous', role: 'assistant' as const, content: 'I will preserve the prose voice.', timestamp: 2 },
+    ];
+    const chunks: unknown[] = [];
+    for await (const chunk of runtime.query(runtime.prepareTurn({ text: 'Continue the edit.' }), history)) {
+      chunks.push(chunk);
+    }
+    expect(chunks).toEqual([{ type: 'done' }]);
+
+    expect(prompt).toHaveBeenCalledTimes(1);
+    const promptText = prompt.mock.calls[0][0].prompt
+      .map((block: { text?: string }) => block.text ?? '').join('\n');
+    expect(promptText).toContain('Continue the edit.');
+    expect(promptText).not.toContain('Keep the language rich.');
+  });
+
+  it('still withholds the transcript after the drop has survived a reload', async () => {
+    const runtime = new MimocodeChatRuntime(createMockPlugin());
+    const prompt = jest.fn().mockResolvedValue({});
+
+    // A fresh process: the drop happened last time and only the conversation
+    // remembers it. Without that memory this reads as a first-ever send.
+    runtime.syncConversationState({
+      providerState: { sessionDropped: true },
+      sessionId: null,
+    });
+
+    jest.spyOn(runtime, 'ensureReady').mockResolvedValue(true);
+    (runtime as any).createSession = jest.fn().mockImplementation(async () => {
+      (runtime as any).sessionId = 'session-2';
+      return 'session-2';
+    });
+    (runtime as any).connection = { prompt };
+    (runtime as any).applySelectedMode = jest.fn().mockResolvedValue(undefined);
+    (runtime as any).applySelectedModel = jest.fn().mockResolvedValue(undefined);
+    (runtime as any).applySelectedEffort = jest.fn().mockResolvedValue(undefined);
+    (runtime as any).getActiveDisplayModel = jest.fn().mockReturnValue('mimocode:test-model');
+
+    const history = [
+      { id: 'user-previous', role: 'user' as const, content: 'Keep the language rich.', timestamp: 1 },
+    ];
+    const chunks: unknown[] = [];
+    for await (const chunk of runtime.query(runtime.prepareTurn({ text: 'Continue the edit.' }), history)) {
+      chunks.push(chunk);
+    }
+    expect(chunks).toEqual([{ type: 'done' }]);
+
+    expect(prompt).toHaveBeenCalledTimes(1);
+    const promptText = prompt.mock.calls[0][0].prompt
+      .map((block: { text?: string }) => block.text ?? '').join('\n');
+    expect(promptText).not.toContain('Keep the language rich.');
+  });
+
+  it('still replays the transcript for a genuine cold resume', async () => {
+    const runtime = new MimocodeChatRuntime(createMockPlugin());
+    const prompt = jest.fn().mockResolvedValue({});
+
+    runtime.syncConversationState({ sessionId: null });
+    jest.spyOn(runtime, 'ensureReady').mockResolvedValue(true);
+    (runtime as any).createSession = jest.fn().mockImplementation(async () => {
+      (runtime as any).sessionId = 'session-2';
+      return 'session-2';
+    });
+    (runtime as any).connection = { prompt };
+    (runtime as any).applySelectedMode = jest.fn().mockResolvedValue(undefined);
+    (runtime as any).applySelectedModel = jest.fn().mockResolvedValue(undefined);
+    (runtime as any).applySelectedEffort = jest.fn().mockResolvedValue(undefined);
+    (runtime as any).getActiveDisplayModel = jest.fn().mockReturnValue('mimocode:test-model');
+
+    const history = [
+      { id: 'user-previous', role: 'user' as const, content: 'Keep the language rich.', timestamp: 1 },
+    ];
+    const chunks: unknown[] = [];
+    for await (const chunk of runtime.query(runtime.prepareTurn({ text: 'Continue the edit.' }), history)) {
+      chunks.push(chunk);
+    }
+    expect(chunks).toEqual([{ type: 'done' }]);
+
+    const promptText = prompt.mock.calls[0][0].prompt
+      .map((block: { text?: string }) => block.text ?? '').join('\n');
+    expect(promptText).toContain('Keep the language rich.');
+  });
+
+  it('keeps the binding when the agent still lists the session it failed to load', async () => {
+    const runtime = new MimocodeChatRuntime(createMockPlugin());
+    runtime.syncConversationState({ sessionId: 'session-1' });
+    const error = new JsonRpcErrorResponse('session/load', -32603, 'Internal error', {});
+    (runtime as any).connection = {
+      listSessions: jest.fn().mockResolvedValue({ sessions: [{ sessionId: 'session-1' }] }),
+      loadSession: jest.fn().mockRejectedValue(error),
+    };
+
+    await expect((runtime as any).loadSession('session-1', '/vault')).rejects.toBe(error);
+
+    expect(runtime.getSessionId()).toBe('session-1');
+    expect(runtime.consumeSessionInvalidation()).toBe(false);
+  });
+
+  it('soft-fails a session the agent no longer lists, whatever the error said', async () => {
+    const runtime = new MimocodeChatRuntime(createMockPlugin());
+    runtime.syncConversationState({ sessionId: 'session-1' });
+    (runtime as any).connection = {
+      listSessions: jest.fn().mockResolvedValue({ sessions: [{ sessionId: 'session-9' }] }),
+      loadSession: jest.fn().mockRejectedValue(
+        new JsonRpcErrorResponse('session/load', -32603, 'Internal error', {}),
+      ),
+    };
+
+    await expect((runtime as any).loadSession('session-1', '/vault')).resolves.toBe(false);
+  });
+
+  it('restores a dropped session from the conversation so a reload does not replay the transcript', () => {
+    const runtime = new MimocodeChatRuntime(createMockPlugin());
+
+    runtime.syncConversationState({
+      providerState: { sessionDropped: true },
+      sessionId: null,
+    });
+
+    expect(runtime.consumeSessionInvalidation()).toBe(true);
+  });
+
   it('preserves the saved session binding when session/load fails transiently', async () => {
     const runtime = new MimocodeChatRuntime(createMockPlugin());
     runtime.syncConversationState({ sessionId: 'session-1' });

--- a/tests/unit/providers/opencode/OpencodeChatRuntime.test.ts
+++ b/tests/unit/providers/opencode/OpencodeChatRuntime.test.ts
@@ -405,9 +405,158 @@ describe('OpencodeChatRuntime', () => {
       sessionInvalidated: true,
     });
     expect(updates.updates.sessionId).toBeNull();
+    // The drop is recorded so the next launch does not read a dropped session
+    // as a conversation that never had one and replay the transcript into it.
     expect(updates.updates.providerState).toEqual({
       databasePath: '/persisted/opencode.db',
+      sessionDropped: true,
     });
+  });
+
+  it('does not replay the transcript when readiness drops the session', async () => {
+    const runtime = new OpencodeChatRuntime(createMockPlugin());
+    runtime.syncConversationState({ sessionId: 'session-1' });
+    const prompt = jest.fn().mockResolvedValue({});
+
+    // Readiness hits a session/load failure and soft-fails, exactly as
+    // handleSessionLoadFailure leaves things.
+    jest.spyOn(runtime, 'ensureReady').mockImplementation(async () => {
+      (runtime as any).sessionId = null;
+      (runtime as any).loadedSessionId = null;
+      (runtime as any).sessionInvalidated = true;
+      return true;
+    });
+    (runtime as any).createSession = jest.fn().mockImplementation(async () => {
+      (runtime as any).sessionId = 'session-2';
+      return 'session-2';
+    });
+    (runtime as any).connection = { prompt };
+    (runtime as any).applySelectedMode = jest.fn().mockResolvedValue(undefined);
+    (runtime as any).applySelectedModel = jest.fn().mockResolvedValue(undefined);
+    (runtime as any).applySelectedEffort = jest.fn().mockResolvedValue(undefined);
+    (runtime as any).getActiveDisplayModel = jest.fn().mockReturnValue('opencode:test-model');
+
+    const history = [
+      { id: 'user-previous', role: 'user' as const, content: 'Keep the language rich.', timestamp: 1 },
+      { id: 'assistant-previous', role: 'assistant' as const, content: 'I will preserve the prose voice.', timestamp: 2 },
+    ];
+    const chunks: unknown[] = [];
+    for await (const chunk of runtime.query(runtime.prepareTurn({ text: 'Continue the edit.' }), history)) {
+      chunks.push(chunk);
+    }
+    expect(chunks).toEqual([{ type: 'done' }]);
+
+    expect(prompt).toHaveBeenCalledTimes(1);
+    const promptText = prompt.mock.calls[0][0].prompt
+      .map((block: { text?: string }) => block.text ?? '').join('\n');
+    expect(promptText).toContain('Continue the edit.');
+    expect(promptText).not.toContain('Keep the language rich.');
+  });
+
+  it('still withholds the transcript after the drop has survived a reload', async () => {
+    const runtime = new OpencodeChatRuntime(createMockPlugin());
+    const prompt = jest.fn().mockResolvedValue({});
+
+    // A fresh process: the drop happened last time and only the conversation
+    // remembers it. Without that memory this reads as a first-ever send.
+    runtime.syncConversationState({
+      providerState: { sessionDropped: true },
+      sessionId: null,
+    });
+
+    jest.spyOn(runtime, 'ensureReady').mockResolvedValue(true);
+    (runtime as any).createSession = jest.fn().mockImplementation(async () => {
+      (runtime as any).sessionId = 'session-2';
+      return 'session-2';
+    });
+    (runtime as any).connection = { prompt };
+    (runtime as any).applySelectedMode = jest.fn().mockResolvedValue(undefined);
+    (runtime as any).applySelectedModel = jest.fn().mockResolvedValue(undefined);
+    (runtime as any).applySelectedEffort = jest.fn().mockResolvedValue(undefined);
+    (runtime as any).getActiveDisplayModel = jest.fn().mockReturnValue('opencode:test-model');
+
+    const history = [
+      { id: 'user-previous', role: 'user' as const, content: 'Keep the language rich.', timestamp: 1 },
+    ];
+    const chunks: unknown[] = [];
+    for await (const chunk of runtime.query(runtime.prepareTurn({ text: 'Continue the edit.' }), history)) {
+      chunks.push(chunk);
+    }
+    expect(chunks).toEqual([{ type: 'done' }]);
+
+    expect(prompt).toHaveBeenCalledTimes(1);
+    const promptText = prompt.mock.calls[0][0].prompt
+      .map((block: { text?: string }) => block.text ?? '').join('\n');
+    expect(promptText).not.toContain('Keep the language rich.');
+  });
+
+  it('still replays the transcript for a genuine cold resume', async () => {
+    const runtime = new OpencodeChatRuntime(createMockPlugin());
+    const prompt = jest.fn().mockResolvedValue({});
+
+    runtime.syncConversationState({ sessionId: null });
+    jest.spyOn(runtime, 'ensureReady').mockResolvedValue(true);
+    (runtime as any).createSession = jest.fn().mockImplementation(async () => {
+      (runtime as any).sessionId = 'session-2';
+      return 'session-2';
+    });
+    (runtime as any).connection = { prompt };
+    (runtime as any).applySelectedMode = jest.fn().mockResolvedValue(undefined);
+    (runtime as any).applySelectedModel = jest.fn().mockResolvedValue(undefined);
+    (runtime as any).applySelectedEffort = jest.fn().mockResolvedValue(undefined);
+    (runtime as any).getActiveDisplayModel = jest.fn().mockReturnValue('opencode:test-model');
+
+    const history = [
+      { id: 'user-previous', role: 'user' as const, content: 'Keep the language rich.', timestamp: 1 },
+    ];
+    const chunks: unknown[] = [];
+    for await (const chunk of runtime.query(runtime.prepareTurn({ text: 'Continue the edit.' }), history)) {
+      chunks.push(chunk);
+    }
+    expect(chunks).toEqual([{ type: 'done' }]);
+
+    const promptText = prompt.mock.calls[0][0].prompt
+      .map((block: { text?: string }) => block.text ?? '').join('\n');
+    expect(promptText).toContain('Keep the language rich.');
+  });
+
+  it('keeps the binding when the agent still lists the session it failed to load', async () => {
+    const runtime = new OpencodeChatRuntime(createMockPlugin());
+    runtime.syncConversationState({ sessionId: 'session-1' });
+    const error = new JsonRpcErrorResponse('session/load', -32603, 'Internal error', {});
+    (runtime as any).connection = {
+      listSessions: jest.fn().mockResolvedValue({ sessions: [{ sessionId: 'session-1' }] }),
+      loadSession: jest.fn().mockRejectedValue(error),
+    };
+
+    await expect((runtime as any).loadSession('session-1', '/vault')).rejects.toBe(error);
+
+    expect(runtime.getSessionId()).toBe('session-1');
+    expect(runtime.consumeSessionInvalidation()).toBe(false);
+  });
+
+  it('soft-fails a session the agent no longer lists, whatever the error said', async () => {
+    const runtime = new OpencodeChatRuntime(createMockPlugin());
+    runtime.syncConversationState({ sessionId: 'session-1' });
+    (runtime as any).connection = {
+      listSessions: jest.fn().mockResolvedValue({ sessions: [{ sessionId: 'session-9' }] }),
+      loadSession: jest.fn().mockRejectedValue(
+        new JsonRpcErrorResponse('session/load', -32603, 'Internal error', {}),
+      ),
+    };
+
+    await expect((runtime as any).loadSession('session-1', '/vault')).resolves.toBe(false);
+  });
+
+  it('restores a dropped session from the conversation so a reload does not replay the transcript', () => {
+    const runtime = new OpencodeChatRuntime(createMockPlugin());
+
+    runtime.syncConversationState({
+      providerState: { sessionDropped: true },
+      sessionId: null,
+    });
+
+    expect(runtime.consumeSessionInvalidation()).toBe(true);
   });
 
   it('preserves the saved session binding when session/load fails transiently', async () => {


### PR DESCRIPTION
Supersedes #100 and #102. Same defect they found, plus the two reasons their fix does not hold — and the detection rewritten against what the CLIs actually return.

## What the CLIs actually return

I resumed a session id that none of them has ever seen. Verbatim:

| CLI | `session/load` on a missing session |
|---|---|
| MiMoCode 0.1.13 | `-32603 "Internal error"`, `data: {}` |
| OpenCode 1.18.18 | `-32603 "Internal error: OpenCode service failure"`, `data: {service:"session"}` |
| Kimi Code 0.31.1 | `-32602 "Invalid params: Unknown sessionId: …"` |

Run through the shipped detector, all three come back **NOT DETECTED**. The first two say nothing at all; the third spells it `sessionId`, and `\bsession\b` does not match that.

So `isAcpMissingSessionError` has never once recognised a missing session on any CLI we ship against. Every stale resume threw instead, the user got a generic start failure, and the dead id was retried on the next turn forever.

## Three fixes

**1. Ask, don't guess.** `isAcpSessionGone` consults `session/list` — same ACP surface, agent already answering on this connection, and only on a load that has already failed. Not listed → gone, soft-fail into a fresh session. Still listed → something else failed, keep the binding and let the error surface, which is what an expired token needs. No listing method → exactly today's behaviour. The message patterns are widened from the same captured payloads, so an agent that does say it costs no round trip.

**2. Make the drop durable.** `consumeSessionInvalidation()` clears the flag, `save()` calls it, and `TabManager.destroy()` saves every tab on quit. Drop a session, quit before typing, and the next launch sees a conversation that looks like it never had one. `providerState.sessionDropped` records it; it clears itself when a real session id is persisted again.

**3. Stop the replay.** History bootstrap is now reserved for a cold resume that never held a session id. A dropped session starts clean — recovering that context is the user's call, not a purchase made on their behalf. This is #100's and #102's fix; it only holds because of 2.

## Verification

Live, against the installed CLIs — MiMoCode 0.1.13, OpenCode 1.18.18, Kimi Code 0.31.1. Each reports the failure opaquely, each still lists its live sessions, and `isAcpSessionGone` told the two apart on all three. Their real payloads are checked in as fixtures, so a CLI that starts answering properly shows up as a test change.

Each fix was reverted in turn to confirm its tests fail without it: 3 fail for the detection, 6 for the durable marker, 3 for the replay guard.

Unit 7315 ✓ · integration 216 ✓ · typecheck ✓ · lint ✓ · `build:release` ✓.

## Scope

The three twins only — they are the only runtimes that used the detector, and the only ones whose CLI I could put on the wire. Gemini, Qwen and Grok resume through their own paths and are untouched. All three `AGENTS.md` session-resume contracts are updated to match, so the documented policy is the one that ships.

https://claude.ai/code/session_01TDYHm4Ggxppte2w94Bdtak