### PR TITLE
fix(providers): finish the session-resume fix for Gemini, Qwen and Grok

### DIFF
--- a/src/providers/gemini/AGENTS.md
+++ b/src/providers/gemini/AGENTS.md
@@ -28,3 +28,8 @@ gemini --acp
 ```
 
 Custom CLI paths are stored per host under `providerConfigs.gemini.cliPathsByHost`. If no custom path exists, Grimoire launches `gemini` from PATH.
+
+## Session resume
+
+- On `session/load` failure, decide with `isAcpSessionGone` rather than treating any failure as proof the session is gone. Gemini CLI reports a missing session as `-32603 Internal error` with `data.details` naming the reason, which the shared message patterns recognise; it exposes no session listing, so anything unrecognised - transport, authentication, configuration - propagates with the binding intact.
+- A dropped session is recorded in `providerState.sessionDropped` and read back on load, because the in-memory flag is consumed by the first save. Never replay the transcript into a replacement session: history bootstrap is for a cold resume that never held a session id.

--- a/src/providers/gemini/runtime/GeminiChatRuntime.ts
+++ b/src/providers/gemini/runtime/GeminiChatRuntime.ts
@@ -60,6 +60,7 @@ import {
   buildAcpUsageInfo,
   extractAcpSessionModelState,
   extractAcpSessionModeState,
+  isAcpSessionGone,
   mapAcpApprovalDecision,
   resolveWorkspacePath,
 } from '../../acp';
@@ -78,6 +79,7 @@ import {
   getGeminiProviderSettings,
   updateGeminiProviderSettings,
 } from '../settings';
+import { getGeminiState } from '../types';
 import { buildGeminiRuntimeEnv } from './GeminiRuntimeEnvironment';
 
 interface ActiveTurn {
@@ -191,6 +193,9 @@ export class GeminiChatRuntime implements ChatRuntime {
       this.currentSessionModelId = null;
     }
     this.sessionId = nextSessionId;
+    if (!nextSessionId && getGeminiState(conversation?.providerState).sessionDropped) {
+      this.sessionInvalidated = true;
+    }
   }
 
   async reloadMcpServers(): Promise<void> {
@@ -261,8 +266,15 @@ export class GeminiChatRuntime implements ChatRuntime {
   ): AsyncGenerator<StreamChunk> {
     const previousMessages = conversationHistory ?? [];
     const expectedSessionId = this.sessionId;
+    // A session that was dropped must not have the transcript replayed into its
+    // replacement: that silently re-buys the whole conversation, once per failed
+    // resume, without anyone asking. Bootstrap is for a genuine cold resume -
+    // one where no session was ever held. `sessionInvalidated` is what tells the
+    // two apart, and it is restored from the conversation, because the drop
+    // usually happens during warmup, before query() runs at all.
     let shouldBootstrapHistory = previousMessages.length > 0
-      && (!expectedSessionId || this.sessionInvalidated);
+      && !expectedSessionId
+      && !this.sessionInvalidated;
 
     if (!(await this.ensureReady())) {
       yield { type: 'error', content: t('chat.ui.errors.provider.startFailed', { provider: ProviderRegistry.getProviderDisplayNameOrId('gemini') }) };
@@ -277,9 +289,9 @@ export class GeminiChatRuntime implements ChatRuntime {
     }
 
     const cwd = getVaultPath(this.plugin.app) ?? process.cwd();
-    if (expectedSessionId && !this.sessionId) {
-      shouldBootstrapHistory = previousMessages.length > 0;
-    }
+    // Deliberately no bootstrap here: if readiness dropped the session, the
+    // replacement starts clean and recovering the earlier context is the user's
+    // call, not a purchase we make for them.
 
     if (!this.sessionId) {
       const sessionId = await this.createSession(cwd);
@@ -435,14 +447,23 @@ export class GeminiChatRuntime implements ChatRuntime {
     conversation: Conversation | null;
     sessionInvalidated: boolean;
   }): SessionUpdateResult {
+    const existingState = getGeminiState(params.conversation?.providerState);
     const updates: Partial<Conversation> = {
       providerState: params.conversation?.providerState,
       sessionId: this.sessionId,
     };
 
-    if (params.sessionInvalidated && !this.sessionId) {
-      updates.providerState = undefined;
+    // "We had a session and lost it" has to outlive the runtime that learned it:
+    // the in-memory flag is consumed by the first save, and saves happen on tab
+    // close and on quit. Without this the next launch reads a dropped session as
+    // a conversation that never had one and replays the whole transcript into a
+    // fresh one. It clears itself once a real session id is persisted again.
+    if (!this.sessionId && (params.sessionInvalidated || existingState.sessionDropped === true)) {
+      updates.providerState = { sessionDropped: true };
       updates.sessionId = null;
+    } else if (this.sessionId && existingState.sessionDropped === true) {
+      const { sessionDropped: _dropped, ...rest } = existingState;
+      updates.providerState = rest;
     }
 
     return { updates };
@@ -545,12 +566,13 @@ export class GeminiChatRuntime implements ChatRuntime {
   }
 
   private async loadSession(sessionId: string, cwd: string): Promise<boolean> {
-    if (!this.connection) {
+    const connection = this.connection;
+    if (!connection) {
       return false;
     }
 
     try {
-      const response = await this.connection.loadSession({
+      const response = await connection.loadSession({
         cwd,
         mcpServers: this.getMcpServers(),
         sessionId,
@@ -565,7 +587,17 @@ export class GeminiChatRuntime implements ChatRuntime {
         modes: response.modes ?? null,
       });
       return true;
-    } catch {
+    } catch (error) {
+      // Ask the agent whether the session still exists instead of treating any
+      // failure as proof it is gone - an expired token looks identical from
+      // here, and swallowing it drops the conversation's context with no signal.
+      if (!(await isAcpSessionGone({
+        error,
+        listSessions: () => connection.listSessions(),
+        sessionId,
+      }))) {
+        throw error;
+      }
       return false;
     }
   }

--- a/src/providers/gemini/types/index.ts
+++ b/src/providers/gemini/types/index.ts
@@ -1,4 +1,10 @@
 export interface GeminiProviderState {
+  /**
+   * Set when a saved session failed to load and no replacement was persisted.
+   * Read back on the next load so a dropped session is not mistaken for a
+   * conversation that never had one.
+   */
+  sessionDropped?: boolean;
   sessionId?: string;
 }
 

--- a/src/providers/grok/AGENTS.md
+++ b/src/providers/grok/AGENTS.md
@@ -20,3 +20,8 @@
 - When changing launch artifacts or command loading, verify against current Grok Build runtime output rather than inferred schemas.
 - Refresh the Grok model catalog from live `grok models` whenever the chat picker or settings catalog asks. Do not TTL-skip that path; join an in-flight CLI refresh instead.
 - Plan indicators prefer the Grok-native `x.ai/billing` ACP extension and its unified weekly or monthly usage window. The authenticated billing endpoint and legacy credits protobuf remain compatibility fallbacks. `GrokPlanUsageStore` still aggregates ACP/session/API-key spend for the current month when cost data exists.
+
+## Session resume
+
+- `loadSession` still treats every failure as a lost session. That is deliberate, not an oversight: the Grok CLI would not answer an ACP handshake off a bare probe, so what it reports for a session it no longer has is unobserved, and narrowing this blind would turn a silent recovery into a user-visible error on every stale resume. Move it onto `isAcpSessionGone` once the wire behaviour can be captured.
+- A dropped session is recorded in `providerState.sessionDropped` and read back on load, because the in-memory flag is consumed by the first save. Never replay the transcript into a replacement session: history bootstrap is for a cold resume that never held a session id.

--- a/src/providers/grok/runtime/GrokChatRuntime.ts
+++ b/src/providers/grok/runtime/GrokChatRuntime.ts
@@ -288,6 +288,9 @@ export class GrokChatRuntime implements ChatRuntime {
     }
     this.sessionId = nextSessionId;
     const state = getGrokState(conversation?.providerState);
+    if (!nextSessionId && state.sessionDropped) {
+      this.sessionInvalidated = true;
+    }
     if (state.sessionDirPath) {
       this.currentSessionDirPath = state.sessionDirPath;
     }
@@ -518,8 +521,15 @@ export class GrokChatRuntime implements ChatRuntime {
   ): AsyncGenerator<StreamChunk> {
     const previousMessages = conversationHistory ?? [];
     const expectedSessionId = this.sessionId;
+    // A session that was dropped must not have the transcript replayed into its
+    // replacement: that silently re-buys the whole conversation, once per failed
+    // resume, without anyone asking. Bootstrap is for a genuine cold resume -
+    // one where no session was ever held. `sessionInvalidated` is what tells the
+    // two apart, and it is restored from the conversation, because the drop
+    // usually happens during warmup, before query() runs at all.
     let shouldBootstrapHistory = previousMessages.length > 0
-      && (!expectedSessionId || this.sessionInvalidated);
+      && !expectedSessionId
+      && !this.sessionInvalidated;
 
     if (!(await this.ensureReady())) {
       logGrokDebug(this.plugin, 'query.ensureReady.failed', {
@@ -538,9 +548,9 @@ export class GrokChatRuntime implements ChatRuntime {
     }
 
     const cwd = getVaultPath(this.plugin.app) ?? process.cwd();
-    if (expectedSessionId && !this.sessionId) {
-      shouldBootstrapHistory = previousMessages.length > 0;
-    }
+    // Deliberately no bootstrap here: if readiness dropped the session, the
+    // replacement starts clean and recovering the earlier context is the user's
+    // call, not a purchase we make for them.
 
     if (!this.sessionId) {
       const sessionId = await this.createSession(cwd);
@@ -797,20 +807,30 @@ export class GrokChatRuntime implements ChatRuntime {
       : null;
     const sessionDirPath = this.currentSessionDirPath ?? existingState?.sessionDirPath;
     const workspacePath = this.currentWorkspacePath ?? existingState?.workspacePath;
-    const providerState: GrokProviderState = {
-      ...(sessionDirPath ? { sessionDirPath } : {}),
-      ...(workspacePath ? { workspacePath } : {}),
-    };
-
     // On invalidation without a replacement session, clear sessionId so the
     // next send creates a fresh ACP session, but keep native path metadata.
     const sessionId = params.sessionInvalidated && !this.sessionId
       ? null
       : this.sessionId;
+    // "We had a session and lost it" has to outlive the runtime that learned
+    // it: the in-memory flag is consumed by the first save, and saves happen on
+    // tab close and on quit. Without this the next launch reads a dropped
+    // session as a conversation that never had one and replays the whole
+    // transcript into a fresh one. It clears once a real session id is back.
+    const sessionDropped = !sessionId
+      && (params.sessionInvalidated || existingState?.sessionDropped === true);
+    const providerState: GrokProviderState = {
+      ...(sessionDropped ? { sessionDropped: true } : {}),
+      ...(sessionDirPath ? { sessionDirPath } : {}),
+      ...(workspacePath ? { workspacePath } : {}),
+    };
 
+    // An empty object would leave the stored state untouched, so a marker that
+    // has just cleared still has to be written out.
+    const mustClearMarker = existingState?.sessionDropped === true && !sessionDropped;
     return {
       updates: {
-        providerState: Object.keys(providerState).length > 0
+        providerState: Object.keys(providerState).length > 0 || mustClearMarker
           ? providerState as Record<string, unknown>
           : undefined,
         sessionId,
@@ -1613,13 +1633,14 @@ export class GrokChatRuntime implements ChatRuntime {
   }
 
   private async loadSession(sessionId: string, cwd: string): Promise<boolean> {
-    if (!this.connection) {
+    const connection = this.connection;
+    if (!connection) {
       return false;
     }
 
     try {
       this.setSupportedCommands([]);
-      const response = await this.connection.loadSession({
+      const response = await connection.loadSession({
         cwd,
         mcpServers: this.getMcpServers(),
         sessionId,
@@ -1652,6 +1673,11 @@ export class GrokChatRuntime implements ChatRuntime {
         error,
         level: 'warn',
       });
+      // Deliberately still swallows every failure. Grok's CLI would not answer
+      // an ACP handshake here, so what it reports for a session it no longer
+      // has is unknown - and narrowing this blind would turn a silent recovery
+      // into a user-visible error on every stale resume. Left as it was until
+      // the wire behaviour can be observed.
       return false;
     }
   }

--- a/src/providers/grok/types/index.ts
+++ b/src/providers/grok/types/index.ts
@@ -1,4 +1,10 @@
 export interface GrokProviderState {
+  /**
+   * Set when a saved session failed to load and no replacement was persisted.
+   * Read back on the next load so a dropped session is not mistaken for a
+   * conversation that never had one.
+   */
+  sessionDropped?: boolean;
   sessionDirPath?: string;
   workspacePath?: string;
 }
@@ -11,6 +17,9 @@ export function getGrokState(
   }
 
   const state: GrokProviderState = {};
+  if (providerState.sessionDropped === true) {
+    state.sessionDropped = true;
+  }
   if (typeof providerState.sessionDirPath === 'string' && providerState.sessionDirPath.trim()) {
     state.sessionDirPath = providerState.sessionDirPath.trim();
   }

--- a/src/providers/qwen/AGENTS.md
+++ b/src/providers/qwen/AGENTS.md
@@ -31,3 +31,8 @@ qwen --acp
 ```
 
 Custom CLI paths are stored per host under `providerConfigs.qwen.cliPathsByHost`. If no custom path exists, Grimoire launches `qwen` from PATH.
+
+## Session resume
+
+- On `session/load` failure, decide with `isAcpSessionGone` rather than treating any failure as proof the session is gone. Qwen Code names a missing session in the error (`-32002 Resource not found: session:<id>`) and also answers `session/list`, so both paths are available; anything unrecognised - transport, authentication, configuration - propagates with the binding intact.
+- A dropped session is recorded in `providerState.sessionDropped` and read back on load, because the in-memory flag is consumed by the first save. Never replay the transcript into a replacement session: history bootstrap is for a cold resume that never held a session id.

--- a/src/providers/qwen/runtime/QwenChatRuntime.ts
+++ b/src/providers/qwen/runtime/QwenChatRuntime.ts
@@ -61,6 +61,7 @@ import {
   buildAcpUsageInfo,
   extractAcpSessionModelState,
   extractAcpSessionModeState,
+  isAcpSessionGone,
   resolveWorkspacePath,
 } from '../../acp';
 import { toAcpMcpServers } from '../../acp/mcp/toAcpMcpServers';
@@ -79,6 +80,7 @@ import {
   type QwenMode,
   updateQwenProviderSettings,
 } from '../settings';
+import { getQwenState } from '../types';
 import { buildQwenRuntimeEnv } from './QwenRuntimeEnvironment';
 
 interface ActiveTurn {
@@ -210,6 +212,9 @@ export class QwenChatRuntime implements ChatRuntime {
       this.supportedCommands = [];
     }
     this.sessionId = nextSessionId;
+    if (!nextSessionId && getQwenState(conversation?.providerState).sessionDropped) {
+      this.sessionInvalidated = true;
+    }
   }
 
   async reloadMcpServers(): Promise<void> {
@@ -284,8 +289,15 @@ export class QwenChatRuntime implements ChatRuntime {
   ): AsyncGenerator<StreamChunk> {
     const previousMessages = conversationHistory ?? [];
     const expectedSessionId = this.sessionId;
+    // A session that was dropped must not have the transcript replayed into its
+    // replacement: that silently re-buys the whole conversation, once per failed
+    // resume, without anyone asking. Bootstrap is for a genuine cold resume -
+    // one where no session was ever held. `sessionInvalidated` is what tells the
+    // two apart, and it is restored from the conversation, because the drop
+    // usually happens during warmup, before query() runs at all.
     let shouldBootstrapHistory = previousMessages.length > 0
-      && (!expectedSessionId || this.sessionInvalidated);
+      && !expectedSessionId
+      && !this.sessionInvalidated;
 
     if (!(await this.ensureReady())) {
       yield { type: 'error', content: t('chat.ui.errors.provider.startFailed', { provider: ProviderRegistry.getProviderDisplayNameOrId('qwen') }) };
@@ -300,9 +312,9 @@ export class QwenChatRuntime implements ChatRuntime {
     }
 
     const cwd = getVaultPath(this.plugin.app) ?? process.cwd();
-    if (expectedSessionId && !this.sessionId) {
-      shouldBootstrapHistory = previousMessages.length > 0;
-    }
+    // Deliberately no bootstrap here: if readiness dropped the session, the
+    // replacement starts clean and recovering the earlier context is the user's
+    // call, not a purchase we make for them.
 
     if (!this.sessionId) {
       const sessionId = await this.createSession(cwd);
@@ -466,14 +478,23 @@ export class QwenChatRuntime implements ChatRuntime {
     conversation: Conversation | null;
     sessionInvalidated: boolean;
   }): SessionUpdateResult {
+    const existingState = getQwenState(params.conversation?.providerState);
     const updates: Partial<Conversation> = {
       providerState: params.conversation?.providerState,
       sessionId: this.sessionId,
     };
 
-    if (params.sessionInvalidated && !this.sessionId) {
-      updates.providerState = undefined;
+    // "We had a session and lost it" has to outlive the runtime that learned it:
+    // the in-memory flag is consumed by the first save, and saves happen on tab
+    // close and on quit. Without this the next launch reads a dropped session as
+    // a conversation that never had one and replays the whole transcript into a
+    // fresh one. It clears itself once a real session id is persisted again.
+    if (!this.sessionId && (params.sessionInvalidated || existingState.sessionDropped === true)) {
+      updates.providerState = { sessionDropped: true };
       updates.sessionId = null;
+    } else if (this.sessionId && existingState.sessionDropped === true) {
+      const { sessionDropped: _dropped, ...rest } = existingState;
+      updates.providerState = rest;
     }
 
     return { updates };
@@ -580,12 +601,13 @@ export class QwenChatRuntime implements ChatRuntime {
   }
 
   private async loadSession(sessionId: string, cwd: string): Promise<boolean> {
-    if (!this.connection) {
+    const connection = this.connection;
+    if (!connection) {
       return false;
     }
 
     try {
-      const response = await this.connection.loadSession({
+      const response = await connection.loadSession({
         cwd,
         mcpServers: this.getMcpServers(),
         sessionId,
@@ -602,7 +624,17 @@ export class QwenChatRuntime implements ChatRuntime {
         modes: response.modes ?? null,
       });
       return true;
-    } catch {
+    } catch (error) {
+      // Ask the agent whether the session still exists instead of treating any
+      // failure as proof it is gone - an expired token looks identical from
+      // here, and swallowing it drops the conversation's context with no signal.
+      if (!(await isAcpSessionGone({
+        error,
+        listSessions: () => connection.listSessions(),
+        sessionId,
+      }))) {
+        throw error;
+      }
       return false;
     }
   }

--- a/src/providers/qwen/types/index.ts
+++ b/src/providers/qwen/types/index.ts
@@ -1,4 +1,10 @@
 export interface QwenProviderState {
+  /**
+   * Set when a saved session failed to load and no replacement was persisted.
+   * Read back on the next load so a dropped session is not mistaken for a
+   * conversation that never had one.
+   */
+  sessionDropped?: boolean;
   sessionId?: string;
 }
 

--- a/tests/unit/providers/gemini/runtime/GeminiChatRuntime.test.ts
+++ b/tests/unit/providers/gemini/runtime/GeminiChatRuntime.test.ts
@@ -3,6 +3,7 @@ import * as fs from 'node:fs/promises';
 import { hashCatalogFingerprint } from '@/core/providers/catalogFingerprint';
 import type { StreamChunk } from '@/core/types';
 import type { AcpContentBlock } from '@/providers/acp';
+import { JsonRpcErrorResponse } from '@/providers/acp/AcpJsonRpcTransport';
 import { resolveGeminiModelCatalogFingerprint } from '@/providers/gemini/modelCatalogFingerprint';
 import { GeminiChatRuntime } from '@/providers/gemini/runtime/GeminiChatRuntime';
 import { getGeminiProviderSettings, updateGeminiProviderSettings } from '@/providers/gemini/settings';
@@ -33,6 +34,13 @@ async function collect(generator: AsyncGenerator<StreamChunk>): Promise<StreamCh
     chunks.push(chunk);
   }
   return chunks;
+}
+
+function allPromptText(prompt: jest.Mock): string {
+  return prompt.mock.calls
+    .flatMap((call: any[]) => (call[0]?.prompt ?? []) as Array<{ text?: string }>)
+    .map(block => block.text ?? '')
+    .join('\n');
 }
 
 describe('GeminiChatRuntime', () => {
@@ -129,6 +137,176 @@ describe('GeminiChatRuntime', () => {
       'gemini-2.5-pro',
       'gemini-3-pro',
     ]);
+  });
+
+  it('soft-fails a session the agent reports it no longer has', async () => {
+    const runtime = new GeminiChatRuntime(createMockPlugin());
+    // Captured from gemini by loading a session id it has never had.
+    const missingSessionError = new JsonRpcErrorResponse(
+      'session/load',
+      -32603,
+      'Internal error',
+      { details: 'No previous sessions found for this project.' },
+    );
+    (runtime as any).connection = {
+      loadSession: jest.fn().mockRejectedValue(missingSessionError),
+    };
+
+    await expect((runtime as any).loadSession('session-1', '/vault')).resolves.toBe(false);
+  });
+
+  it('keeps the binding when the load failed for a reason other than a missing session', async () => {
+    const runtime = new GeminiChatRuntime(createMockPlugin());
+    runtime.syncConversationState({ sessionId: 'session-1' });
+    const error = new JsonRpcErrorResponse('session/load', -32000, 'Authentication failed');
+    (runtime as any).connection = {
+      listSessions: jest.fn().mockResolvedValue({ sessions: [{ sessionId: 'session-1' }] }),
+      loadSession: jest.fn().mockRejectedValue(error),
+    };
+
+    await expect((runtime as any).loadSession('session-1', '/vault')).rejects.toBe(error);
+    expect(runtime.getSessionId()).toBe('session-1');
+  });
+
+  it('does not replay the transcript when readiness drops the session', async () => {
+    const runtime = new GeminiChatRuntime(createMockPlugin());
+    runtime.syncConversationState({ sessionId: 'session-1' });
+    const prompt = jest.fn().mockResolvedValue({});
+
+    jest.spyOn(runtime, 'ensureReady').mockImplementation(async () => {
+      (runtime as any).sessionId = null;
+      (runtime as any).loadedSessionId = null;
+      (runtime as any).sessionInvalidated = true;
+      return true;
+    });
+    (runtime as any).createSession = jest.fn().mockImplementation(async () => {
+      (runtime as any).sessionId = 'session-2';
+      return 'session-2';
+    });
+    (runtime as any).connection = { prompt };
+
+    const history = [
+      { id: 'user-previous', role: 'user' as const, content: 'Keep the language rich.', timestamp: 1 },
+    ];
+    await collect(runtime.query(runtime.prepareTurn({ text: 'Continue the edit.' }), history));
+
+    // Some runtimes send a settings command of their own before the turn, so
+    // the assertion is about everything that reached the agent.
+    const promptText = allPromptText(prompt);
+    expect(promptText).toContain('Continue the edit.');
+    expect(promptText).not.toContain('Keep the language rich.');
+  });
+
+  it('still withholds the transcript after the drop has survived a reload', async () => {
+    const runtime = new GeminiChatRuntime(createMockPlugin());
+    const prompt = jest.fn().mockResolvedValue({});
+
+    runtime.syncConversationState({
+      providerState: { sessionDropped: true },
+      sessionId: null,
+    });
+
+    jest.spyOn(runtime, 'ensureReady').mockResolvedValue(true);
+    (runtime as any).createSession = jest.fn().mockImplementation(async () => {
+      (runtime as any).sessionId = 'session-2';
+      return 'session-2';
+    });
+    (runtime as any).connection = { prompt };
+
+    const history = [
+      { id: 'user-previous', role: 'user' as const, content: 'Keep the language rich.', timestamp: 1 },
+    ];
+    await collect(runtime.query(runtime.prepareTurn({ text: 'Continue the edit.' }), history));
+
+    expect(allPromptText(prompt)).not.toContain('Keep the language rich.');
+  });
+
+  it('still replays the transcript for a genuine cold resume', async () => {
+    const runtime = new GeminiChatRuntime(createMockPlugin());
+    const prompt = jest.fn().mockResolvedValue({});
+
+    runtime.syncConversationState({ sessionId: null });
+    jest.spyOn(runtime, 'ensureReady').mockResolvedValue(true);
+    (runtime as any).createSession = jest.fn().mockImplementation(async () => {
+      (runtime as any).sessionId = 'session-2';
+      return 'session-2';
+    });
+    (runtime as any).connection = { prompt };
+
+    const history = [
+      { id: 'user-previous', role: 'user' as const, content: 'Keep the language rich.', timestamp: 1 },
+    ];
+    await collect(runtime.query(runtime.prepareTurn({ text: 'Continue the edit.' }), history));
+
+    expect(allPromptText(prompt)).toContain('Keep the language rich.');
+  });
+
+  it('records a dropped session on the conversation so a reload can tell it from a cold start', () => {
+    const runtime = new GeminiChatRuntime(createMockPlugin());
+    runtime.syncConversationState({ sessionId: 'session-1' });
+    (runtime as any).sessionId = null;
+    (runtime as any).sessionInvalidated = true;
+
+    const updates = runtime.buildSessionUpdates({
+      conversation: {
+        id: 'conv-1',
+        providerId: 'gemini',
+        providerState: {},
+        sessionId: 'session-1',
+      } as any,
+      sessionInvalidated: true,
+    });
+
+    expect(updates.updates.sessionId).toBeNull();
+    expect((updates.updates.providerState as any)?.sessionDropped).toBe(true);
+  });
+
+  it('keeps the dropped marker across a save that no longer carries the flag', () => {
+    const runtime = new GeminiChatRuntime(createMockPlugin());
+    (runtime as any).sessionId = null;
+
+    // consumeSessionInvalidation() already took the in-memory answer, so this
+    // save reports false; only the conversation still knows.
+    const updates = runtime.buildSessionUpdates({
+      conversation: {
+        id: 'conv-1',
+        providerId: 'gemini',
+        providerState: { sessionDropped: true },
+        sessionId: null,
+      } as any,
+      sessionInvalidated: false,
+    });
+
+    expect((updates.updates.providerState as any)?.sessionDropped).toBe(true);
+  });
+
+  it('clears the dropped marker once a replacement session is persisted', () => {
+    const runtime = new GeminiChatRuntime(createMockPlugin());
+    (runtime as any).sessionId = 'session-2';
+
+    const updates = runtime.buildSessionUpdates({
+      conversation: {
+        id: 'conv-1',
+        providerId: 'gemini',
+        providerState: { sessionDropped: true },
+        sessionId: null,
+      } as any,
+      sessionInvalidated: false,
+    });
+
+    expect(updates.updates.sessionId).toBe('session-2');
+    expect((updates.updates.providerState as any)?.sessionDropped).toBeUndefined();
+  });
+
+  it('restores a dropped session from the conversation on load', () => {
+    const runtime = new GeminiChatRuntime(createMockPlugin());
+
+    runtime.syncConversationState({
+      providerState: { sessionDropped: true },
+      sessionId: null,
+    });
+
+    expect(runtime.consumeSessionInvalidation()).toBe(true);
   });
 
   it('streams ACP assistant chunks and done', async () => {

--- a/tests/unit/providers/grok/GrokChatRuntime.test.ts
+++ b/tests/unit/providers/grok/GrokChatRuntime.test.ts
@@ -40,6 +40,13 @@ function createMockPlugin(overrides: Record<string, unknown> = {}): any {
   };
 }
 
+function allPromptText(prompt: jest.Mock): string {
+  return prompt.mock.calls
+    .flatMap((call: any[]) => (call[0]?.prompt ?? []) as Array<{ text?: string }>)
+    .map(block => block.text ?? '')
+    .join('\n');
+}
+
 describe('GrokChatRuntime', () => {
   beforeEach(() => {
     grokPlanUsageStore.reset();
@@ -60,6 +67,153 @@ describe('GrokChatRuntime', () => {
     }
     return chunks;
   }
+
+  it('does not replay the transcript when readiness drops the session', async () => {
+    const runtime = new GrokChatRuntime(createMockPlugin());
+    runtime.syncConversationState({ sessionId: 'session-1' });
+    const prompt = jest.fn().mockResolvedValue({});
+
+    jest.spyOn(runtime, 'ensureReady').mockImplementation(async () => {
+      (runtime as any).sessionId = null;
+      (runtime as any).loadedSessionId = null;
+      (runtime as any).sessionInvalidated = true;
+      return true;
+    });
+    (runtime as any).createSession = jest.fn().mockImplementation(async () => {
+      (runtime as any).sessionId = 'session-2';
+      return 'session-2';
+    });
+    (runtime as any).connection = { prompt };
+
+    const history = [
+      { id: 'user-previous', role: 'user' as const, content: 'Keep the language rich.', timestamp: 1 },
+    ];
+    for await (const chunk of runtime.query(runtime.prepareTurn({ text: 'Continue the edit.' }), history)) {
+      void chunk;
+    }
+
+    // Some runtimes send a settings command of their own before the turn, so
+    // the assertion is about everything that reached the agent.
+    const promptText = allPromptText(prompt);
+    expect(promptText).toContain('Continue the edit.');
+    expect(promptText).not.toContain('Keep the language rich.');
+  });
+
+  it('still withholds the transcript after the drop has survived a reload', async () => {
+    const runtime = new GrokChatRuntime(createMockPlugin());
+    const prompt = jest.fn().mockResolvedValue({});
+
+    runtime.syncConversationState({
+      providerState: { sessionDropped: true },
+      sessionId: null,
+    });
+
+    jest.spyOn(runtime, 'ensureReady').mockResolvedValue(true);
+    (runtime as any).createSession = jest.fn().mockImplementation(async () => {
+      (runtime as any).sessionId = 'session-2';
+      return 'session-2';
+    });
+    (runtime as any).connection = { prompt };
+
+    const history = [
+      { id: 'user-previous', role: 'user' as const, content: 'Keep the language rich.', timestamp: 1 },
+    ];
+    for await (const chunk of runtime.query(runtime.prepareTurn({ text: 'Continue the edit.' }), history)) {
+      void chunk;
+    }
+
+    expect(allPromptText(prompt)).not.toContain('Keep the language rich.');
+  });
+
+  it('still replays the transcript for a genuine cold resume', async () => {
+    const runtime = new GrokChatRuntime(createMockPlugin());
+    const prompt = jest.fn().mockResolvedValue({});
+
+    runtime.syncConversationState({ sessionId: null });
+    jest.spyOn(runtime, 'ensureReady').mockResolvedValue(true);
+    (runtime as any).createSession = jest.fn().mockImplementation(async () => {
+      (runtime as any).sessionId = 'session-2';
+      return 'session-2';
+    });
+    (runtime as any).connection = { prompt };
+
+    const history = [
+      { id: 'user-previous', role: 'user' as const, content: 'Keep the language rich.', timestamp: 1 },
+    ];
+    for await (const chunk of runtime.query(runtime.prepareTurn({ text: 'Continue the edit.' }), history)) {
+      void chunk;
+    }
+
+    expect(allPromptText(prompt)).toContain('Keep the language rich.');
+  });
+
+  it('records a dropped session on the conversation so a reload can tell it from a cold start', () => {
+    const runtime = new GrokChatRuntime(createMockPlugin());
+    runtime.syncConversationState({ sessionId: 'session-1' });
+    (runtime as any).sessionId = null;
+    (runtime as any).sessionInvalidated = true;
+
+    const updates = runtime.buildSessionUpdates({
+      conversation: {
+        id: 'conv-1',
+        providerId: 'grok',
+        providerState: {},
+        sessionId: 'session-1',
+      } as any,
+      sessionInvalidated: true,
+    });
+
+    expect(updates.updates.sessionId).toBeNull();
+    expect((updates.updates.providerState as any)?.sessionDropped).toBe(true);
+  });
+
+  it('keeps the dropped marker across a save that no longer carries the flag', () => {
+    const runtime = new GrokChatRuntime(createMockPlugin());
+    (runtime as any).sessionId = null;
+
+    // consumeSessionInvalidation() already took the in-memory answer, so this
+    // save reports false; only the conversation still knows.
+    const updates = runtime.buildSessionUpdates({
+      conversation: {
+        id: 'conv-1',
+        providerId: 'grok',
+        providerState: { sessionDropped: true },
+        sessionId: null,
+      } as any,
+      sessionInvalidated: false,
+    });
+
+    expect((updates.updates.providerState as any)?.sessionDropped).toBe(true);
+  });
+
+  it('clears the dropped marker once a replacement session is persisted', () => {
+    const runtime = new GrokChatRuntime(createMockPlugin());
+    (runtime as any).sessionId = 'session-2';
+
+    const updates = runtime.buildSessionUpdates({
+      conversation: {
+        id: 'conv-1',
+        providerId: 'grok',
+        providerState: { sessionDropped: true },
+        sessionId: null,
+      } as any,
+      sessionInvalidated: false,
+    });
+
+    expect(updates.updates.sessionId).toBe('session-2');
+    expect((updates.updates.providerState as any)?.sessionDropped).toBeUndefined();
+  });
+
+  it('restores a dropped session from the conversation on load', () => {
+    const runtime = new GrokChatRuntime(createMockPlugin());
+
+    runtime.syncConversationState({
+      providerState: { sessionDropped: true },
+      sessionId: null,
+    });
+
+    expect(runtime.consumeSessionInvalidation()).toBe(true);
+  });
 
   it('persists the user question so a failed turn is not wiped on hydrate', () => {
     const runtime = new GrokChatRuntime(createMockPlugin());

--- a/tests/unit/providers/qwen/runtime/QwenChatRuntime.test.ts
+++ b/tests/unit/providers/qwen/runtime/QwenChatRuntime.test.ts
@@ -4,6 +4,7 @@ import { hashCatalogFingerprint } from '@/core/providers/catalogFingerprint';
 import { ProviderWorkspaceRegistry } from '@/core/providers/ProviderWorkspaceRegistry';
 import type { StreamChunk } from '@/core/types';
 import type { AcpContentBlock } from '@/providers/acp';
+import { JsonRpcErrorResponse } from '@/providers/acp/AcpJsonRpcTransport';
 import { resolveQwenModelCatalogFingerprint } from '@/providers/qwen/modelCatalogFingerprint';
 import { QwenChatRuntime } from '@/providers/qwen/runtime/QwenChatRuntime';
 import { getQwenProviderSettings, updateQwenProviderSettings } from '@/providers/qwen/settings';
@@ -36,10 +37,187 @@ async function collect(generator: AsyncGenerator<StreamChunk>): Promise<StreamCh
   return chunks;
 }
 
+function allPromptText(prompt: jest.Mock): string {
+  return prompt.mock.calls
+    .flatMap((call: any[]) => (call[0]?.prompt ?? []) as Array<{ text?: string }>)
+    .map(block => block.text ?? '')
+    .join('\n');
+}
+
 describe('QwenChatRuntime', () => {
   afterEach(async () => {
     jest.restoreAllMocks();
     await fs.rm('/tmp/grimoire-qwen-test-vault', { force: true, recursive: true });
+  });
+
+  it('soft-fails a session the agent reports it no longer has', async () => {
+    const runtime = new QwenChatRuntime(createMockPlugin());
+    // Captured from qwen by loading a session id it has never had.
+    const missingSessionError = new JsonRpcErrorResponse(
+      'session/load',
+      -32002,
+      'Resource not found: session:session-1',
+      { uri: 'session:session-1' },
+    );
+    (runtime as any).connection = {
+      loadSession: jest.fn().mockRejectedValue(missingSessionError),
+    };
+
+    await expect((runtime as any).loadSession('session-1', '/vault')).resolves.toBe(false);
+  });
+
+  it('keeps the binding when the load failed for a reason other than a missing session', async () => {
+    const runtime = new QwenChatRuntime(createMockPlugin());
+    runtime.syncConversationState({ sessionId: 'session-1' });
+    const error = new JsonRpcErrorResponse('session/load', -32000, 'Authentication failed');
+    (runtime as any).connection = {
+      listSessions: jest.fn().mockResolvedValue({ sessions: [{ sessionId: 'session-1' }] }),
+      loadSession: jest.fn().mockRejectedValue(error),
+    };
+
+    await expect((runtime as any).loadSession('session-1', '/vault')).rejects.toBe(error);
+    expect(runtime.getSessionId()).toBe('session-1');
+  });
+
+  it('does not replay the transcript when readiness drops the session', async () => {
+    const runtime = new QwenChatRuntime(createMockPlugin());
+    runtime.syncConversationState({ sessionId: 'session-1' });
+    const prompt = jest.fn().mockResolvedValue({});
+
+    jest.spyOn(runtime, 'ensureReady').mockImplementation(async () => {
+      (runtime as any).sessionId = null;
+      (runtime as any).loadedSessionId = null;
+      (runtime as any).sessionInvalidated = true;
+      return true;
+    });
+    (runtime as any).createSession = jest.fn().mockImplementation(async () => {
+      (runtime as any).sessionId = 'session-2';
+      return 'session-2';
+    });
+    (runtime as any).connection = { prompt };
+
+    const history = [
+      { id: 'user-previous', role: 'user' as const, content: 'Keep the language rich.', timestamp: 1 },
+    ];
+    await collect(runtime.query(runtime.prepareTurn({ text: 'Continue the edit.' }), history));
+
+    // Some runtimes send a settings command of their own before the turn, so
+    // the assertion is about everything that reached the agent.
+    const promptText = allPromptText(prompt);
+    expect(promptText).toContain('Continue the edit.');
+    expect(promptText).not.toContain('Keep the language rich.');
+  });
+
+  it('still withholds the transcript after the drop has survived a reload', async () => {
+    const runtime = new QwenChatRuntime(createMockPlugin());
+    const prompt = jest.fn().mockResolvedValue({});
+
+    runtime.syncConversationState({
+      providerState: { sessionDropped: true },
+      sessionId: null,
+    });
+
+    jest.spyOn(runtime, 'ensureReady').mockResolvedValue(true);
+    (runtime as any).createSession = jest.fn().mockImplementation(async () => {
+      (runtime as any).sessionId = 'session-2';
+      return 'session-2';
+    });
+    (runtime as any).connection = { prompt };
+
+    const history = [
+      { id: 'user-previous', role: 'user' as const, content: 'Keep the language rich.', timestamp: 1 },
+    ];
+    await collect(runtime.query(runtime.prepareTurn({ text: 'Continue the edit.' }), history));
+
+    expect(allPromptText(prompt)).not.toContain('Keep the language rich.');
+  });
+
+  it('still replays the transcript for a genuine cold resume', async () => {
+    const runtime = new QwenChatRuntime(createMockPlugin());
+    const prompt = jest.fn().mockResolvedValue({});
+
+    runtime.syncConversationState({ sessionId: null });
+    jest.spyOn(runtime, 'ensureReady').mockResolvedValue(true);
+    (runtime as any).createSession = jest.fn().mockImplementation(async () => {
+      (runtime as any).sessionId = 'session-2';
+      return 'session-2';
+    });
+    (runtime as any).connection = { prompt };
+
+    const history = [
+      { id: 'user-previous', role: 'user' as const, content: 'Keep the language rich.', timestamp: 1 },
+    ];
+    await collect(runtime.query(runtime.prepareTurn({ text: 'Continue the edit.' }), history));
+
+    expect(allPromptText(prompt)).toContain('Keep the language rich.');
+  });
+
+  it('records a dropped session on the conversation so a reload can tell it from a cold start', () => {
+    const runtime = new QwenChatRuntime(createMockPlugin());
+    runtime.syncConversationState({ sessionId: 'session-1' });
+    (runtime as any).sessionId = null;
+    (runtime as any).sessionInvalidated = true;
+
+    const updates = runtime.buildSessionUpdates({
+      conversation: {
+        id: 'conv-1',
+        providerId: 'qwen',
+        providerState: {},
+        sessionId: 'session-1',
+      } as any,
+      sessionInvalidated: true,
+    });
+
+    expect(updates.updates.sessionId).toBeNull();
+    expect((updates.updates.providerState as any)?.sessionDropped).toBe(true);
+  });
+
+  it('keeps the dropped marker across a save that no longer carries the flag', () => {
+    const runtime = new QwenChatRuntime(createMockPlugin());
+    (runtime as any).sessionId = null;
+
+    // consumeSessionInvalidation() already took the in-memory answer, so this
+    // save reports false; only the conversation still knows.
+    const updates = runtime.buildSessionUpdates({
+      conversation: {
+        id: 'conv-1',
+        providerId: 'qwen',
+        providerState: { sessionDropped: true },
+        sessionId: null,
+      } as any,
+      sessionInvalidated: false,
+    });
+
+    expect((updates.updates.providerState as any)?.sessionDropped).toBe(true);
+  });
+
+  it('clears the dropped marker once a replacement session is persisted', () => {
+    const runtime = new QwenChatRuntime(createMockPlugin());
+    (runtime as any).sessionId = 'session-2';
+
+    const updates = runtime.buildSessionUpdates({
+      conversation: {
+        id: 'conv-1',
+        providerId: 'qwen',
+        providerState: { sessionDropped: true },
+        sessionId: null,
+      } as any,
+      sessionInvalidated: false,
+    });
+
+    expect(updates.updates.sessionId).toBe('session-2');
+    expect((updates.updates.providerState as any)?.sessionDropped).toBeUndefined();
+  });
+
+  it('restores a dropped session from the conversation on load', () => {
+    const runtime = new QwenChatRuntime(createMockPlugin());
+
+    runtime.syncConversationState({
+      providerState: { sessionDropped: true },
+      sessionId: null,
+    });
+
+    expect(runtime.consumeSessionInvalidation()).toBe(true);
   });
 
   it('does not start when the provider is disabled', async () => {


### PR DESCRIPTION
Supersedes #102. #104 covered the OpenCode/MiMoCode/Kimi Code trio; these three resume through their own code and were left with the same defect in a slightly different shape.

## What is different about these three

They never used the shared detector at all. Gemini and Qwen have a bare `catch { return false }` and the caller clears the session — so an expired token and a session that genuinely no longer exists are indistinguishable. Both silently drop the binding, and with #102's replay guard on top, both then drop the conversation's context with nothing said. That is the same trade #100 was heading for, already shipped here.

## Three fixes

**1. Discriminate.** Both now go through `isAcpSessionGone`. The widened patterns from #104 answer both without a round trip — I resumed an id neither has ever had:

| CLI | `session/load` on a missing session | Recognised? |
|---|---|---|
| Gemini CLI 0.53.1 | `-32603 "Internal error"`, `data.details: "No previous sessions found for this project."` | yes |
| Qwen Code 0.21.8 | `-32002 "Resource not found: session:<id>"` | yes |

`Authentication failed` is not recognised, and Gemini exposes no session listing to fall back on, so it propagates with the binding intact — which is the point. Qwen answers `session/list` too, so it has the listing as a backstop.

**2. Make the drop durable.** `consumeSessionInvalidation()` clears the flag, `save()` calls it, `TabManager.destroy()` saves every tab on quit. `providerState.sessionDropped` records it and is read back on load. Gemini and Qwen wiped `providerState` outright on invalidation, so the marker replaces that wipe; Grok's state filter had to learn the key.

**3. Stop the replay.** #102's fix, which only holds because of 2.

## Grok gets 2 and 3 only

Its CLI would not answer an ACP handshake off a bare probe, so what it reports for a session it no longer has is unobserved. Narrowing its catch blind would turn a silent recovery into a user-visible error on every stale resume — worse than the bug, and untestable. Its `AGENTS.md` records the reason and what would lift it.

## Verification

Live against the installed CLIs for Gemini and Qwen; their real payloads are checked in as fixtures. Each fix reverted in turn to confirm its tests fail without it — 2 for the detection, 6 for the durable marker, 3 for the replay guard.

Unit 7340 ✓ · integration 216 ✓ · typecheck ✓ · lint ✓ · `build:release` ✓.

https://claude.ai/code/session_01TDYHm4Ggxppte2w94Bdtak