### PR TITLE
fix(claude): route auto-mode questions through user dialogs

### DIFF
--- a/src/providers/claude/runtime/ClaudeApprovalHandler.ts
+++ b/src/providers/claude/runtime/ClaudeApprovalHandler.ts
@@ -22,6 +22,7 @@ import type {
 } from '../../../core/types';
 import type { PermissionMode } from '../../../core/types/settings';
 import { buildPermissionUpdates } from '../security/ClaudePermissionUpdates';
+import { prepareAskUserQuestionInput } from './claudeAskUserQuestion';
 
 export interface ClaudeApprovalHandlerDeps {
   getAllowedTools: () => string[] | null;
@@ -83,23 +84,15 @@ export function createClaudeApprovalCallback(
     const askUserQuestionCallback = deps.getAskUserQuestionCallback();
     if (toolName === TOOL_ASK_USER_QUESTION && askUserQuestionCallback) {
       try {
-        // The SDK's JSDoc says "Other will be provided automatically" but
-        // the SDK doesn't inject isOther into the canUseTool input. Grimoire
-        // intercepts at canUseTool and renders its own UI, so we must inject
-        // isOther here to match the Claude Code CLI's built-in behavior.
-        const questions = (input).questions;
-        if (Array.isArray(questions)) {
-          for (const q of questions) {
-            if (q && typeof q === 'object' && !('isOther' in q)) {
-              (q as Record<string, unknown>).isOther = true;
-            }
-          }
-        }
-        const answers = await askUserQuestionCallback(input, options.signal);
+        // The SDK's JSDoc says "Other will be provided automatically" but the
+        // SDK doesn't inject isOther into the canUseTool input, so Grimoire
+        // adds it before rendering its own UI.
+        const preparedInput = prepareAskUserQuestionInput(input);
+        const answers = await askUserQuestionCallback(preparedInput, options.signal);
         if (answers === null) {
           return { behavior: 'deny', message: 'User declined to answer.', interrupt: true };
         }
-        return { behavior: 'allow', updatedInput: { ...input, answers } };
+        return { behavior: 'allow', updatedInput: { ...preparedInput, answers } };
       } catch (error) {
         return {
           behavior: 'deny',

--- a/src/providers/claude/runtime/ClaudeChatRuntime.ts
+++ b/src/providers/claude/runtime/ClaudeChatRuntime.ts
@@ -805,6 +805,7 @@ export class ClaudeChatRuntime implements ChatRuntime {
         ? { sessionId: resumeSessionId, sessionAt: resumeAtMessageId, fork: this.pendingForkSession || undefined }
         : undefined,
       canUseTool: this.createApprovalCallback(),
+      onUserDialog: this.createUserDialogCallback(),
       hooks,
       externalContextPaths,
       orchestratorMode,
@@ -1658,6 +1659,7 @@ export class ClaudeChatRuntime implements ChatRuntime {
       sessionId: this.sessionManager.getSessionId() ?? undefined,
       modelOverride: queryOptions?.model,
       canUseTool: this.createApprovalCallback(),
+      onUserDialog: this.createUserDialogCallback(),
       hooks,
       mcpMentions: queryOptions?.mcpMentions,
       enabledMcpServers: queryOptions?.enabledMcpServers,
@@ -1964,6 +1966,45 @@ export class ClaudeChatRuntime implements ChatRuntime {
         }
       },
     });
+  }
+
+  private createUserDialogCallback(): NonNullable<Options['onUserDialog']> {
+    return async (request, { signal }) => {
+      if (request.dialogKind !== 'permission_ask_user_question') {
+        return { behavior: 'cancelled' };
+      }
+
+      const payload = request.payload;
+      const questions = payload.questions;
+      if (!Array.isArray(questions) || questions.length === 0 || !this.askUserQuestionCallback) {
+        return { behavior: 'cancelled' };
+      }
+
+      try {
+        const answers = await this.askUserQuestionCallback({ questions }, signal);
+        if (answers === null) {
+          return { behavior: 'cancelled' };
+        }
+
+        const permissionResult = isRecord(payload.permissionResult)
+          ? payload.permissionResult
+          : { behavior: 'allow' };
+        const existingInput = isRecord(permissionResult.updatedInput)
+          ? permissionResult.updatedInput
+          : { questions };
+
+        return {
+          behavior: 'completed',
+          result: {
+            ...permissionResult,
+            behavior: 'allow',
+            updatedInput: { ...existingInput, questions, answers },
+          },
+        };
+      } catch {
+        return { behavior: 'cancelled' };
+      }
+    };
   }
 
   private resolveSDKPermissionMode(mode: PermissionMode): SDKPermissionMode {

--- a/src/providers/claude/runtime/ClaudeChatRuntime.ts
+++ b/src/providers/claude/runtime/ClaudeChatRuntime.ts
@@ -84,6 +84,10 @@ import {
 import { resolveClaudeContextWindowSize } from '../types/models';
 import { type ClaudeProviderState, getClaudeState } from '../types/providerState';
 import { createClaudeApprovalCallback } from './ClaudeApprovalHandler';
+import {
+  CLAUDE_ASK_USER_QUESTION_DIALOG_KIND,
+  prepareAskUserQuestionInput,
+} from './claudeAskUserQuestion';
 import { applyClaudeDynamicUpdates } from './ClaudeDynamicUpdates';
 import { MessageChannel } from './ClaudeMessageChannel';
 import {
@@ -1968,41 +1972,74 @@ export class ClaudeChatRuntime implements ChatRuntime {
     });
   }
 
+  /**
+   * Dialog results use the CLI's own shape - `behavior` plus `updatedInput`,
+   * `permissionUpdates`, `feedback` and `contentBlocks` - not the SDK's
+   * `PermissionResult`, so the answer is built explicitly rather than by
+   * reusing the payload's permission result.
+   */
   private createUserDialogCallback(): NonNullable<Options['onUserDialog']> {
     return async (request, { signal }) => {
-      if (request.dialogKind !== 'permission_ask_user_question') {
+      if (request.dialogKind !== CLAUDE_ASK_USER_QUESTION_DIALOG_KIND) {
         return { behavior: 'cancelled' };
       }
 
       const payload = request.payload;
-      const questions = payload.questions;
+      const permissionResult = isRecord(payload.permissionResult) ? payload.permissionResult : {};
+
+      // The CLI resolves permission before it asks the host to render, so a
+      // denial stays denied - answering the question would upgrade it.
+      if (permissionResult.behavior === 'deny') {
+        const message = typeof permissionResult.message === 'string' ? permissionResult.message : undefined;
+        return {
+          behavior: 'completed',
+          result: { behavior: 'deny', ...(message ? { feedback: message } : {}) },
+        };
+      }
+
+      // Only `questions` travels in the payload; the rest of the tool input
+      // lives on the permission result and has to be carried back untouched.
+      const baseInput = isRecord(permissionResult.updatedInput) ? permissionResult.updatedInput : {};
+      const questions = Array.isArray(payload.questions) ? payload.questions : baseInput.questions;
       if (!Array.isArray(questions) || questions.length === 0 || !this.askUserQuestionCallback) {
         return { behavior: 'cancelled' };
       }
 
+      const input = prepareAskUserQuestionInput({ ...baseInput, questions });
+
       try {
-        const answers = await this.askUserQuestionCallback({ questions }, signal);
+        const answers = await this.askUserQuestionCallback(input, signal);
         if (answers === null) {
+          return {
+            behavior: 'completed',
+            result: { behavior: 'deny', feedback: 'User declined to answer.' },
+          };
+        }
+
+        return {
+          behavior: 'completed',
+          result: { behavior: 'allow', updatedInput: { ...input, answers } },
+        };
+      } catch (error) {
+        if (signal.aborted) {
           return { behavior: 'cancelled' };
         }
 
-        const permissionResult = isRecord(payload.permissionResult)
-          ? payload.permissionResult
-          : { behavior: 'allow' };
-        const existingInput = isRecord(permissionResult.updatedInput)
-          ? permissionResult.updatedInput
-          : { questions };
+        this.plugin.recordDebugLog?.({
+          data: { providerId: this.providerId, mode: request.dialogKind },
+          error,
+          event: 'user_dialog.failed',
+          level: 'warn',
+          scope: 'claude.dialog',
+        });
 
         return {
           behavior: 'completed',
           result: {
-            ...permissionResult,
-            behavior: 'allow',
-            updatedInput: { ...existingInput, questions, answers },
+            behavior: 'deny',
+            feedback: `Failed to get user answers: ${error instanceof Error ? error.message : 'Unknown error'}`,
           },
         };
-      } catch {
-        return { behavior: 'cancelled' };
       }
     };
   }

--- a/src/providers/claude/runtime/ClaudeQueryOptionsBuilder.ts
+++ b/src/providers/claude/runtime/ClaudeQueryOptionsBuilder.ts
@@ -20,6 +20,7 @@ import {
 import {
   resolveEffortLevel,
 } from '../types/models';
+import { CLAUDE_ASK_USER_QUESTION_DIALOG_KIND } from './claudeAskUserQuestion';
 import { createCustomSpawnFunction } from './customSpawn';
 import {
   DISABLED_BUILTIN_SUBAGENTS,
@@ -254,8 +255,10 @@ export class QueryOptionsBuilder {
   }
 
   /**
-   * AskUserQuestion uses request_user_dialog in auto/bypass modes in newer
-   * Claude Code versions, so it does not reliably pass through canUseTool.
+   * Newer Claude Code versions can hand AskUserQuestion to the host through a
+   * request_user_dialog control request instead of canUseTool. The CLI fails
+   * closed on undeclared kinds, so the handler only ever runs when the kind is
+   * advertised here.
    */
   private static applyUserDialogHandler(
     options: Options,
@@ -263,7 +266,7 @@ export class QueryOptionsBuilder {
   ): void {
     if (!onUserDialog) return;
     options.onUserDialog = onUserDialog;
-    options.supportedDialogKinds = ['permission_ask_user_question'];
+    options.supportedDialogKinds = [CLAUDE_ASK_USER_QUESTION_DIALOG_KIND];
   }
 
   private static buildBaseOptions(

--- a/src/providers/claude/runtime/ClaudeQueryOptionsBuilder.ts
+++ b/src/providers/claude/runtime/ClaudeQueryOptionsBuilder.ts
@@ -36,6 +36,7 @@ export interface QueryOptionsContext {
   enhancedPath: string;
   mcpManager: McpServerManager;
   pluginManager: AppPluginManager;
+  onUserDialog?: Options['onUserDialog'];
 }
 
 export interface PersistentQueryContext extends QueryOptionsContext {
@@ -157,6 +158,7 @@ export class QueryOptionsBuilder {
       ctx.settings.permissionMode,
       ctx.canUseTool,
     );
+    QueryOptionsBuilder.applyUserDialogHandler(options, ctx.onUserDialog);
     QueryOptionsBuilder.applyThinking(options, ctx.settings, ctx.settings.model);
     options.hooks = ctx.hooks;
 
@@ -210,6 +212,7 @@ export class QueryOptionsBuilder {
       ctx.settings.permissionMode,
       ctx.canUseTool,
     );
+    QueryOptionsBuilder.applyUserDialogHandler(options, ctx.onUserDialog);
     options.hooks = ctx.hooks;
     QueryOptionsBuilder.applyThinking(options, ctx.settings, ctx.modelOverride ?? ctx.settings.model);
 
@@ -248,6 +251,19 @@ export class QueryOptionsBuilder {
     }
 
     options.permissionMode = QueryOptionsBuilder.resolveClaudeSdkPermissionMode(permissionMode);
+  }
+
+  /**
+   * AskUserQuestion uses request_user_dialog in auto/bypass modes in newer
+   * Claude Code versions, so it does not reliably pass through canUseTool.
+   */
+  private static applyUserDialogHandler(
+    options: Options,
+    onUserDialog?: Options['onUserDialog'],
+  ): void {
+    if (!onUserDialog) return;
+    options.onUserDialog = onUserDialog;
+    options.supportedDialogKinds = ['permission_ask_user_question'];
   }
 
   private static buildBaseOptions(

--- a/src/providers/claude/runtime/claudeAskUserQuestion.ts
+++ b/src/providers/claude/runtime/claudeAskUserQuestion.ts
@@ -1,0 +1,33 @@
+/**
+ * Dialog kind the Claude Code CLI uses to hand an AskUserQuestion call to the
+ * host renderer instead of resolving it through `canUseTool`.
+ */
+export const CLAUDE_ASK_USER_QUESTION_DIALOG_KIND = 'permission_ask_user_question';
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+/**
+ * The CLI adds the free-text "Other" choice inside its own AskUserQuestion UI,
+ * and neither the `canUseTool` input nor the dialog payload carries that flag.
+ * Grimoire renders the question itself, so every entry point must inject it to
+ * match the CLI's built-in behavior.
+ */
+export function prepareAskUserQuestionInput(
+  input: Record<string, unknown>,
+): Record<string, unknown> {
+  const questions = input.questions;
+  if (!Array.isArray(questions)) {
+    return input;
+  }
+
+  return {
+    ...input,
+    questions: (questions as unknown[]).map(question => (
+      isRecord(question) && !('isOther' in question)
+        ? { ...question, isOther: true }
+        : question
+    )),
+  };
+}

--- a/tests/unit/providers/claude/runtime/ClaudeChatRuntime.test.ts
+++ b/tests/unit/providers/claude/runtime/ClaudeChatRuntime.test.ts
@@ -644,6 +644,31 @@ describe('ClaudeChatRuntime', () => {
         expect(result.behavior).toBe('allow');
         expect(callback).toHaveBeenCalled();
       });
+
+      it('injects the CLI free-text option before rendering AskUserQuestion', async () => {
+        const callback = jest.fn().mockResolvedValue({ 'Choose a theme': 'Dark' });
+        service.setAskUserQuestionCallback(callback);
+
+        const question = { options: [{ label: 'Light' }], question: 'Choose a theme' };
+        const canUseTool = (service as any).createApprovalCallback();
+        const result = await canUseTool(
+          'AskUserQuestion',
+          { questions: [question] },
+          canUseToolOptions,
+        );
+
+        expect(callback).toHaveBeenCalledWith(
+          { questions: [{ ...question, isOther: true }] },
+          canUseToolOptions.signal,
+        );
+        expect(result).toEqual({
+          behavior: 'allow',
+          updatedInput: {
+            answers: { 'Choose a theme': 'Dark' },
+            questions: [{ ...question, isOther: true }],
+          },
+        });
+      });
     });
   });
 
@@ -654,42 +679,98 @@ describe('ClaudeChatRuntime', () => {
       options: [{ label: 'Light' }, { label: 'Dark' }],
       question: 'Choose a theme',
     }];
+    const preparedQuestions = [{ ...questions[0], isOther: true }];
+
+    function requestDialog(payload: Record<string, unknown>, dialogKind = 'permission_ask_user_question') {
+      const onUserDialog = (service as any).createUserDialogCallback();
+      return onUserDialog({ dialogKind, payload }, dialogOptions);
+    }
 
     it('routes permission_ask_user_question through the shared callback', async () => {
       const callback = jest.fn().mockResolvedValue({ 'Choose a theme': 'Dark' });
       service.setAskUserQuestionCallback(callback);
 
-      const onUserDialog = (service as any).createUserDialogCallback();
-      const result = await onUserDialog({
-        dialogKind: 'permission_ask_user_question',
-        payload: {
-          permissionResult: { behavior: 'allow', updatedInput: { questions } },
-          questions,
+      const result = await requestDialog({
+        permissionResult: {
+          behavior: 'allow',
+          updatedInput: { metadata: { source: 'cli' }, questions },
         },
-      }, dialogOptions);
+        questions,
+      });
 
-      expect(callback).toHaveBeenCalledWith({ questions }, dialogOptions.signal);
+      // Only `questions` travels in the dialog payload, so the rest of the
+      // tool input has to come back from the permission result.
+      expect(callback).toHaveBeenCalledWith(
+        { metadata: { source: 'cli' }, questions: preparedQuestions },
+        dialogOptions.signal,
+      );
       expect(result).toEqual({
         behavior: 'completed',
         result: {
           behavior: 'allow',
           updatedInput: {
             answers: { 'Choose a theme': 'Dark' },
-            questions,
+            metadata: { source: 'cli' },
+            questions: preparedQuestions,
           },
         },
       });
+    });
+
+    it('keeps a denied permission decision instead of upgrading it to allow', async () => {
+      const callback = jest.fn();
+      service.setAskUserQuestionCallback(callback);
+
+      const result = await requestDialog({
+        permissionResult: { behavior: 'deny', message: 'Blocked by a deny rule.' },
+        questions,
+      });
+
+      expect(callback).not.toHaveBeenCalled();
+      expect(result).toEqual({
+        behavior: 'completed',
+        result: { behavior: 'deny', feedback: 'Blocked by a deny rule.' },
+      });
+    });
+
+    it('denies with feedback when the user dismisses the question', async () => {
+      const callback = jest.fn().mockResolvedValue(null);
+      service.setAskUserQuestionCallback(callback);
+
+      const result = await requestDialog({ questions });
+
+      expect(result).toEqual({
+        behavior: 'completed',
+        result: { behavior: 'deny', feedback: 'User declined to answer.' },
+      });
+    });
+
+    it('denies with the failure reason when the question UI throws', async () => {
+      const callback = jest.fn().mockRejectedValue(new Error('render failed'));
+      service.setAskUserQuestionCallback(callback);
+
+      const result = await requestDialog({ questions });
+
+      expect(result).toEqual({
+        behavior: 'completed',
+        result: { behavior: 'deny', feedback: 'Failed to get user answers: render failed' },
+      });
+    });
+
+    it('cancels dialogs that carry no questions', async () => {
+      const callback = jest.fn();
+      service.setAskUserQuestionCallback(callback);
+
+      await expect(requestDialog({ questions: [] })).resolves.toEqual({ behavior: 'cancelled' });
+      expect(callback).not.toHaveBeenCalled();
     });
 
     it('cancels unsupported dialogs without opening the question UI', async () => {
       const callback = jest.fn();
       service.setAskUserQuestionCallback(callback);
 
-      const onUserDialog = (service as any).createUserDialogCallback();
-      await expect(onUserDialog({
-        dialogKind: 'unknown_dialog',
-        payload: { questions },
-      }, dialogOptions)).resolves.toEqual({ behavior: 'cancelled' });
+      await expect(requestDialog({ questions }, 'unknown_dialog'))
+        .resolves.toEqual({ behavior: 'cancelled' });
       expect(callback).not.toHaveBeenCalled();
     });
   });

--- a/tests/unit/providers/claude/runtime/ClaudeChatRuntime.test.ts
+++ b/tests/unit/providers/claude/runtime/ClaudeChatRuntime.test.ts
@@ -647,6 +647,53 @@ describe('ClaudeChatRuntime', () => {
     });
   });
 
+  describe('AskUserQuestion dialog flow', () => {
+    const dialogOptions = { signal: new AbortController().signal };
+    const questions = [{
+      multiSelect: false,
+      options: [{ label: 'Light' }, { label: 'Dark' }],
+      question: 'Choose a theme',
+    }];
+
+    it('routes permission_ask_user_question through the shared callback', async () => {
+      const callback = jest.fn().mockResolvedValue({ 'Choose a theme': 'Dark' });
+      service.setAskUserQuestionCallback(callback);
+
+      const onUserDialog = (service as any).createUserDialogCallback();
+      const result = await onUserDialog({
+        dialogKind: 'permission_ask_user_question',
+        payload: {
+          permissionResult: { behavior: 'allow', updatedInput: { questions } },
+          questions,
+        },
+      }, dialogOptions);
+
+      expect(callback).toHaveBeenCalledWith({ questions }, dialogOptions.signal);
+      expect(result).toEqual({
+        behavior: 'completed',
+        result: {
+          behavior: 'allow',
+          updatedInput: {
+            answers: { 'Choose a theme': 'Dark' },
+            questions,
+          },
+        },
+      });
+    });
+
+    it('cancels unsupported dialogs without opening the question UI', async () => {
+      const callback = jest.fn();
+      service.setAskUserQuestionCallback(callback);
+
+      const onUserDialog = (service as any).createUserDialogCallback();
+      await expect(onUserDialog({
+        dialogKind: 'unknown_dialog',
+        payload: { questions },
+      }, dialogOptions)).resolves.toEqual({ behavior: 'cancelled' });
+      expect(callback).not.toHaveBeenCalled();
+    });
+  });
+
   describe('Session Restoration', () => {
     it('should restore session with custom model', () => {
       const customModel = 'claude-3-opus';

--- a/tests/unit/providers/claude/runtime/QueryOptionsBuilder.test.ts
+++ b/tests/unit/providers/claude/runtime/QueryOptionsBuilder.test.ts
@@ -388,6 +388,20 @@ describe('QueryOptionsBuilder', () => {
       expect(options.canUseTool).toBe(canUseTool);
     });
 
+    it('registers the AskUserQuestion dialog handler in persistent queries', () => {
+      const onUserDialog = jest.fn();
+      const ctx = {
+        ...createMockContext({ onUserDialog }),
+        abortController: new AbortController(),
+        hooks: {},
+      };
+
+      const options = QueryOptionsBuilder.buildPersistentQueryOptions(ctx);
+
+      expect(options.onUserDialog).toBe(onUserDialog);
+      expect(options.supportedDialogKinds).toEqual(['permission_ask_user_question']);
+    });
+
     it('sets normal safe mode options to ask before edits', () => {
       const canUseTool = jest.fn();
       const ctx = {

--- a/tests/unit/providers/claude/runtime/QueryOptionsBuilder.test.ts
+++ b/tests/unit/providers/claude/runtime/QueryOptionsBuilder.test.ts
@@ -669,6 +669,22 @@ describe('QueryOptionsBuilder', () => {
   });
 
   describe('buildColdStartQueryOptions', () => {
+    it('registers the AskUserQuestion dialog handler on a cold start too', () => {
+      const onUserDialog = jest.fn();
+      const ctx = {
+        ...createMockContext({ onUserDialog }),
+        abortController: new AbortController(),
+        hooks: {},
+        mcpMentions: new Set<string>(),
+        hasEditorContext: false,
+      };
+
+      const options = QueryOptionsBuilder.buildColdStartQueryOptions(ctx);
+
+      expect(options.onUserDialog).toBe(onUserDialog);
+      expect(options.supportedDialogKinds).toEqual(['permission_ask_user_question']);
+    });
+
     it('names the task tools on a cold start too', () => {
       const ctx = {
         ...createMockContext(),


### PR DESCRIPTION
## Motivation

I encountered this while migrating from Claudian to Grimoire. In Claudian's YOLO mode, Claude can still use `AskUserQuestion` when a task requires an explicit user decision. Grimoire already has a shared structured-question UI, but newer Claude Code versions may route these requests through `request_user_dialog` while bypass/auto mode is active, so they no longer reliably reach the existing `canUseTool` path.

Auto-approve should control whether tool actions require permission. It should not prevent the agent from asking the user to resolve a material ambiguity.

## Changes

- Register an `onUserDialog` handler for persistent and cold-start Claude queries.
- Advertise support for `permission_ask_user_question` dialogs.
- Route the dialog through Grimoire's existing structured-question callback.
- Preserve the SDK permission result while attaching the user's answers.
- Cancel unsupported or dismissed dialogs cleanly.

## Verification

- Claude runtime tests: 276 passed.
- Typecheck passed.
- Lint passed.
- Release build and isolated bundle verification passed.