### PR TITLE
fix(codex): enable user input in default mode

### DIFF
--- a/src/providers/codex/runtime/CodexLaunchSpecBuilder.ts
+++ b/src/providers/codex/runtime/CodexLaunchSpecBuilder.ts
@@ -14,12 +14,17 @@ export interface BuildCodexLaunchSpecOptions {
   resolveDefaultWslDistro?: () => string | undefined;
 }
 
-// Keep Grimoire's structured AskUserQuestion UI available while Codex is in
-// its normal/default collaboration mode (the toolbar's Safe and Auto modes).
+// Codex keeps request_user_input behind an experimental feature flag in its
+// default collaboration mode (the toolbar's Safe and Auto modes), so without
+// this the agent is told the tool is unavailable and answers by guessing.
+// `--enable <feature>` is the documented spelling, but it aborts the whole
+// app-server on a feature name the installed Codex does not know; the config
+// override it expands to is ignored instead, which keeps every other Codex
+// feature working if the flag is ever renamed or graduated upstream.
 const CODEX_APP_SERVER_ARGS = Object.freeze([
   'app-server',
-  '--enable',
-  'default_mode_request_user_input',
+  '-c',
+  'features.default_mode_request_user_input=true',
   '--listen',
   'stdio://',
 ]);

--- a/src/providers/codex/runtime/CodexLaunchSpecBuilder.ts
+++ b/src/providers/codex/runtime/CodexLaunchSpecBuilder.ts
@@ -14,7 +14,15 @@ export interface BuildCodexLaunchSpecOptions {
   resolveDefaultWslDistro?: () => string | undefined;
 }
 
-const CODEX_APP_SERVER_ARGS = Object.freeze(['app-server', '--listen', 'stdio://']);
+// Keep Grimoire's structured AskUserQuestion UI available while Codex is in
+// its normal/default collaboration mode (the toolbar's Safe and Auto modes).
+const CODEX_APP_SERVER_ARGS = Object.freeze([
+  'app-server',
+  '--enable',
+  'default_mode_request_user_input',
+  '--listen',
+  'stdio://',
+]);
 
 export function buildCodexLaunchSpec(
   options: BuildCodexLaunchSpecOptions,

--- a/tests/unit/providers/codex/runtime/CodexLaunchSpecBuilder.test.ts
+++ b/tests/unit/providers/codex/runtime/CodexLaunchSpecBuilder.test.ts
@@ -17,7 +17,13 @@ describe('buildCodexLaunchSpec', () => {
     });
 
     expect(spec.command).toBe('C:\\Users\\user\\AppData\\Roaming\\npm\\codex.exe');
-    expect(spec.args).toEqual(['app-server', '--listen', 'stdio://']);
+    expect(spec.args).toEqual([
+      'app-server',
+      '--enable',
+      'default_mode_request_user_input',
+      '--listen',
+      'stdio://',
+    ]);
     expect(spec.spawnCwd).toBe('C:\\repo');
     expect(spec.targetCwd).toBe('C:\\repo');
     expect(spec.target).toMatchObject({
@@ -51,6 +57,8 @@ describe('buildCodexLaunchSpec', () => {
       '/mnt/c/repo',
       'codex',
       'app-server',
+      '--enable',
+      'default_mode_request_user_input',
       '--listen',
       'stdio://',
     ]);
@@ -86,6 +94,8 @@ describe('buildCodexLaunchSpec', () => {
       '/mnt/c/repo',
       'codex',
       'app-server',
+      '--enable',
+      'default_mode_request_user_input',
       '--listen',
       'stdio://',
     ]);

--- a/tests/unit/providers/codex/runtime/CodexLaunchSpecBuilder.test.ts
+++ b/tests/unit/providers/codex/runtime/CodexLaunchSpecBuilder.test.ts
@@ -1,6 +1,28 @@
 import { buildCodexLaunchSpec } from '@/providers/codex/runtime/CodexLaunchSpecBuilder';
 
 describe('buildCodexLaunchSpec', () => {
+  it('enables the default-mode question feature through a config override', () => {
+    const spec = buildCodexLaunchSpec({
+      settings: {},
+      resolvedCliCommand: 'codex',
+      hostVaultPath: '/vault',
+      env: {},
+      hostPlatform: 'darwin',
+    });
+
+    // `--enable <feature>` aborts the app-server on a Codex build that does
+    // not know the feature, which would take down the whole provider; the
+    // config override it expands to is ignored there instead.
+    expect(spec.args).toEqual([
+      'app-server',
+      '-c',
+      'features.default_mode_request_user_input=true',
+      '--listen',
+      'stdio://',
+    ]);
+    expect(spec.args).not.toContain('--enable');
+  });
+
   it('builds a native Windows launch spec with a direct codex executable', () => {
     const spec = buildCodexLaunchSpec({
       settings: {
@@ -19,8 +41,8 @@ describe('buildCodexLaunchSpec', () => {
     expect(spec.command).toBe('C:\\Users\\user\\AppData\\Roaming\\npm\\codex.exe');
     expect(spec.args).toEqual([
       'app-server',
-      '--enable',
-      'default_mode_request_user_input',
+      '-c',
+      'features.default_mode_request_user_input=true',
       '--listen',
       'stdio://',
     ]);
@@ -57,8 +79,8 @@ describe('buildCodexLaunchSpec', () => {
       '/mnt/c/repo',
       'codex',
       'app-server',
-      '--enable',
-      'default_mode_request_user_input',
+      '-c',
+      'features.default_mode_request_user_input=true',
       '--listen',
       'stdio://',
     ]);
@@ -94,8 +116,8 @@ describe('buildCodexLaunchSpec', () => {
       '/mnt/c/repo',
       'codex',
       'app-server',
-      '--enable',
-      'default_mode_request_user_input',
+      '-c',
+      'features.default_mode_request_user_input=true',
       '--listen',
       'stdio://',
     ]);


### PR DESCRIPTION
## Motivation

I encountered this while migrating from Claudian to Grimoire. In Claudian's YOLO mode, the agent can still ask a structured question when a task requires an explicit user decision. Grimoire already handles Codex `item/tool/requestUserInput` requests in its shared question UI, but Codex does not expose `request_user_input` in Default mode unless its official feature flag is enabled.

Auto-approve should control whether tool actions require permission. It should not prevent the agent from asking the user to resolve a material ambiguity.

Before this change, Codex could report that `request_user_input` was only available in Plan mode, or proceed by making an assumption instead of asking.

## Changes

- Start Codex app-server with the official `default_mode_request_user_input` feature enabled.
- Apply the flag to native Windows/macOS/Linux and WSL launch specifications.
- Keep the existing request routing and shared question UI unchanged.

## Compatibility

The flag is experimental and remains owned by Codex. It was verified with Codex CLI 0.117.0 and 0.147.0. Codex currently treats Default-mode questions as non-blocking and may resolve an unanswered request after its provider-defined timeout.

## Verification

- Codex launch and request-router tests: 32 passed.
- Typecheck passed.
- Lint passed.
- Release build and isolated bundle verification passed.
- Verified a live Grimoire app-server process starts with the feature enabled.