### PR TITLE
fix(deps): clear the fast-uri and qs advisories the audit gate fails on

### DIFF
--- a/DISCLOSURES.md
+++ b/DISCLOSURES.md
@@ -119,15 +119,16 @@ The MCP SDK range is `^1.30.0`, whose dependency contract accepts `@hono/node-se
 
 - Clean installation, the full unit suite, release-bundle verification, and `npm audit --omit=dev` are required release gates before publication.
 - A clean audit is a verified release target, not a standing claim in this document.
+- `.npmrc` sets `min-release-age=7`, so a freshly published release cannot enter the lockfile for a week. When a security fix lands inside that window, it is admitted through `lockfile-age-exceptions.json` with an `expiresAt` no later than the package's natural eligibility, never by lowering the quarantine itself.
 
 | Package | Source | In `main.js` | Locked version | Advisory range | Status |
 |---|---|---|---|---|---|
 | `@modelcontextprotocol/sdk` | Direct dependency | Verify from release bundle | 1.30.0 | Direct SDK; audit gate applies | Locked from the declared `^1.30.0` range |
 | `hono` | MCP SDK | Verify from release bundle | 4.13.0 | `<4.12.34` | Above tracked ranges |
 | `@hono/node-server` | MCP SDK | Verify from release bundle | 2.1.0 | `<2.0.5` | Narrow override to a patched release |
-| `fast-uri` | MCP SDK / AJV | Verify from release bundle | 3.1.5 | `>=3.0.0 <3.1.5` | Above tracked ranges |
+| `fast-uri` | MCP SDK / AJV | Verify from release bundle | 3.1.6 | `>=3.0.0 <=3.1.5` | Above tracked ranges |
 | `ip-address` | MCP SDK / Express rate limit | Verify from release bundle | 10.4.0 | `<=10.1.0` | Above tracked range |
-| `qs` | MCP SDK / Express | Verify from release bundle | 6.15.3 | `>=6.11.1 <=6.15.1` | Above tracked range |
+| `qs` | MCP SDK / Express | Verify from release bundle | 6.16.0 | `>=2.2.5 <6.16.0` | Above tracked range; admitted before the 7-day quarantine through a `lockfile-age-exceptions.json` entry that expires at its natural eligibility |
 | `@anthropic-ai/sdk` | Claude Agent SDK | Verify from release bundle | 0.115.0 | `>=0.79.0 <0.91.1` | Above tracked range |
 | `ws` | jsdom | Development dependency | 8.21.2 | `>=8.0.0 <8.20.1` | Development-only; above tracked range |
 | `brace-expansion` 1.x | Nested tooling dependency | Development dependency | 1.1.18 | `<1.1.18` | Development-only; patched |

--- a/lockfile-age-exceptions.json
+++ b/lockfile-age-exceptions.json
@@ -40,6 +40,7 @@
     { "package": "jose", "version": "6.2.8", "reason": "Pre-existing audited lockfile transition.", "expiresAt": "2026-08-10T12:01:12.001Z" },
     { "package": "js-yaml", "version": "4.3.1", "reason": "Pre-existing audited lockfile transition.", "expiresAt": "2026-08-07T17:39:51.183Z" },
     { "package": "node-releases", "version": "2.0.52", "reason": "Pre-existing audited lockfile transition.", "expiresAt": "2026-08-11T05:59:28.009Z" },
+    { "package": "qs", "version": "6.16.0", "reason": "Security fix for GHSA-4mjr-xmp4-gh2g and GHSA-x5fp-wj9c-mxmx; qs 6.15.3 is the last vulnerable release and 6.16.0 is the first fixed one. Expires at its natural eligibility.", "expiresAt": "2026-09-05T23:50:15.803Z" },
     { "package": "tsx", "version": "4.23.5", "reason": "Pre-existing audited lockfile transition.", "expiresAt": "2026-08-09T23:18:23.595Z" },
     { "package": "typescript-eslint", "version": "8.66.0", "reason": "Pre-existing audited lockfile transition.", "expiresAt": "2026-08-10T17:36:21.323Z" },
     { "package": "ws", "version": "8.21.2", "reason": "Pre-existing audited lockfile transition.", "expiresAt": "2026-08-10T20:37:45.880Z" }

--- a/package-lock.json
+++ b/package-lock.json
@@ -6747,9 +6747,9 @@
       "peer": true
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.6.tgz",
+      "integrity": "sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==",
       "funding": [
         {
           "type": "github",
@@ -9937,9 +9937,9 @@
       "license": "MIT"
     },
     "node_modules/qs": {
-      "version": "6.15.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
-      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+      "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "es-define-property": "^1.0.1",

--- a/scripts/check-review-dependencies.mjs
+++ b/scripts/check-review-dependencies.mjs
@@ -23,9 +23,9 @@ const advisories = [
   },
   {
     packageName: "fast-uri",
-    vulnerableRange: ">=3.0.0 <3.1.5",
-    advisory: "GHSA-q3j6-qgpj-74h6 / GHSA-v39h-62p7-jpjc / GHSA-7p8r-x3mc-p8w7",
-    isVulnerable: (version) => greaterThanOrEqual(version, "3.0.0") && lessThan(version, "3.1.5"),
+    vulnerableRange: ">=3.0.0 <=3.1.5",
+    advisory: "GHSA-q3j6-qgpj-74h6 / GHSA-v39h-62p7-jpjc / GHSA-7p8r-x3mc-p8w7 / GHSA-5jgf-p345-68v8 / GHSA-f65p-4m7j-42xc / GHSA-fph4-wmhf-6fwf / GHSA-jqff-g426-hqxp",
+    isVulnerable: (version) => greaterThanOrEqual(version, "3.0.0") && lessThanOrEqual(version, "3.1.5"),
   },
   {
     packageName: "ip-address",
@@ -58,9 +58,9 @@ const advisories = [
   },
   {
     packageName: "qs",
-    vulnerableRange: ">=6.11.1 <=6.15.1",
-    advisory: "GHSA-q8mj-m7cp-5q26",
-    isVulnerable: (version) => greaterThanOrEqual(version, "6.11.1") && lessThanOrEqual(version, "6.15.1"),
+    vulnerableRange: ">=2.2.5 <6.16.0",
+    advisory: "GHSA-q8mj-m7cp-5q26 / GHSA-4mjr-xmp4-gh2g / GHSA-x5fp-wj9c-mxmx",
+    isVulnerable: (version) => greaterThanOrEqual(version, "2.2.5") && lessThan(version, "6.16.0"),
   },
 ];
 

--- a/tests/unit/scripts/reviewGate.test.ts
+++ b/tests/unit/scripts/reviewGate.test.ts
@@ -69,7 +69,12 @@ describe('Obsidian review gate', () => {
     expect(dependencyGate).toContain('GHSA-8j4g-w8fx-2239');
     expect(dependencyGate).toContain('lessThan(version, "4.12.34")');
     expect(dependencyGate).toContain('GHSA-7p8r-x3mc-p8w7');
-    expect(dependencyGate).toContain('lessThan(version, "3.1.5")');
+    // 3.1.5 moved from the first patched release to the last vulnerable one
+    // when the September 2026 fast-uri advisories landed.
+    expect(dependencyGate).toContain('GHSA-jqff-g426-hqxp');
+    expect(dependencyGate).toContain('lessThanOrEqual(version, "3.1.5")');
+    expect(dependencyGate).toContain('GHSA-4mjr-xmp4-gh2g');
+    expect(dependencyGate).toContain('lessThan(version, "6.16.0")');
     expect(dependencyGate).toContain('GHSA-rgw5-rvv9-x895');
     expect(dependencyGate).toContain('lessThan(version, "1.1.18")');
     expect(dependencyGate).toContain('lessThan(version, "2.1.4")');
@@ -83,6 +88,8 @@ describe('Obsidian review gate', () => {
       'node_modules/@hono/node-server': { version: '2.0.4' },
       'node_modules/brace-expansion': { version: '5.0.8' },
       'node_modules/example/node_modules/brace-expansion': { version: '1.1.17' },
+      'node_modules/fast-uri': { version: '3.1.5' },
+      'node_modules/qs': { version: '6.15.3' },
     });
 
     expect(result.status).toBe(1);
@@ -90,6 +97,8 @@ describe('Obsidian review gate', () => {
     expect(result.stderr).toContain('@hono/node-server@2.0.4');
     expect(result.stderr).toContain('brace-expansion@5.0.8');
     expect(result.stderr).toContain('brace-expansion@1.1.17');
+    expect(result.stderr).toContain('fast-uri@3.1.5');
+    expect(result.stderr).toContain('qs@6.15.3');
   });
 
   it('accepts patched hoisted, scoped, and nested lockfile packages', () => {
@@ -97,7 +106,8 @@ describe('Obsidian review gate', () => {
       '': { version: '1.0.0' },
       'node_modules/hono': { version: '4.12.34' },
       'node_modules/@hono/node-server': { version: '2.0.5' },
-      'node_modules/fast-uri': { version: '3.1.5' },
+      'node_modules/fast-uri': { version: '3.1.6' },
+      'node_modules/qs': { version: '6.16.0' },
       'node_modules/brace-expansion': { version: '5.0.9' },
       'node_modules/example/node_modules/brace-expansion': { version: '1.1.18' },
     });


### PR DESCRIPTION
## Why CI is red

`npm audit` has failed on `main` since the September 2026 advisories (run `33739635487` on the #113 merge, and every PR branched off it). Both findings are transitive under `@modelcontextprotocol/sdk@1.30.0`:

| Package | Path | Advisory range | Fix |
|---|---|---|---|
| `fast-uri@3.1.5` | sdk → `ajv@8.20.0` (wants `^3.0.1`) | `>=3.0.0 <=3.1.5` (high) | `3.1.6` |
| `qs@6.15.3` | sdk → `express@5.2.1` / `body-parser@2.3.0` (want `^6.14.0` / `^6.15.2`) | `>=2.2.5 <6.16.0` (moderate) | `6.16.0` |

The SDK is already on its newest release, and both fixes satisfy the ranges `ajv` and `express` declare, so nothing in `package.json` has to move. What stopped `npm audit fix` from clearing it was this repository's own quarantine: `.npmrc` sets `min-release-age=7`, and `qs@6.16.0` was published 2026-08-29, four days before this branch. npm therefore reported `fix available via npm audit fix` on every run while refusing to install the version that fixes it.

## What this changes

- **`fast-uri` → 3.1.6.** Published 2026-08-23, past the quarantine on its own, and out of the advisory range. No exception needed. (3.1.7 exists but is one day old.)
- **`qs` → 6.16.0** through a `lockfile-age-exceptions.json` entry whose `expiresAt` is `2026-09-05T23:50:15.803Z` — the package's natural eligibility, which is the ceiling `validateExceptionEligibility` enforces. This is the bridge that file exists for and the shape its other forty entries already use. The quarantine itself stays at seven days; the entry becomes redundant on 5 September rather than needing to be removed.
- **`review:deps` ranges realigned.** The gate tracked `fast-uri >=3.0.0 <3.1.5` and `qs >=6.11.1 <=6.15.1`, so it reported "Obsidian review dependency check passed" on precisely the versions `npm audit` was failing on. Both now match the current advisories, which is why the gate's patched-tree fixture had to move off `fast-uri@3.1.5` — that version is now the last vulnerable one, not the first patched one. The vulnerable-tree fixture gains `fast-uri@3.1.5` and `qs@6.15.3` so the drift cannot recur silently.
- **`DISCLOSURES.md`** records the new locked versions and, in the release-gate list, how a security fix that lands inside the quarantine window is admitted.

`package.json` is untouched; the lockfile diff is two version bumps and nothing else.

## Verification

Every gate the CI job runs, locally:

| Gate | Result |
|---|---|
| `npm audit` | **found 0 vulnerabilities** (was 1 high + 1 moderate) |
| `npm audit --omit=dev` | exit 0 |
| `npm audit signatures` | 135 packages with verified attestations |
| `npm run check:lockfile-age` | passed (829 packages, 7-day minimum) |
| `review:source` / `review:css` / `review:deps` | exit 0 |
| unit / integration | 413 suites, 7404 tests / 4 suites, 216 tests |
| `npm run typecheck` / `npm run lint` | exit 0 |
| `npm run build:release` | bundle built, loads and opens `grimoire-view` |

https://claude.ai/code/session_01Fpm9BLo5CxYVYFgK5vBAAM