### PR TITLE
feat(chat): make the fallback conversation title readable

### DIFF
--- a/src/core/prompt/fallbackTitle.ts
+++ b/src/core/prompt/fallbackTitle.ts
@@ -1,3 +1,5 @@
+import { extractUserQuery } from '../../utils/context';
+
 const DEFAULT_MAX_TITLE_LENGTH = 50;
 const ELLIPSIS = '...';
 /** Below this length a first sentence carries too little signal to stand alone as a title. */
@@ -8,7 +10,13 @@ const MIN_SIGNAL_LENGTH = 12;
  * wise collapse to a single word.
  */
 const MIN_WORD_CUT_RATIO = 0.3;
-const TRAILING_NOISE = /[\s.,;:!?—–-]+$/;
+/**
+ * A first message can carry a pasted file. Only its opening can ever reach a title,
+ * so every scan below runs over a bounded prefix instead of the whole paste.
+ */
+const SCAN_LIMIT = 4096;
+const NOISE_CHAR = /[\s.,;:!?—–-]/;
+const TAG_NAME = /^[A-Za-z_][\w.:-]*/;
 
 export interface FallbackTitleOptions {
   /** Maximum length of the returned title. Defaults to 50. */
@@ -22,60 +30,155 @@ export interface FallbackTitleOptions {
  *
  * Deterministic and side-effect free: context blocks are dropped, the first
  * meaningful sentence is selected without breaking on decimals or versions, the
- * result is cut on a word boundary and disambiguated against existing titles.
+ * result is folded onto one line, cut on a word boundary and disambiguated against
+ * existing titles.
  */
 export function buildFallbackTitle(
   message: string,
   options: FallbackTitleOptions = {},
 ): string {
   const maxLength = options.maxLength ?? DEFAULT_MAX_TITLE_LENGTH;
-  const text = stripLeadingContextBlocks(message);
+  const text = selectTitleSource(message);
   if (!text) {
     return '';
   }
 
   const sentence = selectFirstMeaningfulSentence(text);
-  const truncated = truncateOnWordBoundary(sentence, maxLength);
+  const truncated = truncateOnWordBoundary(collapseWhitespace(sentence), maxLength);
 
   return disambiguate(truncated, options.existingTitles, maxLength);
 }
 
 /**
- * Drops XML-ish context blocks that the host prepends to the first message, so the
- * title comes from what the user actually typed.
+ * Narrows the message down to what the user actually typed.
+ *
+ * `extractUserQuery` removes the context Grimoire appends to a prompt, which is
+ * written as a suffix; the leading-block pass additionally drops blocks a CLI host
+ * prepends, such as `<git_status>` or a self-closing `<image … />` marker.
  */
-function stripLeadingContextBlocks(message: string): string {
-  let rest = message.trim();
+function selectTitleSource(message: string): string {
+  const bounded = message.slice(0, SCAN_LIMIT).trim();
+  if (!bounded) {
+    return '';
+  }
+
+  return stripLeadingContextBlocks(extractUserQuery(bounded).trim() || bounded);
+}
+
+function stripLeadingContextBlocks(text: string): string {
+  let rest = text;
 
   for (;;) {
     if (!rest.startsWith('<')) {
       return rest;
     }
 
-    const openEnd = rest.indexOf('>');
-    if (openEnd === -1) {
+    const name = readTagName(rest, 1);
+    if (!name) {
       return rest;
     }
 
-    const openTag = rest.slice(1, openEnd);
-    const tagName = openTag.split(/[\s/>]/)[0];
-    if (!tagName || !/^[A-Za-z_][\w.-]*$/.test(tagName)) {
+    const blockEnd = findLeadingBlockEnd(rest, name);
+    if (blockEnd === -1) {
       return rest;
     }
 
-    const closingTag = `</${tagName}>`;
-    const closingIndex = rest.indexOf(closingTag, openEnd);
-    const next = closingIndex === -1
-      ? rest.slice(openEnd + 1)
-      : rest.slice(closingIndex + closingTag.length);
-
-    const trimmedNext = next.trim();
-    if (!trimmedNext) {
-      return '';
+    const next = rest.slice(blockEnd).trim();
+    if (!next) {
+      // Nothing but blocks. A host context dump carries no identity worth keeping,
+      // while markup the user typed is the only signal this message has.
+      return isContextBlockName(name) ? '' : rest;
     }
 
-    rest = trimmedNext;
+    rest = next;
   }
+}
+
+/** Host context blocks are snake_case by convention; markup a user types is not. */
+function isContextBlockName(name: string): boolean {
+  return name.includes('_');
+}
+
+function readTagName(text: string, start: number): string {
+  return TAG_NAME.exec(text.slice(start, start + 64))?.[0] ?? '';
+}
+
+/** Index just past the block opened at 0, or -1 when the text does not open one. */
+function findLeadingBlockEnd(text: string, name: string): number {
+  const openEnd = findTagEnd(text, 0);
+  if (openEnd === -1) {
+    return -1;
+  }
+  if (text[openEnd - 1] === '/') {
+    return openEnd + 1;
+  }
+
+  return findBlockEnd(text, name, openEnd + 1);
+}
+
+/**
+ * End of the block whose opening tag ends before `from`, counting nested tags of the
+ * same name. A block that is never closed ends with its opening tag.
+ */
+function findBlockEnd(text: string, name: string, from: number): number {
+  let depth = 1;
+  let index = from;
+
+  while (index < text.length) {
+    const open = text.indexOf('<', index);
+    if (open === -1) {
+      break;
+    }
+
+    const end = findTagEnd(text, open);
+    if (end === -1) {
+      break;
+    }
+
+    if (isTagNamed(text, open, name)) {
+      if (text[open + 1] === '/') {
+        depth -= 1;
+        if (depth === 0) {
+          return end + 1;
+        }
+      } else if (text[end - 1] !== '/') {
+        depth += 1;
+      }
+    }
+
+    index = end + 1;
+  }
+
+  return from;
+}
+
+/** Index of the `>` closing the tag that starts at `start`, ignoring quoted values. */
+function findTagEnd(text: string, start: number): number {
+  let quote = '';
+
+  for (let index = start; index < text.length; index += 1) {
+    const char = text[index];
+    if (quote) {
+      if (char === quote) {
+        quote = '';
+      }
+      continue;
+    }
+    if (char === '"' || char === "'") {
+      quote = char;
+      continue;
+    }
+    if (char === '>') {
+      return index;
+    }
+  }
+
+  return -1;
+}
+
+function isTagNamed(text: string, index: number, name: string): boolean {
+  const start = index + (text[index + 1] === '/' ? 2 : 1);
+  return text.startsWith(name, start) && /[\s/>]/.test(text[start + name.length] ?? '>');
 }
 
 /**
@@ -84,66 +187,81 @@ function stripLeadingContextBlocks(message: string): string {
  * such as `0.4` or `1.4.5`.
  */
 function selectFirstMeaningfulSentence(text: string): string {
-  for (const boundary of collectSentenceBoundaries(text)) {
-    const candidate = text.slice(0, boundary).replace(TRAILING_NOISE, '');
+  for (let index = 0; index < text.length; index += 1) {
+    if (!isSentenceEnd(text, index)) {
+      continue;
+    }
+
+    const candidate = trimNoise(text.slice(0, index));
     if (candidate.length >= MIN_SIGNAL_LENGTH) {
       return candidate;
     }
   }
 
-  return text.replace(TRAILING_NOISE, '');
+  return trimNoise(text);
 }
 
-function collectSentenceBoundaries(text: string): number[] {
-  const boundaries: number[] = [];
-
-  for (let index = 0; index < text.length; index += 1) {
-    const char = text[index];
-    if (char === '\n') {
-      boundaries.push(index);
-      continue;
-    }
-
-    if (char !== '.' && char !== '!' && char !== '?') {
-      continue;
-    }
-
-    const previous = text[index - 1];
-    const next = text[index + 1];
-    const insideNumber = isDigit(previous) && isDigit(next);
-    if (insideNumber) {
-      continue;
-    }
-
-    if (next === undefined || /\s/.test(next)) {
-      boundaries.push(index);
-    }
+function isSentenceEnd(text: string, index: number): boolean {
+  const char = text[index];
+  if (char === '\n') {
+    return true;
+  }
+  if (char !== '.' && char !== '!' && char !== '?') {
+    return false;
   }
 
-  return boundaries;
+  const next = text[index + 1];
+  if (isDigit(text[index - 1]) && isDigit(next)) {
+    return false;
+  }
+
+  return next === undefined || /\s/.test(next);
 }
 
 function isDigit(char: string | undefined): boolean {
   return char !== undefined && char >= '0' && char <= '9';
 }
 
+/** Trailing punctuation and whitespace, trimmed one character at a time so that no
+ * amount of it can make the scan super-linear. */
+function trimNoise(text: string): string {
+  let end = text.length;
+  while (end > 0 && NOISE_CHAR.test(text[end - 1])) {
+    end -= 1;
+  }
+
+  return text.slice(0, end);
+}
+
+/** Titles are single-line: they are stored as metadata and a rename input would drop
+ * the breaks anyway, gluing the surrounding words together. */
+function collapseWhitespace(text: string): string {
+  return text.replace(/\s+/g, ' ').trim();
+}
+
 function truncateOnWordBoundary(text: string, maxLength: number): string {
   if (text.length <= maxLength) {
     return text;
   }
+  if (maxLength <= ELLIPSIS.length) {
+    return trimDanglingSurrogate(text.slice(0, maxLength));
+  }
 
-  const budget = Math.max(1, maxLength - ELLIPSIS.length);
-  const hardCut = text.slice(0, budget).replace(/\s+$/, '');
+  const hardCut = trimDanglingSurrogate(text.slice(0, maxLength - ELLIPSIS.length)).trimEnd();
   const lastSpace = hardCut.lastIndexOf(' ');
-  const wordCut = lastSpace > 0
-    ? hardCut.slice(0, lastSpace).replace(TRAILING_NOISE, '')
-    : '';
+  const wordCut = lastSpace > 0 ? trimNoise(hardCut.slice(0, lastSpace)) : '';
 
   if (wordCut.length >= maxLength * MIN_WORD_CUT_RATIO) {
     return `${wordCut}${ELLIPSIS}`;
   }
 
   return `${hardCut}${ELLIPSIS}`;
+}
+
+/** A cut must not leave the leading half of a surrogate pair behind. */
+function trimDanglingSurrogate(text: string): string {
+  const last = text.charCodeAt(text.length - 1);
+  return last >= 0xd800 && last <= 0xdbff ? text.slice(0, -1) : text;
 }
 
 function disambiguate(
@@ -166,16 +284,17 @@ function disambiguate(
     return title;
   }
 
-  for (let counter = 2; counter < 1000; counter += 1) {
-    const suffix = ` (${counter})`;
+  // ` 2`, ` 3` … is the discriminator tab duplication and forking already use.
+  // Distinct counters always render distinct candidates, so a finite set of taken
+  // titles cannot keep the loop running.
+  for (let counter = 2; ; counter += 1) {
+    const suffix = ` ${counter}`;
     const base = title.length + suffix.length <= maxLength
       ? title
-      : title.slice(0, Math.max(1, maxLength - suffix.length)).replace(/\s+$/, '');
+      : trimDanglingSurrogate(title.slice(0, Math.max(1, maxLength - suffix.length))).trimEnd();
     const candidate = `${base}${suffix}`;
     if (!taken.has(candidate)) {
       return candidate;
     }
   }
-
-  return title;
 }

--- a/src/core/prompt/fallbackTitle.ts
+++ b/src/core/prompt/fallbackTitle.ts
@@ -1,0 +1,181 @@
+const DEFAULT_MAX_TITLE_LENGTH = 50;
+const ELLIPSIS = '...';
+/** Below this length a first sentence carries too little signal to stand alone as a title. */
+const MIN_SIGNAL_LENGTH = 12;
+/**
+ * A word-boundary cut is preferred, but only while it keeps a useful share of the
+ * budget. Messages that open with one very long token (a path, a URL) would other-
+ * wise collapse to a single word.
+ */
+const MIN_WORD_CUT_RATIO = 0.3;
+const TRAILING_NOISE = /[\s.,;:!?—–-]+$/;
+
+export interface FallbackTitleOptions {
+  /** Maximum length of the returned title. Defaults to 50. */
+  maxLength?: number;
+  /** Titles already in use; a matching title gets a numeric discriminator. */
+  existingTitles?: Iterable<string>;
+}
+
+/**
+ * Builds a conversation title from the first user message without calling a model.
+ *
+ * Deterministic and side-effect free: context blocks are dropped, the first
+ * meaningful sentence is selected without breaking on decimals or versions, the
+ * result is cut on a word boundary and disambiguated against existing titles.
+ */
+export function buildFallbackTitle(
+  message: string,
+  options: FallbackTitleOptions = {},
+): string {
+  const maxLength = options.maxLength ?? DEFAULT_MAX_TITLE_LENGTH;
+  const text = stripLeadingContextBlocks(message);
+  if (!text) {
+    return '';
+  }
+
+  const sentence = selectFirstMeaningfulSentence(text);
+  const truncated = truncateOnWordBoundary(sentence, maxLength);
+
+  return disambiguate(truncated, options.existingTitles, maxLength);
+}
+
+/**
+ * Drops XML-ish context blocks that the host prepends to the first message, so the
+ * title comes from what the user actually typed.
+ */
+function stripLeadingContextBlocks(message: string): string {
+  let rest = message.trim();
+
+  for (;;) {
+    if (!rest.startsWith('<')) {
+      return rest;
+    }
+
+    const openEnd = rest.indexOf('>');
+    if (openEnd === -1) {
+      return rest;
+    }
+
+    const openTag = rest.slice(1, openEnd);
+    const tagName = openTag.split(/[\s/>]/)[0];
+    if (!tagName || !/^[A-Za-z_][\w.-]*$/.test(tagName)) {
+      return rest;
+    }
+
+    const closingTag = `</${tagName}>`;
+    const closingIndex = rest.indexOf(closingTag, openEnd);
+    const next = closingIndex === -1
+      ? rest.slice(openEnd + 1)
+      : rest.slice(closingIndex + closingTag.length);
+
+    const trimmedNext = next.trim();
+    if (!trimmedNext) {
+      return '';
+    }
+
+    rest = trimmedNext;
+  }
+}
+
+/**
+ * Returns the first sentence long enough to describe the request. Sentence ends are
+ * detected on line breaks and on terminal punctuation that is not part of a number
+ * such as `0.4` or `1.4.5`.
+ */
+function selectFirstMeaningfulSentence(text: string): string {
+  for (const boundary of collectSentenceBoundaries(text)) {
+    const candidate = text.slice(0, boundary).replace(TRAILING_NOISE, '');
+    if (candidate.length >= MIN_SIGNAL_LENGTH) {
+      return candidate;
+    }
+  }
+
+  return text.replace(TRAILING_NOISE, '');
+}
+
+function collectSentenceBoundaries(text: string): number[] {
+  const boundaries: number[] = [];
+
+  for (let index = 0; index < text.length; index += 1) {
+    const char = text[index];
+    if (char === '\n') {
+      boundaries.push(index);
+      continue;
+    }
+
+    if (char !== '.' && char !== '!' && char !== '?') {
+      continue;
+    }
+
+    const previous = text[index - 1];
+    const next = text[index + 1];
+    const insideNumber = isDigit(previous) && isDigit(next);
+    if (insideNumber) {
+      continue;
+    }
+
+    if (next === undefined || /\s/.test(next)) {
+      boundaries.push(index);
+    }
+  }
+
+  return boundaries;
+}
+
+function isDigit(char: string | undefined): boolean {
+  return char !== undefined && char >= '0' && char <= '9';
+}
+
+function truncateOnWordBoundary(text: string, maxLength: number): string {
+  if (text.length <= maxLength) {
+    return text;
+  }
+
+  const budget = Math.max(1, maxLength - ELLIPSIS.length);
+  const hardCut = text.slice(0, budget).replace(/\s+$/, '');
+  const lastSpace = hardCut.lastIndexOf(' ');
+  const wordCut = lastSpace > 0
+    ? hardCut.slice(0, lastSpace).replace(TRAILING_NOISE, '')
+    : '';
+
+  if (wordCut.length >= maxLength * MIN_WORD_CUT_RATIO) {
+    return `${wordCut}${ELLIPSIS}`;
+  }
+
+  return `${hardCut}${ELLIPSIS}`;
+}
+
+function disambiguate(
+  title: string,
+  existingTitles: Iterable<string> | undefined,
+  maxLength: number,
+): string {
+  if (!title || !existingTitles) {
+    return title;
+  }
+
+  const taken = new Set<string>();
+  for (const existing of existingTitles) {
+    if (typeof existing === 'string') {
+      taken.add(existing.trim());
+    }
+  }
+
+  if (!taken.has(title)) {
+    return title;
+  }
+
+  for (let counter = 2; counter < 1000; counter += 1) {
+    const suffix = ` (${counter})`;
+    const base = title.length + suffix.length <= maxLength
+      ? title
+      : title.slice(0, Math.max(1, maxLength - suffix.length)).replace(/\s+$/, '');
+    const candidate = `${base}${suffix}`;
+    if (!taken.has(candidate)) {
+      return candidate;
+    }
+  }
+
+  return title;
+}

--- a/src/features/chat/controllers/ConversationController.ts
+++ b/src/features/chat/controllers/ConversationController.ts
@@ -1,5 +1,6 @@
 import { Menu, Notice, setIcon, setTooltip } from 'obsidian';
 
+import { buildFallbackTitle } from '../../../core/prompt/fallbackTitle';
 import { ProviderRegistry } from '../../../core/providers/ProviderRegistry';
 import type { ProviderId, TitleGenerationService } from '../../../core/providers/types';
 import type { ChatRuntime } from '../../../core/runtime/ChatRuntime';
@@ -1201,10 +1202,26 @@ export class ConversationController {
 
   /** Generates a fallback title from the first message (used when AI fails). */
   generateFallbackTitle(firstMessage: string): string {
-    const firstSentence = firstMessage.split(/[.!?\n]/)[0].trim();
-    const autoTitle = firstSentence.substring(0, 50);
-    const suffix = firstSentence.length > 50 ? '...' : '';
-    return `${autoTitle}${suffix}`;
+    const existingTitles = this.collectExistingTitles();
+    const title = buildFallbackTitle(firstMessage, { existingTitles });
+    if (title) {
+      return title;
+    }
+
+    // Nothing but host context blocks: keep a stable, localised label rather than
+    // leaving the conversation nameless in the history list.
+    return buildFallbackTitle(t('chat.ui.view.conversation'), { existingTitles });
+  }
+
+  /** Titles already in use, so a new conversation does not duplicate one of them. */
+  private collectExistingTitles(): string[] {
+    try {
+      return this.deps.plugin.getConversationList()
+        .map((conversation) => conversation.title)
+        .filter((title): title is string => typeof title === 'string');
+    } catch {
+      return [];
+    }
   }
 
   /** Regenerates AI title for a conversation. */

--- a/src/features/chat/controllers/ConversationController.ts
+++ b/src/features/chat/controllers/ConversationController.ts
@@ -1216,8 +1216,7 @@ export class ConversationController {
   /** Titles already in use, so a new conversation does not duplicate one of them. */
   private collectExistingTitles(): string[] {
     try {
-      return this.deps.plugin.getConversationList()
-        .map((conversation) => conversation.title)
+      return this.deps.plugin.getConversationTitles()
         .filter((title): title is string => typeof title === 'string');
     } catch {
       return [];

--- a/src/main.ts
+++ b/src/main.ts
@@ -997,6 +997,14 @@ export default class GrimoirePlugin extends Plugin {
     }));
   }
 
+  /**
+   * Titles only. Callers that just need uniqueness would otherwise pay for the
+   * preview, model label and source count of every conversation.
+   */
+  getConversationTitles(): string[] {
+    return this.conversations.map(c => c.title);
+  }
+
   async persistTabManagerState(state: AppTabManagerState): Promise<void> {
     this.lastKnownTabManagerState = state;
     await this.storage.setTabManagerState(state);

--- a/tests/integration/main.test.ts
+++ b/tests/integration/main.test.ts
@@ -1053,6 +1053,18 @@ describe('GrimoirePlugin', () => {
     });
   });
 
+  describe('getConversationTitles', () => {
+    it('should return the title of every conversation', async () => {
+      await plugin.onload();
+
+      const conv = await plugin.createConversation();
+      await plugin.renameConversation(conv.id, 'Release checklist');
+
+      expect(plugin.getConversationTitles()).toContain('Release checklist');
+      expect(plugin.getConversationTitles()).toHaveLength(plugin.getConversationList().length);
+    });
+  });
+
   describe('loadSettings with conversations', () => {
     it('should load saved conversations from metadata files', async () => {
       const timestamp = Date.now();

--- a/tests/unit/core/prompt/fallbackTitle.test.ts
+++ b/tests/unit/core/prompt/fallbackTitle.test.ts
@@ -1,0 +1,94 @@
+import { buildFallbackTitle } from '@/core/prompt/fallbackTitle';
+
+describe('buildFallbackTitle', () => {
+  it('keeps a short single-line message unchanged', () => {
+    expect(buildFallbackTitle('Reply only OK')).toBe('Reply only OK');
+  });
+
+  it('returns an empty string for a message without usable text', () => {
+    expect(buildFallbackTitle('   \n\n  ')).toBe('');
+  });
+
+  it('truncates on a word boundary instead of mid-word', () => {
+    const message = 'do you know how to run commands such as search inside our shared notes workspace';
+
+    const title = buildFallbackTitle(message);
+
+    expect(title.endsWith('...')).toBe(true);
+    expect(title.length).toBeLessThanOrEqual(50);
+    expect(title).toBe('do you know how to run commands such as...');
+  });
+
+  it('does not end a sentence on a decimal number or version', () => {
+    const message = 'update the firmware from 1.4.5 to 1.5.0';
+
+    expect(buildFallbackTitle(message)).toBe('update the firmware from 1.4.5 to 1.5.0');
+  });
+
+  it('still ends the title at a real sentence boundary', () => {
+    const message = 'Update the changelog. Then double-check the release notes.';
+
+    expect(buildFallbackTitle(message)).toBe('Update the changelog');
+  });
+
+  it('skips leading XML context blocks and uses the first real text', () => {
+    const message = [
+      '<git_status>',
+      'This is the git status at the start of the conversation.',
+      '</git_status>',
+      '',
+      'review the work that was done on reducing the running costs',
+    ].join('\n');
+
+    expect(buildFallbackTitle(message)).toBe('review the work that was done on reducing the...');
+  });
+
+  it('skips a leading self-closing image tag', () => {
+    const message = '<image name=[Image #1] path="C:\\TEMP\\shot.png" />\nTell me what this warning means';
+
+    expect(buildFallbackTitle(message)).toBe('Tell me what this warning means');
+  });
+
+  it('gathers more text when the first sentence carries almost no signal', () => {
+    const message = 'Hi. Need to pick a colour scheme for the dashboard';
+
+    expect(buildFallbackTitle(message)).toBe('Hi. Need to pick a colour scheme for the dashboard');
+  });
+
+  it('falls back to a hard cut when a word boundary would discard most of the title', () => {
+    const message = 'Read docs/exports/2026-08-26-handoff-summary-and-continue';
+
+    expect(buildFallbackTitle(message)).toBe('Read docs/exports/2026-08-26-handoff-summary-an...');
+  });
+
+  it('disambiguates a title that already exists', () => {
+    const existingTitles = ['check the build log'];
+
+    const title = buildFallbackTitle('check the build log', { existingTitles });
+
+    expect(title).toBe('check the build log (2)');
+  });
+
+  it('keeps counting up when several duplicates already exist', () => {
+    const existingTitles = ['ping', 'ping (2)', 'ping (3)'];
+
+    expect(buildFallbackTitle('ping', { existingTitles })).toBe('ping (4)');
+  });
+
+  it('keeps the disambiguated title within the length limit', () => {
+    const message = 'Read docs/exports/2026-08-26-handoff-summary-and-continue';
+    const first = buildFallbackTitle(message);
+
+    const second = buildFallbackTitle(message, { existingTitles: [first] });
+
+    expect(second.length).toBeLessThanOrEqual(50);
+    expect(second.endsWith('(2)')).toBe(true);
+  });
+
+  it('honours a custom maximum length', () => {
+    const title = buildFallbackTitle('pick a colour scheme for the dashboard', { maxLength: 20 });
+
+    expect(title.length).toBeLessThanOrEqual(20);
+    expect(title).toBe('pick a colour...');
+  });
+});

--- a/tests/unit/core/prompt/fallbackTitle.test.ts
+++ b/tests/unit/core/prompt/fallbackTitle.test.ts
@@ -1,4 +1,5 @@
 import { buildFallbackTitle } from '@/core/prompt/fallbackTitle';
+import { appendContextFiles, appendCurrentNote } from '@/utils/context';
 
 describe('buildFallbackTitle', () => {
   it('keeps a short single-line message unchanged', () => {
@@ -66,13 +67,13 @@ describe('buildFallbackTitle', () => {
 
     const title = buildFallbackTitle('check the build log', { existingTitles });
 
-    expect(title).toBe('check the build log (2)');
+    expect(title).toBe('check the build log 2');
   });
 
   it('keeps counting up when several duplicates already exist', () => {
-    const existingTitles = ['ping', 'ping (2)', 'ping (3)'];
+    const existingTitles = ['ping', 'ping 2', 'ping 3'];
 
-    expect(buildFallbackTitle('ping', { existingTitles })).toBe('ping (4)');
+    expect(buildFallbackTitle('ping', { existingTitles })).toBe('ping 4');
   });
 
   it('keeps the disambiguated title within the length limit', () => {
@@ -82,7 +83,7 @@ describe('buildFallbackTitle', () => {
     const second = buildFallbackTitle(message, { existingTitles: [first] });
 
     expect(second.length).toBeLessThanOrEqual(50);
-    expect(second.endsWith('(2)')).toBe(true);
+    expect(second.endsWith(' 2')).toBe(true);
   });
 
   it('honours a custom maximum length', () => {
@@ -90,5 +91,93 @@ describe('buildFallbackTitle', () => {
 
     expect(title.length).toBeLessThanOrEqual(20);
     expect(title).toBe('pick a colour...');
+  });
+
+  it('honours a maximum length too small to hold an ellipsis', () => {
+    expect(buildFallbackTitle('hello world', { maxLength: 3 })).toBe('hel');
+  });
+
+  describe('context Grimoire appends to the prompt', () => {
+    it('drops the current note appended after a short message', () => {
+      const message = appendCurrentNote('fix it', 'Notes/Daily/2026-09-04.md');
+
+      expect(buildFallbackTitle(message)).toBe('fix it');
+    });
+
+    it('drops the context files appended after a short message', () => {
+      const message = appendContextFiles('what', ['a.md', 'b.md']);
+
+      expect(buildFallbackTitle(message)).toBe('what');
+    });
+  });
+
+  describe('single-line titles', () => {
+    it('folds a message whose first line is too short to stand alone', () => {
+      const message = '# Task\nRefactor the parser';
+
+      expect(buildFallbackTitle(message)).toBe('# Task Refactor the parser');
+    });
+
+    it('folds a tab that follows the first sentence', () => {
+      const message = 'Fix this.\tThen do that thing over there properly';
+
+      expect(buildFallbackTitle(message)).toBe('Fix this. Then do that thing over there properly');
+    });
+
+    it('never returns a title containing a control character', () => {
+      const message = 'a\n\nb\tc\r\nd and then a much longer request follows here';
+
+      expect(buildFallbackTitle(message)).not.toMatch(/[\n\r\t]/);
+    });
+  });
+
+  describe('markup the user typed', () => {
+    it('keeps a message that is nothing but markup', () => {
+      const message = '<button onclick="go()">Click me here please</button>';
+
+      expect(buildFallbackTitle(message)).toBe('<button onclick="go()">Click me here...');
+    });
+
+    it('skips only the outermost block when the same tag nests', () => {
+      const message = '<a><a>x</a></a> real question about the layout';
+
+      expect(buildFallbackTitle(message)).toBe('real question about the layout');
+    });
+
+    it('ignores an angle bracket inside an attribute value', () => {
+      const message = '<image name="a>b.png" />\nWhat is in this picture';
+
+      expect(buildFallbackTitle(message)).toBe('What is in this picture');
+    });
+  });
+
+  describe('bounded work', () => {
+    it('does not backtrack over a long run of punctuation', () => {
+      const message = `a${`${'.'.repeat(20000)}b`.repeat(20)}`;
+
+      const started = Date.now();
+      const title = buildFallbackTitle(message);
+
+      expect(Date.now() - started).toBeLessThan(1000);
+      expect(title.length).toBeLessThanOrEqual(50);
+    });
+
+    it('titles a pasted file from its opening line', () => {
+      const message = `Please review this file and tell me what is wrong\n${'lorem ipsum dolor sit amet '.repeat(40000)}`;
+
+      const started = Date.now();
+
+      expect(buildFallbackTitle(message)).toBe('Please review this file and tell me what is wrong');
+      expect(Date.now() - started).toBeLessThan(1000);
+    });
+  });
+
+  describe('astral characters', () => {
+    it('never cuts a surrogate pair in half', () => {
+      const title = buildFallbackTitle('🎉'.repeat(60));
+
+      expect(title.length).toBeLessThanOrEqual(50);
+      expect(title).not.toMatch(/[\uD800-\uDBFF]$|[\uD800-\uDBFF](?![\uDC00-\uDFFF])/);
+    });
   });
 });

--- a/tests/unit/features/chat/controllers/ConversationController.test.ts
+++ b/tests/unit/features/chat/controllers/ConversationController.test.ts
@@ -50,6 +50,7 @@ function createMockDeps(overrides: Partial<ConversationControllerDeps> = {}): Co
       getConversationById: jest.fn().mockResolvedValue(null),
       getConversationSync: jest.fn().mockReturnValue(null),
       getConversationList: jest.fn().mockReturnValue([]),
+      getConversationTitles: jest.fn().mockReturnValue([]),
       findEmptyConversation: jest.fn().mockResolvedValue(null),
       updateConversation: jest.fn().mockResolvedValue(undefined),
       renameConversation: jest.fn().mockResolvedValue(undefined),
@@ -385,11 +386,9 @@ describe('ConversationController', () => {
     });
 
     it('disambiguates against titles already present in the history', () => {
-      (deps.plugin.getConversationList as jest.Mock).mockReturnValue([
-        { id: 'a', title: 'check the build log', updatedAt: Date.now() },
-      ]);
+      (deps.plugin.getConversationTitles as jest.Mock).mockReturnValue(['check the build log']);
 
-      expect(controller.generateFallbackTitle('check the build log')).toBe('check the build log (2)');
+      expect(controller.generateFallbackTitle('check the build log')).toBe('check the build log 2');
     });
 
     it('uses the generic conversation label when the message is only context', () => {
@@ -399,16 +398,14 @@ describe('ConversationController', () => {
     });
 
     it('disambiguates the generic label as well', () => {
-      (deps.plugin.getConversationList as jest.Mock).mockReturnValue([
-        { id: 'a', title: t('chat.ui.view.conversation'), updatedAt: Date.now() },
-      ]);
+      (deps.plugin.getConversationTitles as jest.Mock).mockReturnValue([t('chat.ui.view.conversation')]);
 
       expect(controller.generateFallbackTitle('<git_status>\nx\n</git_status>'))
-        .toBe(`${t('chat.ui.view.conversation')} (2)`);
+        .toBe(`${t('chat.ui.view.conversation')} 2`);
     });
 
     it('keeps working when the history is unavailable', () => {
-      (deps.plugin.getConversationList as jest.Mock).mockImplementation(() => {
+      (deps.plugin.getConversationTitles as jest.Mock).mockImplementation(() => {
         throw new Error('storage offline');
       });
 

--- a/tests/unit/features/chat/controllers/ConversationController.test.ts
+++ b/tests/unit/features/chat/controllers/ConversationController.test.ts
@@ -5,6 +5,7 @@ import { Menu, Notice } from 'obsidian';
 
 import { ConversationController, type ConversationControllerDeps } from '@/features/chat/controllers/ConversationController';
 import { ChatState } from '@/features/chat/state/ChatState';
+import { t } from '@/i18n/i18n';
 import { confirm } from '@/shared/modals/ConfirmModal';
 
 jest.mock('@/shared/modals/ConfirmModal', () => ({
@@ -367,6 +368,51 @@ describe('ConversationController', () => {
       // Second call should not add another greeting
       controller.initializeWelcome();
       expect(createDivSpy).toHaveBeenCalledTimes(1); // Still 1, not 2
+    });
+  });
+
+  describe('generateFallbackTitle', () => {
+    it('skips leading context blocks injected by the host', () => {
+      const message = '<git_status>\nclean\n</git_status>\n\nupdate the changelog entry';
+
+      expect(controller.generateFallbackTitle(message)).toBe('update the changelog entry');
+    });
+
+    it('cuts on a word boundary rather than mid-word', () => {
+      const message = 'do you know how to run commands such as search inside our shared notes workspace';
+
+      expect(controller.generateFallbackTitle(message)).toBe('do you know how to run commands such as...');
+    });
+
+    it('disambiguates against titles already present in the history', () => {
+      (deps.plugin.getConversationList as jest.Mock).mockReturnValue([
+        { id: 'a', title: 'check the build log', updatedAt: Date.now() },
+      ]);
+
+      expect(controller.generateFallbackTitle('check the build log')).toBe('check the build log (2)');
+    });
+
+    it('uses the generic conversation label when the message is only context', () => {
+      const message = '<git_status>\nThis is the git status at the start of the conversation.\n</git_status>';
+
+      expect(controller.generateFallbackTitle(message)).toBe(t('chat.ui.view.conversation'));
+    });
+
+    it('disambiguates the generic label as well', () => {
+      (deps.plugin.getConversationList as jest.Mock).mockReturnValue([
+        { id: 'a', title: t('chat.ui.view.conversation'), updatedAt: Date.now() },
+      ]);
+
+      expect(controller.generateFallbackTitle('<git_status>\nx\n</git_status>'))
+        .toBe(`${t('chat.ui.view.conversation')} (2)`);
+    });
+
+    it('keeps working when the history is unavailable', () => {
+      (deps.plugin.getConversationList as jest.Mock).mockImplementation(() => {
+        throw new Error('storage offline');
+      });
+
+      expect(controller.generateFallbackTitle('check the build log')).toBe('check the build log');
     });
   });
 


### PR DESCRIPTION
## Problem

Every conversation gets its title from `ConversationController.generateFallbackTitle()`
before any model is asked. When title generation is disabled, unavailable, or
returns an error, that fallback is also the *final* title — for the whole life of
the conversation.

The implementation was five lines:

```ts
generateFallbackTitle(firstMessage: string): string {
  const firstSentence = firstMessage.split(/[.!?\n]/)[0].trim();
  const autoTitle = firstSentence.substring(0, 50);
  const suffix = firstSentence.length > 50 ? '...' : '';
  return `${autoTitle}${suffix}`;
}
```

I measured it over 135 real conversations from my own history (first user message
of each, `displayContent` when present):

| Metric | Result |
|---|---|
| Unique titles | 97 of 135 — 38 duplicates |
| Most repeated single title | 7 conversations |
| Titles longer than the 50 character budget | 77 |
| Titles that are a host context block (`<git_status>`, `<image …>`) | 4 |
| Sentences broken inside a number or version | 7 |

Concrete failures from that data (my corpus is Russian; the examples below are
translated, the counts are from the real messages):

- `"what happens if the device is updated from 1"` — the sentence split fired on
  the `.` of version `1.4.5`. Any decimal loses the rest of the title.
- `"according to AGENTS"` — same cause, this time on a filename.
- `"<git_status>"` as a conversation title, three times over.
- Seven conversations named `"Read docs/exports/2026-08-26-handoff-summ..."`,
  indistinguishable in the history dropdown.
- `substring(0, 50)` plus `'...'` returns up to 53 characters, so the 50 character
  budget was never actually enforced.

## Change

The logic moves into a pure, dependency-free `src/core/prompt/fallbackTitle.ts`:

- **Context blocks are dropped.** Leading XML-ish blocks the host prepends
  (`<git_status>…</git_status>`, self-closing `<image … />`) are skipped so the
  title comes from what the user typed.
- **Sentence ends respect numbers.** A line break always ends a sentence; `.`, `!`
  and `?` only do when followed by whitespace or end of input, and never between
  two digits. `1.4.5` and `0.4` survive; `AGENTS.md` survives too, because the
  character after the dot is not whitespace.
- **A first sentence too short to carry signal is extended** to the next boundary,
  so `"Hi."` no longer becomes the title.
- **Truncation happens on a word boundary**, unless that would discard most of the
  budget — a message opening with one long token (a path, a URL) then gets a hard
  cut instead of collapsing to a single word.
- **Titles are disambiguated** against those already in the history with a `(2)`,
  `(3)` … suffix that stays inside the length budget.
- **The budget is honoured exactly**, ellipsis included.

The controller keeps one behaviour of its own: a message consisting of nothing but
context blocks would otherwise produce an empty name, so it falls back to the
existing localised `chat.ui.view.conversation` label — an existing key, not a new
one — and runs it through the same disambiguation. No new settings, no new i18n
keys, no new public API: `buildFallbackTitle` is called by the controller and
nowhere else.

## Result on the same 135 conversations

| Metric | Before | After |
|---|---|---|
| Unique titles | 97 | 135 |
| Context blocks leaked into titles | 4 | 0 |
| Titles over the 50 character budget | 77 | 0 |
| Empty titles | 0 | 0 |

Examples (translated from the corpus):

```
"what happens if the device is updated from 1" -> "what happens if the device is updated from 1.4.5..."
"according to AGENTS"                          -> "according to AGENTS.md and the routing rules"
"let us continue preparing the draft note..."  -> "let us continue preparing the..."
```

## Tests

`tests/unit/core/prompt/fallbackTitle.test.ts` (13 cases) covers word-boundary and
hard-cut truncation, decimals and versions, sentence boundaries, the short-first-
sentence extension, context-block stripping, disambiguation including the length
budget, and a custom `maxLength`.

`tests/unit/features/chat/controllers/ConversationController.test.ts` gains 6 cases
for the wiring: delegation, history-based disambiguation, the localised label for
context-only messages, and graceful behaviour when the conversation list throws.

All 169 tests in the two suites pass; `eslint --max-warnings=0` and `tsc --noEmit`
are clean. The 23 suites that fail in a full `npm test` on this machine fail
identically on a clean `main` checkout (Windows path and env expectations) and are
unrelated to this change.
