### PR TITLE
fix(chat): keep image attachments viewable, and let Escape close the viewer

### DIFF
--- a/src/core/bootstrap/imageAttachmentLifetime.ts
+++ b/src/core/bootstrap/imageAttachmentLifetime.ts
@@ -1,0 +1,50 @@
+/**
+ * In-memory lifetime of `ImageAttachment.data`.
+ *
+ * Attachment bytes are the largest thing a conversation holds - a single
+ * screenshot is megabytes of base64, and every open conversation keeps its
+ * messages in memory - so they are released once the conversation is saved.
+ *
+ * That is only safe when the provider can put them back. A provider whose
+ * transcript stores the image itself rehydrates the bytes in
+ * `hydrateConversationHistory`; a provider that never sees an image as data
+ * cannot. Antigravity is the second kind: attachments reach `agy` as temp
+ * files that the turn deletes, so this object is the only copy, and clearing
+ * it loses the image for the rest of the session - the full-size viewer shows
+ * an empty frame, and a restored draft would resend empty files.
+ *
+ * The release is therefore opt-in per provider, and the default is to keep the
+ * bytes: a provider that forgets to declare the capability wastes memory,
+ * while one that wrongly claims it loses user data.
+ */
+
+import type { ProviderConversationHistoryService } from '../providers/types';
+import type { Conversation } from '../types';
+
+/**
+ * Clears attachment bytes the provider is able to restore, and leaves every
+ * other attachment intact.
+ */
+export function releaseRestorableImageData(
+  conversation: Conversation,
+  historyService: ProviderConversationHistoryService,
+): void {
+  if (historyService.restoresImageAttachmentData !== true) {
+    return;
+  }
+
+  // A pending fork's deep-cloned images have not reached provider storage yet,
+  // so nothing would restore them.
+  if (historyService.isPendingForkConversation(conversation)) {
+    return;
+  }
+
+  for (const message of conversation.messages) {
+    if (!message.images) {
+      continue;
+    }
+    for (const image of message.images) {
+      image.data = '';
+    }
+  }
+}

--- a/src/core/providers/types.ts
+++ b/src/core/providers/types.ts
@@ -502,6 +502,13 @@ export interface ProviderConversationHistoryService {
   ): Promise<void>;
   resolveSessionIdForConversation(conversation: Conversation | null): string | null;
   isPendingForkConversation(conversation: Conversation): boolean;
+  /**
+   * True when `hydrateConversationHistory` restores `ImageAttachment.data`
+   * from the provider's own transcript, which lets the app release those bytes
+   * from memory after a save. Absent means the bytes are kept: a provider that
+   * receives attachments as anything but data cannot put them back.
+   */
+  restoresImageAttachmentData?: boolean;
   /** Builds opaque provider state for a forked conversation. */
   buildForkProviderState(
     sourceSessionId: string,

--- a/src/features/chat/GrimoireView.ts
+++ b/src/features/chat/GrimoireView.ts
@@ -27,6 +27,7 @@ import { TabBar } from './tabs/TabBar';
 import { TabManager } from './tabs/TabManager';
 import type { ClosedTabSnapshot, TabData, TabId } from './tabs/types';
 import { normalizeMaxTabs } from './tabs/types';
+import { closeTopmostImageViewer } from './ui/imageViewerStack';
 import { ContextUsageMeter, getNextPermissionMode } from './ui/InputToolbar';
 import { requestTabRename } from './ui/RenameTabModal';
 import { buildAssistantResponseMetadata } from './utils/assistantResponseMetadata';
@@ -927,6 +928,11 @@ export class GrimoireView extends ItemView {
     this.scope = new Scope(this.app.scope);
     this.scope.register([], 'Escape', (e: KeyboardEvent) => {
       if (e.isComposing) return;
+      // A full-size image spoken for this Escape: closing it must not also
+      // cost the user the turn that is streaming behind it.
+      if (closeTopmostImageViewer()) {
+        return false;
+      }
       if (!e.defaultPrevented) {
         const activeTab = this.tabManager?.getActiveTab();
         if (activeTab?.state.isStreaming) {

--- a/src/features/chat/rendering/MessageRenderer.ts
+++ b/src/features/chat/rendering/MessageRenderer.ts
@@ -22,6 +22,7 @@ import {
   normalizeLatexDelimiters,
 } from '../../../utils/markdownMath';
 import { findRewindContext } from '../rewind';
+import { registerOpenImageViewer } from '../ui/imageViewerStack';
 import { renderVaultSearchSources } from '../ui/VaultSearchSources';
 import { getAssistantResponseProviderLabel } from '../utils/assistantResponseMetadata';
 import { localizeReasoningLevel } from '../utils/reasoningDisplay';
@@ -945,14 +946,23 @@ export class MessageRenderer {
     const closeBtn = modal.createDiv({ cls: 'grimoire-image-modal-close' });
     closeBtn.setText('\u00D7');
 
+    // See the same handler in ImageContext: closing the viewer must not cost
+    // the user the streaming turn, which the viewer stack guarantees no
+    // matter which Escape listener the browser reaches first.
     const handleEsc = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') {
-        close();
+      if (e.key !== 'Escape') {
+        return;
       }
+      e.preventDefault();
+      e.stopPropagation();
+      close();
     };
 
+    const unregisterViewer = registerOpenImageViewer(() => close());
+
     const close = () => {
-      ownerDocument.removeEventListener('keydown', handleEsc);
+      unregisterViewer();
+      ownerDocument.removeEventListener('keydown', handleEsc, true);
       overlay.remove();
     };
 
@@ -960,7 +970,7 @@ export class MessageRenderer {
     overlay.addEventListener('click', (e) => {
       if (e.target === overlay) close();
     });
-    ownerDocument.addEventListener('keydown', handleEsc);
+    ownerDocument.addEventListener('keydown', handleEsc, true);
   }
 
   /**

--- a/src/features/chat/tabs/Tab.ts
+++ b/src/features/chat/tabs/Tab.ts
@@ -50,6 +50,7 @@ import { SubagentManager } from '../services/SubagentManager';
 import { ChatState } from '../state/ChatState';
 import { BangBashModeManager as BangBashModeManagerClass } from '../ui/BangBashModeManager';
 import { RuntimeContextActivityView } from '../ui/context/RuntimeContextActivity';
+import { closeTopmostImageViewer } from '../ui/imageViewerStack';
 import { createInputToolbar } from '../ui/InputToolbar';
 import { InstructionModeManager as InstructionModeManagerClass } from '../ui/InstructionModeManager';
 import { NavigationSidebar } from '../ui/NavigationSidebar';
@@ -1545,10 +1546,17 @@ export function wireTabInputEvents(tab: TabData, plugin: GrimoirePlugin): void {
     }
 
     // Check !e.isComposing for IME support (Chinese, Japanese, Korean, etc.)
-    if (e.key === 'Escape' && !e.isComposing && state.isStreaming) {
-      e.preventDefault();
-      controllers.inputController?.cancelStreaming();
-      return;
+    if (e.key === 'Escape' && !e.isComposing) {
+      // An open image viewer owns Escape until it is closed.
+      if (closeTopmostImageViewer()) {
+        e.preventDefault();
+        return;
+      }
+      if (state.isStreaming) {
+        e.preventDefault();
+        controllers.inputController?.cancelStreaming();
+        return;
+      }
     }
 
     if (shouldSendMessageFromEnterKey(e, plugin.settings)) {

--- a/src/features/chat/ui/ImageContext.ts
+++ b/src/features/chat/ui/ImageContext.ts
@@ -3,6 +3,7 @@ import * as path from 'path';
 
 import type { ImageAttachment, ImageMediaType } from '../../../core/types';
 import { t } from '../../../i18n/i18n';
+import { registerOpenImageViewer } from './imageViewerStack';
 
 const MAX_IMAGE_SIZE = 5 * 1024 * 1024;
 
@@ -360,14 +361,24 @@ export class ImageContextManager {
     });
     closeBtn.setText('\u00D7');
 
+    // Escape closes the viewer and must not also cancel the streaming turn.
+    // This listener is only one of the two ways that happens: the chat's own
+    // Escape handlers consult the viewer stack before cancelling, so the turn
+    // survives whichever listener the browser reaches first.
     const handleEsc = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') {
-        close();
+      if (e.key !== 'Escape') {
+        return;
       }
+      e.preventDefault();
+      e.stopPropagation();
+      close();
     };
 
+    const unregisterViewer = registerOpenImageViewer(() => close());
+
     const close = () => {
-      ownerDocument.removeEventListener('keydown', handleEsc);
+      unregisterViewer();
+      ownerDocument.removeEventListener('keydown', handleEsc, true);
       overlay.remove();
       if (this.fullImageClose === close) {
         this.fullImageClose = null;
@@ -379,7 +390,7 @@ export class ImageContextManager {
     overlay.addEventListener('click', (e) => {
       if (e.target === overlay) close();
     });
-    ownerDocument.addEventListener('keydown', handleEsc);
+    ownerDocument.addEventListener('keydown', handleEsc, true);
   }
 
   private generateId(): string {

--- a/src/features/chat/ui/imageViewerStack.ts
+++ b/src/features/chat/ui/imageViewerStack.ts
@@ -1,0 +1,65 @@
+/**
+ * Who owns Escape while a full-size image is open.
+ *
+ * Escape has two meanings in the chat view: close the image viewer, and
+ * cancel the streaming turn. The viewer's meaning must win while it is open,
+ * and the first attempt to arrange that - a capture-phase document listener
+ * that called `preventDefault` - did not, because it still depended on
+ * running before Obsidian's own document listener, which is registered when
+ * the app boots and which this plugin does not control.
+ *
+ * Racing that listener is the wrong shape of solution: whoever wins is a
+ * property of registration order rather than of what the key means. So the
+ * cancel paths ask this module instead. An open viewer is registered here,
+ * and every Escape handler that would cancel a turn closes the topmost viewer
+ * first and stops. The outcome no longer depends on which listener runs
+ * first: if the viewer's own listener wins it closes and consumes the key,
+ * and if the cancel path wins it closes the viewer and declines to cancel.
+ *
+ * The stack, rather than a single slot, keeps nesting honest - Escape closes
+ * one viewer at a time, in reverse order of opening.
+ */
+
+type CloseViewer = () => void;
+
+const openViewers: CloseViewer[] = [];
+
+/**
+ * Registers an open viewer and returns the function that unregisters it.
+ * The returned function is safe to call more than once.
+ */
+export function registerOpenImageViewer(close: CloseViewer): () => void {
+  openViewers.push(close);
+  return () => {
+    const index = openViewers.lastIndexOf(close);
+    if (index !== -1) {
+      openViewers.splice(index, 1);
+    }
+  };
+}
+
+/** True when at least one full-size viewer is open. */
+export function hasOpenImageViewer(): boolean {
+  return openViewers.length > 0;
+}
+
+/**
+ * Closes the most recently opened viewer.
+ *
+ * Returns true when a viewer was closed, which the caller reads as "Escape is
+ * spoken for - do not also cancel the turn".
+ */
+export function closeTopmostImageViewer(): boolean {
+  const close = openViewers[openViewers.length - 1];
+  if (!close) {
+    return false;
+  }
+  // `close` unregisters itself; popping here too would drop a second viewer.
+  close();
+  return true;
+}
+
+/** Test seam: drops any viewer left registered by a previous case. */
+export function resetOpenImageViewers(): void {
+  openViewers.length = 0;
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,6 +13,7 @@ import { readBundledChangelog } from './app/changelog/source';
 import type { ChangelogRelease } from './app/changelog/types';
 import { DEFAULT_GRIMOIRE_SETTINGS } from './app/settings/defaultSettings';
 import { SharedStorageService } from './app/storage/SharedStorageService';
+import { releaseRestorableImageData } from './core/bootstrap/imageAttachmentLifetime';
 import {
   applyAssistantResponseMetadataToMessages,
   applyVaultSearchContextsToMessages,
@@ -949,17 +950,10 @@ export default class GrimoirePlugin extends Plugin {
       this.storage.sessions.toSessionMetadata(conversation)
     );
 
-    // Clear image data from memory after save (data is persisted by SDK).
-    // Skip for pending forks: their deep-cloned images aren't in SDK storage yet.
-    if (!ProviderRegistry.getConversationHistoryService(conversation.providerId).isPendingForkConversation(conversation)) {
-      for (const msg of conversation.messages) {
-        if (msg.images) {
-          for (const img of msg.images) {
-            img.data = '';
-          }
-        }
-      }
-    }
+    releaseRestorableImageData(
+      conversation,
+      ProviderRegistry.getConversationHistoryService(conversation.providerId),
+    );
   }
 
   async getConversationById(id: string): Promise<Conversation | null> {

--- a/src/providers/claude/history/ClaudeConversationHistoryService.ts
+++ b/src/providers/claude/history/ClaudeConversationHistoryService.ts
@@ -329,6 +329,13 @@ function sanitizeProviderState(
 }
 
 export class ClaudeConversationHistoryService implements ProviderConversationHistoryService {
+  /**
+   * The SDK transcript keeps user attachments as base64 `image` blocks, and
+   * `extractImages` reads them back on hydration, so the app may release the
+   * in-memory copy after a save.
+   */
+  readonly restoresImageAttachmentData = true;
+
   private hydratedConversationIds = new Set<string>();
 
   isPendingForkConversation(conversation: Conversation): boolean {

--- a/tests/helpers/mockElement.ts
+++ b/tests/helpers/mockElement.ts
@@ -82,8 +82,8 @@ export interface MockElement {
     };
     activeElement?: any;
     body?: any;
-    addEventListener?: (event: string, handler: (...args: any[]) => void) => void;
-    removeEventListener?: (event: string, handler: (...args: any[]) => void) => void;
+    addEventListener?: (event: string, handler: (...args: any[]) => void, options?: any) => void;
+    removeEventListener?: (event: string, handler: (...args: any[]) => void, options?: any) => void;
     dispatchEvent?: (eventOrType: string | { type: string; [key: string]: any }) => void;
     createElement: (tagName: string) => MockElement;
     createElementNS: (namespace: string, tagName: string) => MockElement;
@@ -218,20 +218,24 @@ export function createMockEl(tag = 'div'): any {
     get body() {
       return currentDocument()?.body ?? createMockEl('body');
     },
-    addEventListener(event: string, handler: (...args: any[]) => void) {
+    // `options` is forwarded rather than dropped: capture-phase registration
+    // is the difference between a handler that sees a key first and one that
+    // sees it after the app has acted on it, and a helper that swallows the
+    // argument makes that difference invisible to every test.
+    addEventListener(event: string, handler: (...args: any[]) => void, options?: any) {
       const document = currentDocument();
       if (document?.addEventListener) {
-        document.addEventListener(event, handler);
+        document.addEventListener(event, handler, options);
         return;
       }
       const handlers = documentEventListeners.get(event) ?? [];
       handlers.push(handler);
       documentEventListeners.set(event, handlers);
     },
-    removeEventListener(event: string, handler: (...args: any[]) => void) {
+    removeEventListener(event: string, handler: (...args: any[]) => void, options?: any) {
       const document = currentDocument();
       if (document?.removeEventListener) {
-        document.removeEventListener(event, handler);
+        document.removeEventListener(event, handler, options);
         return;
       }
       const handlers = documentEventListeners.get(event) ?? [];

--- a/tests/unit/core/bootstrap/imageAttachmentLifetime.test.ts
+++ b/tests/unit/core/bootstrap/imageAttachmentLifetime.test.ts
@@ -1,0 +1,87 @@
+import { releaseRestorableImageData } from '@/core/bootstrap/imageAttachmentLifetime';
+import type { ProviderConversationHistoryService } from '@/core/providers/types';
+import type { Conversation, ImageAttachment } from '@/core/types';
+
+function createImage(data: string): ImageAttachment {
+  return {
+    id: 'img-1',
+    name: 'screenshot.png',
+    mediaType: 'image/png',
+    data,
+    size: 12,
+    source: 'paste',
+  };
+}
+
+function createConversation(images: ImageAttachment[]): Conversation {
+  return {
+    id: 'conv-1',
+    providerId: 'antigravity',
+    messages: [
+      { role: 'user', content: 'look', images },
+    ],
+  } as unknown as Conversation;
+}
+
+function createHistoryService(
+  overrides: Partial<ProviderConversationHistoryService> = {},
+): ProviderConversationHistoryService {
+  return {
+    hydrateConversationHistory: jest.fn(),
+    deleteConversationSession: jest.fn(),
+    resolveSessionIdForConversation: jest.fn().mockReturnValue(null),
+    isPendingForkConversation: jest.fn().mockReturnValue(false),
+    buildForkProviderState: jest.fn().mockReturnValue({}),
+    ...overrides,
+  };
+}
+
+describe('releaseRestorableImageData', () => {
+  it('keeps the data when the provider cannot restore it from its own history', () => {
+    // agy receives attachments as temp files that the turn deletes, so nothing
+    // outside this object holds the bytes. Dropping them here loses them.
+    const conversation = createConversation([createImage('YmFzZTY0')]);
+
+    releaseRestorableImageData(conversation, createHistoryService());
+
+    expect(conversation.messages[0].images?.[0].data).toBe('YmFzZTY0');
+  });
+
+  it('drops the data when the provider restores it on hydration', () => {
+    const conversation = createConversation([createImage('YmFzZTY0')]);
+
+    releaseRestorableImageData(
+      conversation,
+      createHistoryService({ restoresImageAttachmentData: true }),
+    );
+
+    expect(conversation.messages[0].images?.[0].data).toBe('');
+  });
+
+  it('keeps the data of a pending fork even when the provider restores it', () => {
+    // A pending fork's deep-cloned images are not in provider storage yet.
+    const conversation = createConversation([createImage('YmFzZTY0')]);
+
+    releaseRestorableImageData(
+      conversation,
+      createHistoryService({
+        restoresImageAttachmentData: true,
+        isPendingForkConversation: jest.fn().mockReturnValue(true),
+      }),
+    );
+
+    expect(conversation.messages[0].images?.[0].data).toBe('YmFzZTY0');
+  });
+
+  it('leaves messages without attachments untouched', () => {
+    const conversation = createConversation([]);
+    conversation.messages.push({ role: 'assistant', content: 'ok' } as never);
+
+    expect(() =>
+      releaseRestorableImageData(
+        conversation,
+        createHistoryService({ restoresImageAttachmentData: true }),
+      ),
+    ).not.toThrow();
+  });
+});

--- a/tests/unit/features/chat/rendering/MessageRenderer.test.ts
+++ b/tests/unit/features/chat/rendering/MessageRenderer.test.ts
@@ -2218,11 +2218,20 @@ describe('MessageRenderer', () => {
         const keydownHandlers = docListeners.get('keydown');
         expect(keydownHandlers).toBeDefined();
         expect(keydownHandlers!.length).toBeGreaterThan(0);
-        keydownHandlers![0]({ key: 'Escape' });
+        const event = { key: 'Escape', preventDefault: jest.fn(), stopPropagation: jest.fn() };
+        keydownHandlers![0](event);
 
         expect(removeSpy).toHaveBeenCalled();
+        // Escape belongs to the overlay alone: the view scope's own handler
+        // cancels the streaming turn, so the key must not travel any further.
+        expect(event.preventDefault).toHaveBeenCalled();
+        expect(event.stopPropagation).toHaveBeenCalled();
         // After close, the keydown handler should be removed
-        expect(document.removeEventListener).toHaveBeenCalledWith('keydown', expect.any(Function));
+        expect(document.removeEventListener).toHaveBeenCalledWith(
+          'keydown',
+          expect.any(Function),
+          true,
+        );
       } finally {
         (globalThis as any).document = origDocument;
       }

--- a/tests/unit/features/chat/ui/ImageContext.test.ts
+++ b/tests/unit/features/chat/ui/ImageContext.test.ts
@@ -789,12 +789,39 @@ describe('ImageContextManager - Private Helpers', () => {
       const image = createImageAttachment();
       manager['showFullImage'](image);
 
-      expect(addEventSpy).toHaveBeenCalledWith('keydown', expect.any(Function));
+      // Capture phase: Obsidian's own document keydown listener is registered
+      // when the app boots, so a bubble-phase handler added now would run after
+      // the view scope has already acted on Escape.
+      expect(addEventSpy).toHaveBeenCalledWith('keydown', expect.any(Function), true);
 
       const escHandler = addEventSpy.mock.calls[0][1];
-      escHandler({ key: 'Escape' });
+      escHandler({ key: 'Escape', preventDefault: jest.fn(), stopPropagation: jest.fn() });
 
-      expect(removeEventSpy).toHaveBeenCalledWith('keydown', escHandler);
+      expect(removeEventSpy).toHaveBeenCalledWith('keydown', escHandler, true);
+    });
+
+    it('should consume Escape so it does not reach the chat and cancel the turn', () => {
+      const image = createImageAttachment();
+      manager['showFullImage'](image);
+
+      const escHandler = addEventSpy.mock.calls[0][1];
+      const event = { key: 'Escape', preventDefault: jest.fn(), stopPropagation: jest.fn() };
+      escHandler(event);
+
+      expect(event.preventDefault).toHaveBeenCalled();
+      expect(event.stopPropagation).toHaveBeenCalled();
+    });
+
+    it('should leave other keys alone', () => {
+      const image = createImageAttachment();
+      manager['showFullImage'](image);
+
+      const escHandler = addEventSpy.mock.calls[0][1];
+      const event = { key: 'a', preventDefault: jest.fn(), stopPropagation: jest.fn() };
+      escHandler(event);
+
+      expect(event.preventDefault).not.toHaveBeenCalled();
+      expect(removeEventSpy).not.toHaveBeenCalled();
     });
 
     it('should close modal when clicking on overlay background', () => {

--- a/tests/unit/features/chat/ui/imageViewerStack.test.ts
+++ b/tests/unit/features/chat/ui/imageViewerStack.test.ts
@@ -1,0 +1,58 @@
+import {
+  closeTopmostImageViewer,
+  hasOpenImageViewer,
+  registerOpenImageViewer,
+  resetOpenImageViewers,
+} from '@/features/chat/ui/imageViewerStack';
+
+describe('imageViewerStack', () => {
+  beforeEach(() => {
+    resetOpenImageViewers();
+  });
+
+  it('reports no open viewer on a quiet chat', () => {
+    expect(hasOpenImageViewer()).toBe(false);
+    expect(closeTopmostImageViewer()).toBe(false);
+  });
+
+  it('closes a registered viewer and says so', () => {
+    const close = jest.fn();
+    registerOpenImageViewer(close);
+
+    expect(hasOpenImageViewer()).toBe(true);
+    expect(closeTopmostImageViewer()).toBe(true);
+    expect(close).toHaveBeenCalledTimes(1);
+  });
+
+  it('closes viewers one at a time, most recent first', () => {
+    const order: string[] = [];
+    const first = jest.fn(() => { order.push('first'); });
+    const second = jest.fn(() => { order.push('second'); });
+    const unregisterFirst = registerOpenImageViewer(first);
+    const unregisterSecond = registerOpenImageViewer(second);
+
+    closeTopmostImageViewer();
+    unregisterSecond();
+    closeTopmostImageViewer();
+    unregisterFirst();
+
+    expect(order).toEqual(['second', 'first']);
+    expect(hasOpenImageViewer()).toBe(false);
+  });
+
+  it('stops reporting a viewer that closed itself', () => {
+    const unregister = registerOpenImageViewer(jest.fn());
+    unregister();
+
+    expect(hasOpenImageViewer()).toBe(false);
+    expect(closeTopmostImageViewer()).toBe(false);
+  });
+
+  it('tolerates a repeated unregister', () => {
+    const unregister = registerOpenImageViewer(jest.fn());
+    unregister();
+
+    expect(() => unregister()).not.toThrow();
+    expect(hasOpenImageViewer()).toBe(false);
+  });
+});


### PR DESCRIPTION
Two defects in image attachments, found while using them on a live vault.
They are independent; the commits are separate and either can be dropped.

## 1. The full-size viewer went blank once a turn ended

Reproduction: attach an image, click it - the full-size view opens. Send
the turn, wait for the answer, click the same image - the overlay opens
empty, with a broken-image placeholder.

`updateConversation` cleared `ImageAttachment.data` for every message on
every call, on the premise its comment states: "data is persisted by
SDK". That premise holds for exactly one provider. Claude's transcript
stores user attachments as base64 `image` blocks and `extractImages`
reads them back on hydration. No other provider does, and Antigravity
cannot: attachments reach `agy` as temp files that the turn deletes, so
the message object is the only copy of the bytes.

The timing in the reproduction follows from that. An `<img>` already in
the document keeps working because its `src` holds the data URI, but the
viewer rebuilds `src` from `image.data` on every click.

Two consequences went past the viewer:

- the clearing fired far from anything that saves messages. Any field
  update reached it, including `{ titleGenerationStatus: 'pending' }`, so
  a method whose contract is "update conversation fields" silently
  emptied message payloads;
- a draft restored through `setImages()` - the path taken when a send
  fails - would resend empty files, with nothing in the UI to say so.

`releaseRestorableImageData` now gates the release on a history-service
capability. The default is to keep the bytes: a provider that forgets to
declare `restoresImageAttachmentData` wastes memory, while one that
wrongly claims it loses user data, so absence means keep. Only
`ClaudeConversationHistoryService` declares it.

## 2. Escape closed the viewer and cancelled the streaming turn

Reproduction: send a turn, open an attached image while it streams, press
Escape. The overlay closes and the turn is interrupted.

Escape means two things in the chat view, and the viewer's handler was
registered on the document in the bubble phase without `preventDefault`,
so the view scope acted first.

Capture phase plus `preventDefault` is the obvious fix and it does not
work - measured on a live vault, not reasoned about. Which listener runs
first is a property of registration order, and Obsidian registers its own
document listener when the app boots, before any plugin can.

So the cancel paths ask rather than race. An open viewer registers itself
in `imageViewerStack`; both Escape handlers that would cancel a turn -
the view scope and the tab's input handler - close the topmost viewer
first and stop there. The outcome is the same under either ordering: the
viewer's listener closes and consumes the key, or a cancel path closes
the viewer and declines to cancel. A stack rather than a single slot
keeps nesting honest.

## Test harness

The mock element's fake `ownerDocument` dropped the third argument of
`addEventListener`. Capture-phase registration was therefore invisible to
tests and indistinguishable from bubble - the assertion that would have
caught this class of bug could not be written. It now forwards `options`.

## Verification

- `npm run typecheck`, `npm run lint`, `npm run build:release`: exit 0.
- Full `node scripts/run-jest.js` on a Windows host: 38 failing tests
  before and after this branch, the same set of suites - these are
  pre-existing POSIX-path failures on this platform, measured on a clean
  `origin/main` rather than taken on trust.
- New unit tests cover the capability gate, the pending-fork exception,
  the viewer stack, and Escape consumption in both viewers.
- Both defects were re-checked by hand on the installed build: the viewer
  now opens the image before and after the answer, and Escape closes the
  overlay without touching the turn.

## Not addressed

Antigravity shows an attached image to the agent for the turn it was
attached to and no later: `agy` has no image blocks in its stream-json,
so a follow-up turn has nothing to resend. That is a property of the
transport, not of this change.
