### PR TITLE
feat(chat): generate conversation titles in the UI locale

### DIFF
--- a/src/core/auxiliary/QueryBackedTitleGenerationService.ts
+++ b/src/core/auxiliary/QueryBackedTitleGenerationService.ts
@@ -1,7 +1,7 @@
 import {
   buildTitleGenerationPrompt,
+  buildTitleGenerationSystemPrompt,
   parseTitleGenerationResponse,
-  TITLE_GENERATION_SYSTEM_PROMPT,
 } from '../prompt/titleGeneration';
 import type {
   TitleGenerationCallback,
@@ -45,7 +45,7 @@ export class QueryBackedTitleGenerationService implements TitleGenerationService
       const text = await runner.query({
         abortController,
         model: this.options.resolveModel?.(),
-        systemPrompt: TITLE_GENERATION_SYSTEM_PROMPT,
+        systemPrompt: buildTitleGenerationSystemPrompt(),
       }, buildTitleGenerationPrompt(userMessage));
       const title = parseTitleGenerationResponse(text);
       await this.safeCallback(

--- a/src/core/prompt/titleGeneration.ts
+++ b/src/core/prompt/titleGeneration.ts
@@ -1,4 +1,4 @@
-import { SUPPORTED_LOCALES } from '../../i18n/constants';
+import { getLocaleInfo } from '../../i18n/constants';
 import { getLocale } from '../../i18n/i18n';
 import type { Locale } from '../../i18n/types';
 
@@ -22,8 +22,7 @@ export const TITLE_GENERATION_SYSTEM_PROMPT = `You are a specialist in summarizi
  * Falls back to English for unknown locales.
  */
 export function resolveTitleLanguageName(locale: Locale = getLocale()): string {
-  return SUPPORTED_LOCALES.find((entry) => entry.code === locale)?.englishName
-    ?? 'English';
+  return getLocaleInfo(locale)?.englishName ?? 'English';
 }
 
 /**
@@ -51,13 +50,19 @@ export function buildTitleGenerationPrompt(userMessage: string): string {
 // conversational preamble / markdown heading. Strip those before using the text.
 const TITLE_NOISE_PREFIXES: readonly RegExp[] = [
   /^\s*(?:#{1,6}\s+|>\s+|[-*•]\s+)/,
-  /^\s*(?:(?:here(?:'s| is)|this is)\s+(?:a|the)\s+)?(?:(?:auto[-\s]?)?generated|suggested|proposed|conversation|chat)?\s*(?:title|name|заголовок|название|тема)\s*[:：\-–—]\s*/i,
+  /^\s*(?:(?:here(?:'s| is)|this is)\s+(?:a|the|your|my|one)\s+)?(?:(?:auto[-\s]?)?generated|suggested|proposed|conversation|chat)?\s*(?:title|name|заголовок|название|тема)\s*[:：\-–—]\s*/i,
   /^\s*(?:auto[-\s]?)?generated\s*[:：\-–—]\s*/i,
 ];
 
+/**
+ * One pass per prefix that can stack ahead of the title (`## Generated title:`
+ * is already three), plus one that finds nothing and ends the loop.
+ */
+const MAX_NOISE_STRIP_PASSES = TITLE_NOISE_PREFIXES.length + 1;
+
 function stripTitleNoise(text: string): string {
   let out = text.trim();
-  for (let pass = 0; pass < 4; pass += 1) {
+  for (let pass = 0; pass < MAX_NOISE_STRIP_PASSES; pass += 1) {
     let changed = false;
     for (const pattern of TITLE_NOISE_PREFIXES) {
       const next = out.replace(pattern, '');
@@ -73,16 +78,27 @@ function stripTitleNoise(text: string): string {
   return out;
 }
 
+/**
+ * A line that only announces the title, such as `Here is your title:`.
+ *
+ * Stripping cannot recognise every phrasing a model invents, and taking the
+ * first line on its own would then promote the announcement over the title
+ * below it - losing the answer entirely, where before it at least survived
+ * inside the text.
+ */
+function isLabelOnlyLine(line: string): boolean {
+  return /[:：]$/.test(line) && line.length <= 60;
+}
+
 export function parseTitleGenerationResponse(responseText: string): string | null {
   const stripped = stripTitleNoise(responseText);
   if (!stripped) {
     return null;
   }
 
-  const firstLine = stripped
-    .split(/\r?\n/)
-    .map((line) => line.trim())
-    .find(Boolean);
+  const lines = stripped.split(/\r?\n/).map((line) => line.trim()).filter(Boolean);
+  const firstLine = lines.find((line, index) => !(isLabelOnlyLine(line) && index < lines.length - 1))
+    ?? lines[0];
   if (!firstLine) {
     return null;
   }

--- a/src/core/prompt/titleGeneration.ts
+++ b/src/core/prompt/titleGeneration.ts
@@ -46,21 +46,56 @@ export function buildTitleGenerationPrompt(userMessage: string): string {
   return `User's request:\n"""\n${truncated}\n"""\n\nGenerate a title for this conversation:`;
 }
 
+// Weaker local models tend to ignore "return ONLY the raw title" and prepend a
+// label ("Generated title:", "Title -", "Заголовок:") or wrap the answer in a
+// conversational preamble / markdown heading. Strip those before using the text.
+const TITLE_NOISE_PREFIXES: readonly RegExp[] = [
+  /^\s*(?:#{1,6}\s+|>\s+|[-*•]\s+)/,
+  /^\s*(?:(?:here(?:'s| is)|this is)\s+(?:a|the)\s+)?(?:(?:auto[-\s]?)?generated|suggested|proposed|conversation|chat)?\s*(?:title|name|заголовок|название|тема)\s*[:：\-–—]\s*/i,
+  /^\s*(?:auto[-\s]?)?generated\s*[:：\-–—]\s*/i,
+];
+
+function stripTitleNoise(text: string): string {
+  let out = text.trim();
+  for (let pass = 0; pass < 4; pass += 1) {
+    let changed = false;
+    for (const pattern of TITLE_NOISE_PREFIXES) {
+      const next = out.replace(pattern, '');
+      if (next !== out) {
+        out = next.trim();
+        changed = true;
+      }
+    }
+    if (!changed) {
+      break;
+    }
+  }
+  return out;
+}
+
 export function parseTitleGenerationResponse(responseText: string): string | null {
-  const trimmed = responseText.trim();
-  if (!trimmed) {
+  const stripped = stripTitleNoise(responseText);
+  if (!stripped) {
     return null;
   }
 
-  let title = trimmed;
+  const firstLine = stripped
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .find(Boolean);
+  if (!firstLine) {
+    return null;
+  }
+
+  let title = firstLine;
   if (
     (title.startsWith('"') && title.endsWith('"'))
     || (title.startsWith("'") && title.endsWith("'"))
   ) {
-    title = title.slice(1, -1);
+    title = title.slice(1, -1).trim();
   }
 
-  title = title.replace(/[.!?:;,]+$/, '');
+  title = title.replace(/[.!?:;,]+$/, '').trim();
 
   if (title.length > MAX_TITLE_LENGTH) {
     title = `${title.slice(0, MAX_TITLE_LENGTH - 3)}...`;

--- a/src/core/prompt/titleGeneration.ts
+++ b/src/core/prompt/titleGeneration.ts
@@ -1,3 +1,7 @@
+import { SUPPORTED_LOCALES } from '../../i18n/constants';
+import { getLocale } from '../../i18n/i18n';
+import type { Locale } from '../../i18n/types';
+
 const MAX_TITLE_INPUT_LENGTH = 500;
 const MAX_TITLE_LENGTH = 50;
 
@@ -12,6 +16,28 @@ export const TITLE_GENERATION_SYSTEM_PROMPT = `You are a specialist in summarizi
 4.  **Tech Context**: Detect and include the primary language/framework if code is present (e.g., "Debug Python script", "Refactor React hook").
 
 **Output**: Return ONLY the raw title text.`;
+
+/**
+ * Resolve the human-readable (English) name of a locale, e.g. `ru` -> `Russian`.
+ * Falls back to English for unknown locales.
+ */
+export function resolveTitleLanguageName(locale: Locale = getLocale()): string {
+  return SUPPORTED_LOCALES.find((entry) => entry.code === locale)?.englishName
+    ?? 'English';
+}
+
+/**
+ * Build the title-generation system prompt for the plugin's current locale.
+ * The base instructions stay in English (models follow them more reliably),
+ * but an explicit directive forces the generated title into the UI language so
+ * a Russian vault does not get English tab titles.
+ */
+export function buildTitleGenerationSystemPrompt(locale: Locale = getLocale()): string {
+  const language = resolveTitleLanguageName(locale);
+  return `${TITLE_GENERATION_SYSTEM_PROMPT}
+
+**Language**: Write the title in ${language}. This overrides any language implied by the examples above; only the final title text is translated, the rules are unchanged.`;
+}
 
 export function buildTitleGenerationPrompt(userMessage: string): string {
   const truncated = userMessage.length > MAX_TITLE_INPUT_LENGTH

--- a/src/providers/claude/auxiliary/ClaudeTitleGenerationService.ts
+++ b/src/providers/claude/auxiliary/ClaudeTitleGenerationService.ts
@@ -1,4 +1,4 @@
-import { TITLE_GENERATION_SYSTEM_PROMPT } from '../../../core/prompt/titleGeneration';
+import { buildTitleGenerationSystemPrompt } from '../../../core/prompt/titleGeneration';
 import type {
   TitleGenerationCallback,
   TitleGenerationResult,
@@ -38,7 +38,7 @@ export class TitleGenerationService {
     try {
       const result = await runColdStartQuery({
         plugin: this.plugin,
-        systemPrompt: TITLE_GENERATION_SYSTEM_PROMPT,
+        systemPrompt: buildTitleGenerationSystemPrompt(),
         tools: [],
         model: this.resolveTitleModel(),
         thinking: { disabled: true },

--- a/src/providers/claude/auxiliary/ClaudeTitleGenerationService.ts
+++ b/src/providers/claude/auxiliary/ClaudeTitleGenerationService.ts
@@ -1,4 +1,8 @@
-import { buildTitleGenerationSystemPrompt } from '../../../core/prompt/titleGeneration';
+import {
+  buildTitleGenerationPrompt,
+  buildTitleGenerationSystemPrompt,
+  parseTitleGenerationResponse,
+} from '../../../core/prompt/titleGeneration';
 import type {
   TitleGenerationCallback,
   TitleGenerationResult,
@@ -32,8 +36,7 @@ export class TitleGenerationService {
     const abortController = new AbortController();
     this.activeGenerations.set(conversationId, abortController);
 
-    const truncatedUser = this.truncateText(userMessage, 500);
-    const prompt = `User's request:\n"""\n${truncatedUser}\n"""\n\nGenerate a title for this conversation:`;
+    const prompt = buildTitleGenerationPrompt(userMessage);
 
     try {
       const result = await runColdStartQuery({
@@ -46,7 +49,7 @@ export class TitleGenerationService {
         abortController,
       }, prompt);
 
-      const title = this.parseTitle(result.text);
+      const title = parseTitleGenerationResponse(result.text);
       if (title) {
         await this.safeCallback(callback, conversationId, { success: true, title });
       } else {
@@ -86,32 +89,6 @@ export class TitleGenerationService {
       envVars.ANTHROPIC_DEFAULT_HAIKU_MODEL ||
       'claude-haiku-4-5'
     );
-  }
-
-  private truncateText(text: string, maxLength: number): string {
-    if (text.length <= maxLength) return text;
-    return text.substring(0, maxLength) + '...';
-  }
-
-  private parseTitle(responseText: string): string | null {
-    const trimmed = responseText.trim();
-    if (!trimmed) return null;
-
-    let title = trimmed;
-    if (
-      (title.startsWith('"') && title.endsWith('"')) ||
-      (title.startsWith("'") && title.endsWith("'"))
-    ) {
-      title = title.slice(1, -1);
-    }
-
-    title = title.replace(/[.!?:;,]+$/, '');
-
-    if (title.length > 50) {
-      title = title.substring(0, 47) + '...';
-    }
-
-    return title || null;
   }
 
   private async safeCallback(

--- a/tests/unit/providers/claude/prompt/titleGeneration.test.ts
+++ b/tests/unit/providers/claude/prompt/titleGeneration.test.ts
@@ -85,5 +85,31 @@ describe('titleGeneration', () => {
       expect(parseTitleGenerationResponse('   ')).toBeNull();
       expect(parseTitleGenerationResponse('Title:')).toBeNull();
     });
+
+    it('strips a preamble whatever determiner it uses', () => {
+      expect(parseTitleGenerationResponse('Here is your title: Fix the parser')).toBe('Fix the parser');
+      expect(parseTitleGenerationResponse('Here is my title: Fix the parser')).toBe('Fix the parser');
+      expect(parseTitleGenerationResponse('Here is the title: Fix the parser')).toBe('Fix the parser');
+    });
+
+    it('skips an announcement that sits on its own line', () => {
+      // Stripping cannot know every phrasing; taking the first line regardless
+      // would promote the announcement and lose the title under it.
+      expect(parseTitleGenerationResponse('Here is your suggestion:\nFix the parser'))
+        .toBe('Fix the parser');
+    });
+
+    it('keeps a title that merely ends in a colon when it is all there is', () => {
+      expect(parseTitleGenerationResponse('Debugging:')).toBe('Debugging');
+    });
+
+    it('does not skip a colon line long enough to be a title in its own right', () => {
+      const long = 'Diagnose the failing deployment pipeline and its cascading effects:';
+
+      const title = parseTitleGenerationResponse(`${long}\nsecond line`);
+
+      expect(title).toMatch(/^Diagnose the failing deployment/);
+      expect(title).not.toBe('second line');
+    });
   });
 });

--- a/tests/unit/providers/claude/prompt/titleGeneration.test.ts
+++ b/tests/unit/providers/claude/prompt/titleGeneration.test.ts
@@ -1,4 +1,9 @@
-import { TITLE_GENERATION_SYSTEM_PROMPT } from '@/core/prompt/titleGeneration';
+import {
+  buildTitleGenerationSystemPrompt,
+  resolveTitleLanguageName,
+  TITLE_GENERATION_SYSTEM_PROMPT,
+} from '@/core/prompt/titleGeneration';
+import { setLocale } from '@/i18n/i18n';
 
 describe('titleGeneration', () => {
   it('exports a non-empty system prompt string', () => {
@@ -16,5 +21,31 @@ describe('titleGeneration', () => {
 
   it('instructs to return only the raw title text', () => {
     expect(TITLE_GENERATION_SYSTEM_PROMPT).toContain('ONLY the raw title text');
+  });
+
+  describe('buildTitleGenerationSystemPrompt', () => {
+    afterEach(() => {
+      setLocale('en');
+    });
+
+    it('resolves a locale to its English language name', () => {
+      expect(resolveTitleLanguageName('ru')).toBe('Russian');
+      expect(resolveTitleLanguageName('en')).toBe('English');
+    });
+
+    it('falls back to English for an unknown locale', () => {
+      expect(resolveTitleLanguageName('xx' as never)).toBe('English');
+    });
+
+    it('keeps the base rules and appends the current locale language directive', () => {
+      setLocale('ru');
+      const prompt = buildTitleGenerationSystemPrompt();
+      expect(prompt).toContain(TITLE_GENERATION_SYSTEM_PROMPT);
+      expect(prompt).toContain('Write the title in Russian');
+    });
+
+    it('honours an explicit locale argument', () => {
+      expect(buildTitleGenerationSystemPrompt('ja')).toContain('Write the title in Japanese');
+    });
   });
 });

--- a/tests/unit/providers/claude/prompt/titleGeneration.test.ts
+++ b/tests/unit/providers/claude/prompt/titleGeneration.test.ts
@@ -1,5 +1,6 @@
 import {
   buildTitleGenerationSystemPrompt,
+  parseTitleGenerationResponse,
   resolveTitleLanguageName,
   TITLE_GENERATION_SYSTEM_PROMPT,
 } from '@/core/prompt/titleGeneration';
@@ -46,6 +47,43 @@ describe('titleGeneration', () => {
 
     it('honours an explicit locale argument', () => {
       expect(buildTitleGenerationSystemPrompt('ja')).toContain('Write the title in Japanese');
+    });
+  });
+
+  describe('parseTitleGenerationResponse', () => {
+    it('returns a clean title unchanged', () => {
+      expect(parseTitleGenerationResponse('Fix the title parser')).toBe('Fix the title parser');
+    });
+
+    it('strips a leading "Generated" prefix from weak models', () => {
+      expect(parseTitleGenerationResponse('generated: Fix the title parser'))
+        .toBe('Fix the title parser');
+      expect(parseTitleGenerationResponse('Generated title - Fix the title parser'))
+        .toBe('Fix the title parser');
+    });
+
+    it('strips a leading "Title:" / localized label prefix', () => {
+      expect(parseTitleGenerationResponse('Title: Debug Python script')).toBe('Debug Python script');
+      expect(parseTitleGenerationResponse('Заголовок: Настроить Klipper')).toBe('Настроить Klipper');
+    });
+
+    it('strips leading markdown noise and conversational preambles', () => {
+      expect(parseTitleGenerationResponse('- Fix the parser')).toBe('Fix the parser');
+      expect(parseTitleGenerationResponse('## Fix the parser')).toBe('Fix the parser');
+      expect(parseTitleGenerationResponse("Here is the title: Fix the parser")).toBe('Fix the parser');
+    });
+
+    it('takes the real title when a label sits on its own line', () => {
+      expect(parseTitleGenerationResponse('Generated title:\n\nFix the parser')).toBe('Fix the parser');
+    });
+
+    it('still trims wrapping quotes and trailing punctuation', () => {
+      expect(parseTitleGenerationResponse('"Fix the parser."')).toBe('Fix the parser');
+    });
+
+    it('returns null when nothing survives stripping', () => {
+      expect(parseTitleGenerationResponse('   ')).toBeNull();
+      expect(parseTitleGenerationResponse('Title:')).toBeNull();
     });
   });
 });


### PR DESCRIPTION
### Problem

Auto-generated conversation titles are always in English, regardless of the
plugin's `locale` setting. `TITLE_GENERATION_SYSTEM_PROMPT` is English and
nothing tells the model which language to answer in, so a non-English vault
gets English tab titles.

Two adjacent issues surfaced while fixing that:

- Weaker title models (e.g. a small local model routed through OpenCode) ignore
  *"return ONLY the raw title text"* and prepend a label — `Generated title:`,
  `Title -`, `Заголовок:` — or a short preamble / markdown heading, which then
  becomes the tab name.
- `ClaudeTitleGenerationService` carried byte-identical private copies of
  `buildTitleGenerationPrompt` and `parseTitleGenerationResponse`, so any
  hardening of the shared helpers silently skipped the Claude title path.

### Changes

**1. Locale-aware system prompt** (`2d00d56`)

New `buildTitleGenerationSystemPrompt(locale?)` in
`src/core/prompt/titleGeneration.ts` appends an explicit language directive
derived from the plugin locale (`getLocale()` + `SUPPORTED_LOCALES`,
e.g. `ru` → *"Write the title in Russian"*). The base rules stay in English —
models follow them more reliably — and only the final title text is translated.
`resolveTitleLanguageName()` is exported alongside it.

The directive is emitted for every locale, `en` included: without it a model
mirrors the conversation language, so an English UI would get Russian titles for
a Russian conversation. Making it explicit fixes both directions.

`TITLE_GENERATION_SYSTEM_PROMPT` is unchanged and still exported.

**2. Response noise stripping** (`0a420e1`)

`parseTitleGenerationResponse()` now strips leading label prefixes
(`Generated:` / `Generated title -` / `Title:` / localised `Заголовок:`,
`Название:`, `Тема:`), markdown headings and bullets, and `Here is the title:`
style preambles; then takes the first real line; and only then trims wrapping
quotes and trailing punctuation. A label is only stripped when followed by a
separator, so a legitimate title like `Title screen crash` is untouched.

**3. Drop the duplicated Claude helpers** (`c07be20`)

`ClaudeTitleGenerationService` now calls the shared `buildTitleGenerationPrompt`
and `parseTitleGenerationResponse` instead of its private `truncateText` +
inline template and `parseTitle`. The copies were behaviourally identical
(500-char input truncation, 50-char output truncation, same quote/punctuation
trimming), so this is a no-op for already-clean responses — the existing
`TitleGenerationService` tests for quotes, trailing punctuation, 50-char
truncation and long-message truncation still pass unchanged — and the Claude
path now gets the same response hardening as every other provider.

Both title services now build the system prompt through the shared helper:
`QueryBackedTitleGenerationService` (Codex, Grok, OpenCode, Gemini, …) and
`ClaudeTitleGenerationService`.

### Tests

`tests/unit/providers/claude/prompt/titleGeneration.test.ts` — 15 cases (was 4):
locale resolution, unknown-locale fallback, explicit-locale argument,
prefix/preamble stripping, label on its own line, quotes and punctuation,
empty → `null`.

Full suite, measured on this branch and on `origin/main` in the same working
copy:

| | Suites failed | Tests failed | Passed | Total |
|---|---|---|---|---|
| `origin/main` | 24 | 37 | 7598 | 7643 |
| this branch | 24 | 37 | 7609 | 7654 |

Identical failure counts — the 37 are pre-existing and unrelated; +11 new
passing tests. `tsc --noEmit` and `eslint --max-warnings=0` clean.

### Relationship to #118

#118 (`feat(chat): make the fallback conversation title readable`) and this PR
are complementary, not competing approaches to the same thing. They touch
disjoint files:

- **#118** improves the *fallback* title — the local, no-LLM heuristic in
  `src/core/prompt/fallbackTitle.ts` used by
  `ConversationController.generateFallbackTitle()` when generation is disabled
  or fails.
- **This PR** improves the *generated* title — the system prompt sent to the
  model and the parsing of its response, in `src/core/prompt/titleGeneration.ts`
  and the two title services.

They can merge in either order without conflict.

### Verification

Checked on a live vault with `locale: ru`: OpenCode routed to a local
`qwen2.5-coder` model produces correct Russian titles; a smaller model that
previously emitted a `Generated` prefix is now parsed cleanly.
