### PR TITLE
fix(grok): keep config.toml-defined local models in the native catalog

### DIFF
--- a/src/providers/grok/runtime/GrokModelsCache.ts
+++ b/src/providers/grok/runtime/GrokModelsCache.ts
@@ -94,15 +94,18 @@ export function readGrokNativeModelCatalog(params: {
 } = {}): GrokNativeModelCatalog {
   const env = params.env ?? process.env;
   const models: GrokDiscoveredModel[] = [];
-  for (const cachePath of resolveGrokModelsCachePaths(params)) {
-    models.push(...readGrokModelsCacheFile(cachePath).models);
-  }
-  // The cloud-sourced models_cache.json never contains locally defined models
-  // (`[model."grok-0.7"]` in config.toml). Without merging them here the runtime
-  // catalog drops the user's local Ollama slot on every ensureReady and the
-  // selected model silently falls back to the frontier default.
+  // Config-declared models come first because `mergeGrokDiscoveredModels` keeps the
+  // first entry for a rawId, and the CLI resolves models in that same order: a
+  // `[model."<id>"]` table outranks the prefetched cloud catalog, which outranks the
+  // built-in defaults. The cloud-sourced models_cache.json never contains locally
+  // defined models at all, so without this the runtime catalog drops the user's local
+  // Ollama slot on every ensureReady and the selected model silently falls back to the
+  // frontier default.
   for (const configPath of resolveGrokConfigPaths(params)) {
     models.push(...readGrokConfigModelDefinitionsFile(configPath));
+  }
+  for (const cachePath of resolveGrokModelsCachePaths(params)) {
+    models.push(...readGrokModelsCacheFile(cachePath).models);
   }
 
   const configuredDefault = readGrokConfigDefaultModel(

--- a/src/providers/grok/runtime/GrokModelsCache.ts
+++ b/src/providers/grok/runtime/GrokModelsCache.ts
@@ -1,6 +1,8 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 
+import { parse as parseToml } from 'smol-toml';
+
 import { sameDiscoveredModels, sameStringList } from '../../../utils/collections';
 import { expandHomePath } from '../../../utils/path';
 import { updateGrokDiscoveryState } from '../discoveryState';
@@ -17,6 +19,7 @@ import { getGrokProviderSettings, updateGrokProviderSettings } from '../settings
 import { resolveGrokDataDir } from './GrokPaths';
 
 export const GROK_MODELS_CACHE_FILE = 'models_cache.json';
+export const GROK_CONFIG_FILE = 'config.toml';
 
 export interface GrokNativeModelCatalog {
   defaultModelId: string | null;
@@ -35,10 +38,17 @@ export function resolveNativeGrokDataDir(
   return resolveGrokDataDir(withoutManagedHome);
 }
 
-export function resolveGrokModelsCachePaths(params: {
-  env?: NodeJS.ProcessEnv;
-  managedGrokHomePath?: string | null;
-} = {}): string[] {
+/**
+ * Every Grok home Grimoire may read from, in priority order: the native data
+ * dir, the managed home it launches the CLI with, and an explicit `GROK_HOME`.
+ */
+function resolveGrokHomeFilePaths(
+  fileName: string,
+  params: {
+    env?: NodeJS.ProcessEnv;
+    managedGrokHomePath?: string | null;
+  },
+): string[] {
   const env = params.env ?? process.env;
   const paths: string[] = [];
   const seen = new Set<string>();
@@ -51,17 +61,31 @@ export function resolveGrokModelsCachePaths(params: {
     paths.push(resolved);
   };
 
-  push(path.join(resolveNativeGrokDataDir(env), GROK_MODELS_CACHE_FILE));
+  push(path.join(resolveNativeGrokDataDir(env), fileName));
   const managedHome = params.managedGrokHomePath?.trim();
   if (managedHome) {
-    push(path.join(expandHomePath(managedHome), GROK_MODELS_CACHE_FILE));
+    push(path.join(expandHomePath(managedHome), fileName));
   }
   const grokHome = env.GROK_HOME?.trim();
   if (grokHome) {
-    push(path.join(expandHomePath(grokHome), GROK_MODELS_CACHE_FILE));
+    push(path.join(expandHomePath(grokHome), fileName));
   }
 
   return paths;
+}
+
+export function resolveGrokModelsCachePaths(params: {
+  env?: NodeJS.ProcessEnv;
+  managedGrokHomePath?: string | null;
+} = {}): string[] {
+  return resolveGrokHomeFilePaths(GROK_MODELS_CACHE_FILE, params);
+}
+
+export function resolveGrokConfigPaths(params: {
+  env?: NodeJS.ProcessEnv;
+  managedGrokHomePath?: string | null;
+} = {}): string[] {
+  return resolveGrokHomeFilePaths(GROK_CONFIG_FILE, params);
 }
 
 export function readGrokNativeModelCatalog(params: {
@@ -73,9 +97,16 @@ export function readGrokNativeModelCatalog(params: {
   for (const cachePath of resolveGrokModelsCachePaths(params)) {
     models.push(...readGrokModelsCacheFile(cachePath).models);
   }
+  // The cloud-sourced models_cache.json never contains locally defined models
+  // (`[model."grok-0.7"]` in config.toml). Without merging them here the runtime
+  // catalog drops the user's local Ollama slot on every ensureReady and the
+  // selected model silently falls back to the frontier default.
+  for (const configPath of resolveGrokConfigPaths(params)) {
+    models.push(...readGrokConfigModelDefinitionsFile(configPath));
+  }
 
   const configuredDefault = readGrokConfigDefaultModel(
-    path.join(resolveNativeGrokDataDir(env), 'config.toml'),
+    path.join(resolveNativeGrokDataDir(env), GROK_CONFIG_FILE),
   );
   const normalized = mergeGrokDiscoveredModels(models);
   return {
@@ -251,6 +282,52 @@ export function parseGrokConfigDefaultModel(toml: string): string | null {
 
   const match = modelsSection[1]?.match(/^\s*default\s*=\s*"([^"]+)"/m);
   return match?.[1]?.trim() || null;
+}
+
+/**
+ * Extract locally declared models from a Grok `config.toml` — the `[model."<id>"]`
+ * tables the CLI merges into `grok models` but never writes into the
+ * cloud-backed `models_cache.json`. Grimoire needs them in the native catalog so
+ * a user-selected local model (e.g. an Ollama slot) survives catalog hydration.
+ */
+export function parseGrokConfigModelDefinitions(toml: string): GrokDiscoveredModel[] {
+  let parsed: unknown;
+  try {
+    parsed = parseToml(toml);
+  } catch {
+    return [];
+  }
+
+  if (!isPlainObject(parsed) || !isPlainObject(parsed.model)) {
+    return [];
+  }
+
+  const models: GrokDiscoveredModel[] = [];
+  for (const [rawId, entry] of Object.entries(parsed.model)) {
+    const id = rawId.trim();
+    // Only `[model.<id>]` tables declare a model; a stray scalar under `[model]`
+    // is not one.
+    if (!id || !isPlainObject(entry)) {
+      continue;
+    }
+
+    const label = readNonEmptyString(entry.name) ?? formatGrokCatalogLabel(id);
+    const description = readNonEmptyString(entry.description);
+    models.push({
+      ...(description ? { description } : {}),
+      label,
+      rawId: id,
+    });
+  }
+  return models;
+}
+
+function readGrokConfigModelDefinitionsFile(filePath: string): GrokDiscoveredModel[] {
+  try {
+    return parseGrokConfigModelDefinitions(fs.readFileSync(filePath, 'utf8'));
+  } catch {
+    return [];
+  }
 }
 
 export function mergeGrokDiscoveredModels(

--- a/tests/unit/providers/grok/GrokModelsCache.test.ts
+++ b/tests/unit/providers/grok/GrokModelsCache.test.ts
@@ -236,4 +236,30 @@ model = "qwen2.5-coder-32k:7b"
       rawId: 'grok-0.7',
     });
   });
+
+  it('lets a config.toml override win over the cached entry for the same model', () => {
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'grimoire-grok-override-'));
+    const managedHome = path.join(tempRoot, 'managed');
+    fs.mkdirSync(managedHome, { recursive: true });
+    fs.writeFileSync(path.join(managedHome, 'models_cache.json'), JSON.stringify({
+      models: { 'grok-4.6': { info: { id: 'grok-4.6', name: 'Grok 4.6' } } },
+    }));
+    // Grok resolves `[model.*]` above the prefetched cloud catalog, so an override of a
+    // frontier model has to reach the picker as the user wrote it.
+    fs.writeFileSync(path.join(managedHome, 'config.toml'), [
+      '[model."grok-4.6"]',
+      'base_url = "https://gateway.example/v1"',
+      'name = "Grok 4.6 (corp gateway)"',
+      '',
+    ].join('\n'));
+
+    const catalog = readGrokNativeModelCatalog({
+      env: { GROK_HOME: managedHome },
+      managedGrokHomePath: managedHome,
+    });
+
+    expect(catalog.models.filter((model) => model.rawId === 'grok-4.6')).toEqual([
+      { label: 'Grok 4.6 (corp gateway)', rawId: 'grok-4.6' },
+    ]);
+  });
 });

--- a/tests/unit/providers/grok/GrokModelsCache.test.ts
+++ b/tests/unit/providers/grok/GrokModelsCache.test.ts
@@ -5,6 +5,7 @@ import * as path from 'node:path';
 import {
   expandGrokVisibleModelsWithFrontier,
   parseGrokConfigDefaultModel,
+  parseGrokConfigModelDefinitions,
   parseGrokModelsCache,
   parseGrokModelsCliOutput,
   readGrokNativeModelCatalog,
@@ -153,6 +154,86 @@ yolo = false
         { label: 'Grok 4.6', rawId: 'grok-4.6' },
         { label: 'Grok 4.5', rawId: 'grok-4.5' },
       ],
+    });
+  });
+
+  it('parses locally defined [model."..."] sections from config.toml', () => {
+    expect(parseGrokConfigModelDefinitions(`
+[models]
+default = "grok-4.6"
+
+[model."grok-0.7"]
+model = "qwen2.5-coder-32k:7b"
+base_url = "http://127.0.0.1:11434/v1"
+name = "Qwen2.5 Coder 7B 32k (Ollama)"
+description = "Local Ollama slot"
+`)).toEqual([
+      {
+        description: 'Local Ollama slot',
+        label: 'Qwen2.5 Coder 7B 32k (Ollama)',
+        rawId: 'grok-0.7',
+      },
+    ]);
+  });
+
+  it('falls back to the catalog label when a local model has no name', () => {
+    expect(parseGrokConfigModelDefinitions(`
+[model."grok-0.7"]
+model = "qwen2.5-coder-32k:7b"
+`)).toEqual([{ label: 'Grok 0.7', rawId: 'grok-0.7' }]);
+  });
+
+  it('ignores scalars under [model] and malformed config.toml', () => {
+    expect(parseGrokConfigModelDefinitions(`
+[model]
+default_timeout = 30
+
+[model."grok-0.7"]
+model = "qwen2.5-coder-32k:7b"
+`)).toEqual([{ label: 'Grok 0.7', rawId: 'grok-0.7' }]);
+    expect(parseGrokConfigModelDefinitions('this is not = valid toml [[[')).toEqual([]);
+    expect(parseGrokConfigModelDefinitions('[models]\ndefault = "grok-4.6"\n')).toEqual([]);
+  });
+
+  it('keeps config.toml-defined local models in the native catalog the runtime reads', () => {
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'grimoire-grok-local-'));
+    const nativeHome = path.join(tempRoot, 'native');
+    const managedHome = path.join(tempRoot, 'managed');
+    fs.mkdirSync(nativeHome, { recursive: true });
+    fs.mkdirSync(managedHome, { recursive: true });
+    // The cloud-sourced cache only ever has the frontier models.
+    fs.writeFileSync(path.join(managedHome, 'models_cache.json'), JSON.stringify({
+      models: {
+        'grok-4.6': { info: { id: 'grok-4.6', name: 'Grok 4.6' } },
+        'grok-4.5': { info: { id: 'grok-4.5', name: 'Grok 4.5' } },
+      },
+    }));
+    // The managed config.toml is where Grimoire writes local Ollama models.
+    fs.writeFileSync(path.join(managedHome, 'config.toml'), [
+      '[models]',
+      'default = "grok-4.6"',
+      '',
+      '[model."grok-0.7"]',
+      'model = "qwen2.5-coder-32k:7b"',
+      'base_url = "http://127.0.0.1:11434/v1"',
+      'name = "Qwen2.5 Coder 7B 32k (Ollama)"',
+      '',
+    ].join('\n'));
+
+    const catalog = readGrokNativeModelCatalog({
+      env: {
+        GROK_AUTH_PATH: path.join(nativeHome, 'auth.json'),
+        GROK_HOME: managedHome,
+      },
+      managedGrokHomePath: managedHome,
+    });
+
+    expect(catalog.models.map((model) => model.rawId)).toEqual(
+      expect.arrayContaining(['grok-4.6', 'grok-4.5', 'grok-0.7']),
+    );
+    expect(catalog.models.find((model) => model.rawId === 'grok-0.7')).toEqual({
+      label: 'Qwen2.5 Coder 7B 32k (Ollama)',
+      rawId: 'grok-0.7',
     });
   });
 });


### PR DESCRIPTION
### Problem

A model declared only in the Grok CLI's `config.toml` as a `[model."<id>"]`
table — the supported way to point Grok at a local OpenAI-compatible endpoint —
can be selected in the Grok tab but is **never actually used**. The session
silently falls back to the frontier default.

`GrokChatRuntime.hydrateNativeModelCatalog()` runs on every `ensureReady()` and
rebuilds the catalog from `readGrokNativeModelCatalog()`, which read **only** the
cloud-backed `models_cache.json` files. Those never contain `[model.*]` entries,
so `applyGrokNativeModelCatalog()` overwrote `discoveredModels` with just the
frontier models. `resolveSelectedRawModelId()` then could not find the selected
id, returned `null`, and `applySelectedModel()` skipped the `setModel` call.

`grok models` (used by `discoverGrokModelsFromCli()`) *does* merge the
config.toml models, so `discoveredModels` oscillated between both shapes
depending on which path ran last — and the hydrate path is the one that runs
immediately before a prompt.

Observed in `unified.jsonl` with a local model selected:

```
model changed                {"model": "grok-4.6"}
backend_search: model switch {"new_model": "grok-4.6", "api_backend": "Responses"}
```

…against a cloud endpoint, despite the tab showing the local model.

### Fix

`readGrokNativeModelCatalog()` now also parses `[model."<id>"]` tables from
`config.toml` (native data dir, managed `GROK_HOME`, and `GROK_HOME`) with
`smol-toml` and merges them into the catalog — mirroring what `grok models`
already does. Config-declared models are merged first and win the dedup (by `rawId`, first wins), matching the
order the CLI itself resolves: README, *Custom Models* — "Priority order: 1. Your config
(`[model.*]`) — highest priority; 2. Prefetched models from remote `/v1/models`; 3. Hardcoded
defaults". A local declaration therefore adds new ids to the catalog, and an override of a
frontier model reaches the picker with the name and description the user wrote. Non-table entries under `[model]` are skipped, so a stray scalar
cannot become a phantom catalog entry.

`resolveGrokModelsCachePaths()` and the new `resolveGrokConfigPaths()` share a
single `resolveGrokHomeFilePaths()` helper rather than repeating the lookup
order; the file names move to `GROK_MODELS_CACHE_FILE` / `GROK_CONFIG_FILE`.

New exports: `parseGrokConfigModelDefinitions()`, `resolveGrokConfigPaths()`,
`GROK_CONFIG_FILE`.

### Scope

Deliberately unchanged: `readGrokConfigDefaultModel()` still reads only the
native data dir, so the *default model* resolution behaves exactly as before.
This PR only makes a config-declared model reachable when explicitly selected.

### Tests

`tests/unit/providers/grok/GrokModelsCache.test.ts` — 4 new cases:
`parseGrokConfigModelDefinitions` parsing with name/description, label fallback
when `name` is absent, scalars under `[model]` and malformed TOML, and
`readGrokNativeModelCatalog` retaining a `config.toml`-only model alongside the
cloud cache.

Full suite, measured on this branch and on `origin/main` in the same working
copy:

| | Suites failed | Tests failed | Passed | Total |
|---|---|---|---|---|
| `origin/main` | 24 | 37 | 7598 | 7643 |
| this branch | 24 | 37 | 7602 | 7647 |

Identical failure counts — the 37 are pre-existing and unrelated; +4 new passing
tests. `tsc --noEmit` and `eslint --max-warnings=0` clean.

### Related

Companion to **`fix(grok): propagate local model config to auxiliaries`**
(branch `fix/grok-auxiliary-model-config`). The two fix opposite ends of the
same feature and touch disjoint files:

- this PR makes a config-declared model survive catalog hydration, so the
  **interactive chat** can actually use the model the user selected;
- that PR copies the user `config.toml` into the derived `GROK_HOME` of
  **auxiliary processes**, so the same model can be used for title generation.

They are independent and can merge in either order.

### Verification

With the fix installed, a local Ollama slot declared as `[model."grok-0.7"]`
routes correctly: `model changed: grok-0.7` →
`model switch {new_model: "qwen2.5-coder-32k:7b", api_backend: "ChatCompletions"}`,
and the model is loaded by the local server for the turn.
