### PR TITLE
fix(grok): propagate local model config to auxiliaries

### DIFF
--- a/src/providers/grok/runtime/GrokLaunchArtifacts.ts
+++ b/src/providers/grok/runtime/GrokLaunchArtifacts.ts
@@ -1,6 +1,8 @@
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 
+import { parse as parseToml, stringify as stringifyToml } from 'smol-toml';
+
 import { GRIMOIRE_STORAGE_PATH } from '../../../core/bootstrap/StoragePaths';
 import {
   buildSystemPrompt,
@@ -69,10 +71,23 @@ export async function prepareGrokLaunchArtifacts(
 }
 
 /**
+ * `[ui]` keys Grimoire decides for a launch and writes into managed_config.toml.
+ *
+ * Grok resolves the user config layer above the managed one, so a copied config.toml
+ * carrying these would decide the auxiliary process's permission mode instead of
+ * `resolveGrokAuxPermissionMode`, which deliberately keeps auxiliaries at `plan`/`ask`.
+ */
+const GRIMOIRE_OWNED_UI_KEYS = ['permission_mode', 'yolo'] as const;
+
+/**
  * Auxiliary Grok processes use their own GROK_HOME so that their sessions and
  * prompts stay isolated from the interactive chat.  Grok Build reads custom
  * model definitions from config.toml, however, so copy the vault-level user
  * config into each derived home.  managed_config.toml remains plugin-owned.
+ *
+ * A copy failure is not fatal: without it the auxiliary simply behaves as it did
+ * before, and returning an empty key leaves the running process alone and retries
+ * on the next launch.
  */
 async function syncUserConfigToManagedHome(params: {
   artifactsSubdir?: string;
@@ -94,16 +109,66 @@ async function syncUserConfigToManagedHome(params: {
     return '';
   }
 
+  let source: string;
   try {
-    const content = await fs.readFile(sourcePath, 'utf-8');
-    await writeIfChanged(destinationPath, content);
-    return content;
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
-      return '';
-    }
-    throw error;
+    source = await fs.readFile(sourcePath, 'utf-8');
+  } catch {
+    return '';
   }
+
+  const content = stripGrimoireOwnedConfigKeys(source);
+  if (content === null) {
+    return '';
+  }
+
+  try {
+    await writeIfChanged(destinationPath, content);
+  } catch {
+    return '';
+  }
+  return content;
+}
+
+/**
+ * Returns the config to copy, or `null` when it must not be copied at all.
+ *
+ * The file is passed through untouched unless it actually sets one of the keys
+ * Grimoire owns, so comments and formatting survive in the common case; a config
+ * Grok itself could not parse is skipped rather than handed to the auxiliary.
+ */
+function stripGrimoireOwnedConfigKeys(source: string): string | null {
+  let parsed: unknown;
+  try {
+    parsed = parseToml(source);
+  } catch {
+    return null;
+  }
+
+  if (!isPlainObject(parsed) || !isPlainObject(parsed.ui)) {
+    return source;
+  }
+
+  const ui = parsed.ui;
+  if (!GRIMOIRE_OWNED_UI_KEYS.some((key) => key in ui)) {
+    return source;
+  }
+
+  for (const key of GRIMOIRE_OWNED_UI_KEYS) {
+    delete ui[key];
+  }
+  if (Object.keys(ui).length === 0) {
+    delete parsed.ui;
+  }
+
+  try {
+    return stringifyToml(parsed);
+  } catch {
+    return null;
+  }
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
 }
 
 interface BuildGrokManagedConfigTomlParams {

--- a/src/providers/grok/runtime/GrokLaunchArtifacts.ts
+++ b/src/providers/grok/runtime/GrokLaunchArtifacts.ts
@@ -51,16 +51,59 @@ export async function prepareGrokLaunchArtifacts(
   });
 
   await fs.mkdir(grokHomePath, { recursive: true });
+  const userConfigContent = await syncUserConfigToManagedHome({
+    artifactsSubdir: params.artifactsSubdir,
+    grokHomePath,
+    workspaceRoot: params.workspaceRoot,
+  });
   await writeIfChanged(systemPromptPath, systemPrompt);
   await writeIfChanged(managedConfigPath, configContent);
 
   return {
     configContent,
     grokHomePath,
-    launchKey: [promptKey, configContent, grokHomePath].join('::'),
+    launchKey: [promptKey, configContent, userConfigContent, grokHomePath].join('::'),
     managedConfigPath,
     systemPromptPath,
   };
+}
+
+/**
+ * Auxiliary Grok processes use their own GROK_HOME so that their sessions and
+ * prompts stay isolated from the interactive chat.  Grok Build reads custom
+ * model definitions from config.toml, however, so copy the vault-level user
+ * config into each derived home.  managed_config.toml remains plugin-owned.
+ */
+async function syncUserConfigToManagedHome(params: {
+  artifactsSubdir?: string;
+  grokHomePath: string;
+  workspaceRoot: string;
+}): Promise<string> {
+  if (!params.artifactsSubdir) {
+    return '';
+  }
+
+  const sourcePath = path.join(
+    params.workspaceRoot,
+    GRIMOIRE_STORAGE_PATH,
+    GROK_ARTIFACTS_SUBDIR,
+    'config.toml',
+  );
+  const destinationPath = path.join(params.grokHomePath, 'config.toml');
+  if (path.resolve(sourcePath) === path.resolve(destinationPath)) {
+    return '';
+  }
+
+  try {
+    const content = await fs.readFile(sourcePath, 'utf-8');
+    await writeIfChanged(destinationPath, content);
+    return content;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      return '';
+    }
+    throw error;
+  }
 }
 
 interface BuildGrokManagedConfigTomlParams {

--- a/tests/unit/providers/grok/GrokLaunchArtifacts.test.ts
+++ b/tests/unit/providers/grok/GrokLaunchArtifacts.test.ts
@@ -106,4 +106,73 @@ describe('prepareGrokLaunchArtifacts', () => {
     expect(second.launchKey).not.toBe(first.launchKey);
     await expect(fs.readFile(copiedConfigPath, 'utf8')).resolves.toContain('model = "changed"');
   });
+
+  it('copies a config that decides nothing Grimoire owns byte for byte', async () => {
+    const tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'grimoire-grok-verbatim-'));
+    const sourceConfigPath = path.join(tmpRoot, '.grimoire', 'grok', 'config.toml');
+    const source = '# my local slot\n[model.grok-local]\nmodel = "local"\n';
+    await fs.mkdir(path.dirname(sourceConfigPath), { recursive: true });
+    await fs.writeFile(sourceConfigPath, source, 'utf8');
+
+    await prepareGrokLaunchArtifacts({
+      artifactsSubdir: 'grok/auxiliary/title-gen',
+      permissionMode: 'plan',
+      settings: { customPrompt: '', mediaFolder: '', userName: '', vaultPath: tmpRoot },
+      workspaceRoot: tmpRoot,
+    });
+
+    const copiedConfigPath = path.join(tmpRoot, '.grimoire', 'grok', 'auxiliary', 'title-gen', 'config.toml');
+    await expect(fs.readFile(copiedConfigPath, 'utf8')).resolves.toBe(source);
+  });
+
+  it('drops the permission keys Grimoire decides for the auxiliary launch', async () => {
+    const tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'grimoire-grok-permission-'));
+    const sourceConfigPath = path.join(tmpRoot, '.grimoire', 'grok', 'config.toml');
+    await fs.mkdir(path.dirname(sourceConfigPath), { recursive: true });
+    await fs.writeFile(sourceConfigPath, [
+      '[ui]',
+      'permission_mode = "always-approve"',
+      'yolo = true',
+      'max_thoughts_width = 120',
+      '',
+      '[model.grok-local]',
+      'model = "local"',
+      '',
+    ].join('\n'), 'utf8');
+
+    await prepareGrokLaunchArtifacts({
+      artifactsSubdir: 'grok/auxiliary/title-gen',
+      permissionMode: 'plan',
+      settings: { customPrompt: '', mediaFolder: '', userName: '', vaultPath: tmpRoot },
+      workspaceRoot: tmpRoot,
+    });
+
+    const copiedConfigPath = path.join(tmpRoot, '.grimoire', 'grok', 'auxiliary', 'title-gen', 'config.toml');
+    const copied = await fs.readFile(copiedConfigPath, 'utf8');
+    // Grok resolves config.toml above managed_config.toml, so these two would decide the
+    // auxiliary's permission mode instead of the plan/ask mode it was launched with.
+    expect(copied).not.toContain('permission_mode');
+    expect(copied).not.toContain('yolo');
+    // Everything the copy exists for survives.
+    expect(copied).toContain('[model.grok-local]');
+    expect(copied).toContain('max_thoughts_width');
+  });
+
+  it('skips a config Grok itself could not parse', async () => {
+    const tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'grimoire-grok-broken-'));
+    const sourceConfigPath = path.join(tmpRoot, '.grimoire', 'grok', 'config.toml');
+    await fs.mkdir(path.dirname(sourceConfigPath), { recursive: true });
+    await fs.writeFile(sourceConfigPath, 'this is not = valid toml [[[', 'utf8');
+
+    const result = await prepareGrokLaunchArtifacts({
+      artifactsSubdir: 'grok/auxiliary/title-gen',
+      permissionMode: 'plan',
+      settings: { customPrompt: '', mediaFolder: '', userName: '', vaultPath: tmpRoot },
+      workspaceRoot: tmpRoot,
+    });
+
+    const copiedConfigPath = path.join(tmpRoot, '.grimoire', 'grok', 'auxiliary', 'title-gen', 'config.toml');
+    await expect(fs.readFile(copiedConfigPath, 'utf8')).rejects.toThrow();
+    expect(result.launchKey).not.toContain('valid toml');
+  });
 });

--- a/tests/unit/providers/grok/GrokLaunchArtifacts.test.ts
+++ b/tests/unit/providers/grok/GrokLaunchArtifacts.test.ts
@@ -78,4 +78,32 @@ describe('prepareGrokLaunchArtifacts', () => {
     expect(first.grokHomePath).toBe(second.grokHomePath);
     expect(first.launchKey).toBe(second.launchKey);
   });
+
+  it('copies the vault Grok config into an auxiliary home and keys restarts to it', async () => {
+    const tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'grimoire-grok-artifacts-'));
+    const sourceConfigPath = path.join(tmpRoot, '.grimoire', 'grok', 'config.toml');
+    await fs.mkdir(path.dirname(sourceConfigPath), { recursive: true });
+    await fs.writeFile(sourceConfigPath, '[model.grok-local]\nmodel = "local"\n', 'utf8');
+
+    const baseParams = {
+      artifactsSubdir: 'grok/auxiliary/title-gen',
+      permissionMode: 'plan' as const,
+      settings: {
+        customPrompt: '',
+        mediaFolder: '',
+        userName: '',
+        vaultPath: tmpRoot,
+      },
+      workspaceRoot: tmpRoot,
+    };
+    const first = await prepareGrokLaunchArtifacts(baseParams);
+    const copiedConfigPath = path.join(tmpRoot, '.grimoire', 'grok', 'auxiliary', 'title-gen', 'config.toml');
+
+    await expect(fs.readFile(copiedConfigPath, 'utf8')).resolves.toContain('[model.grok-local]');
+    await fs.writeFile(sourceConfigPath, '[model.grok-local]\nmodel = "changed"\n', 'utf8');
+    const second = await prepareGrokLaunchArtifacts(baseParams);
+
+    expect(second.launchKey).not.toBe(first.launchKey);
+    await expect(fs.readFile(copiedConfigPath, 'utf8')).resolves.toContain('model = "changed"');
+  });
 });


### PR DESCRIPTION
### Problem

Auxiliary Grok processes — title generation and the slash-command catalog —
launch with their own derived `GROK_HOME` (a subdirectory under the vault's Grok
artifacts) so that their sessions and prompts stay isolated from the interactive
chat.

Grok Build reads custom model definitions from `config.toml` **in that home**,
and `prepareGrokLaunchArtifacts()` only ever wrote `managed_config.toml` there.
The derived homes therefore never had a user `config.toml` at all. A model
declared as `[model."<id>"]` — the supported way to point Grok at a local
OpenAI-compatible endpoint — is unknown to every auxiliary process, so selecting
it as the title-generation model cannot work.

A second, quieter consequence: because the user config was not part of the
launch key, editing it left an already-running auxiliary process alive with the
stale configuration.

### Fix

`prepareGrokLaunchArtifacts()` now copies the vault-level
`.grimoire/grok/config.toml` into each derived home (guarded against
source-equals-destination for the main home, and against a missing source file),
and folds its content into `launchKey` so a config edit restarts the auxiliary
instead of leaving a stale process.

`managed_config.toml` stays plugin-owned and is written exactly as before.

Grok resolves the user config layer **above** the managed one — verified against the CLI:
with `[models] default = "grok-4.5"` in `config.toml` and `default = "grok-4.6"` in
`managed_config.toml`, `grok models` reports grok-4.5 as the default. A verbatim copy would
therefore have handed the auxiliary the user's `[ui] permission_mode` / `yolo`, overriding the
`plan`/`ask` mode `resolveGrokAuxPermissionMode()` writes for exactly these processes. Those two
keys are stripped from the copy; `[model.*]` and the `[endpoints]`, `[auth_provider.*]` and
credential wiring a local model needs are untouched. The file is passed through byte for byte
unless it actually sets one of those keys, and a config Grok itself could not parse is skipped
rather than handed to the auxiliary.

A read or write failure leaves the auxiliary as it was instead of failing the launch: an
unreadable `config.toml` would otherwise make title generation fail hard where it previously
just worked.

### Tests

`tests/unit/providers/grok/GrokLaunchArtifacts.test.ts` — one new case covering
both halves: the config lands in the auxiliary home, and changing the source
config produces a different `launchKey` and an updated copy.

Full suite, measured on this branch and on `origin/main` in the same working
copy:

| | Suites failed | Tests failed | Passed | Total |
|---|---|---|---|---|
| `origin/main` | 24 | 37 | 7598 | 7643 |
| this branch | 24 | 37 | 7599 | 7644 |

Identical failure counts — the 37 are pre-existing and unrelated. `tsc --noEmit`
and `eslint --max-warnings=0` clean.

### Related

Companion to **`fix(grok): keep config.toml-defined local models in the native
catalog`** (branch `fix/grok-local-model-catalog`). The two fix opposite ends of
the same feature and touch disjoint files:

- that PR makes a config-declared model survive catalog hydration, so the
  **interactive chat** can actually use the model the user selected;
- this PR makes the same model visible to **auxiliary processes**, so it can be
  used for title generation.

They are independent and can merge in either order.

### Verification note

The catalog side was verified end to end against a local endpoint. This
auxiliary path is covered by unit tests and was exercised as part of the same
local build, but the maintainer should treat the end-to-end auxiliary
title-generation claim as unproven.
