### PR TITLE
feat(chat): store image attachments in the vault, for every provider

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -110,6 +110,7 @@ The project requires Obsidian 1.13.0 or newer and uses the declarative settings 
 |------|-------|
 | `.grimoire/grimoire-settings.json` | Shared Grimoire app settings plus provider-specific configuration |
 | `.grimoire/sessions/*.meta.json` | Provider-neutral session metadata |
+| `.grimoire/attachments/<sha256>.<ext>` | Image attachment bytes, addressed by content and shared by every provider |
 | `.grimoire/logs/YYYY-MM-DD.jsonl` | Optional sanitized debug logs, written only when Advanced debug logging is enabled |
 | `.grimoire/mcp/<provider>.json` | Grimoire-owned MCP servers injected into ACP sessions for OpenCode, Grok Build, MiMoCode, Kimi Code, Qwen Code, and Gemini CLI |
 | `.grimoire/claude/statusline-usage.json` | Claude Code status-line usage snapshot used to hydrate plan-limit indicators |

--- a/src/app/storage/SharedStorageService.ts
+++ b/src/app/storage/SharedStorageService.ts
@@ -1,6 +1,7 @@
 import type { Plugin } from 'obsidian';
 import { Notice } from 'obsidian';
 
+import { AttachmentStore } from '../../core/attachments/AttachmentStore';
 import { SESSIONS_PATH, SessionStorage } from '../../core/bootstrap/SessionStorage';
 import type { SharedAppStorage } from '../../core/bootstrap/storage';
 import { GRIMOIRE_STORAGE_PATH } from '../../core/bootstrap/StoragePaths';
@@ -63,6 +64,7 @@ function normalizeDraftSettings(value: unknown): Record<string, unknown> | undef
 export class SharedStorageService implements SharedAppStorage {
   readonly grimoireSettings: GrimoireSettingsStorage;
   readonly sessions: SessionStorage;
+  readonly attachments: AttachmentStore;
 
   private adapter: VaultFileAdapter;
   private plugin: Plugin;
@@ -72,6 +74,7 @@ export class SharedStorageService implements SharedAppStorage {
     this.adapter = new VaultFileAdapter(plugin.app);
     this.grimoireSettings = new GrimoireSettingsStorage(this.adapter);
     this.sessions = new SessionStorage(this.adapter);
+    this.attachments = new AttachmentStore(this.adapter);
   }
 
   async initialize(): Promise<{ grimoire: Record<string, unknown> }> {

--- a/src/core/AGENTS.md
+++ b/src/core/AGENTS.md
@@ -6,6 +6,8 @@
 
 - `runtime/` defines neutral chat runtime contracts such as `ChatRuntime`, prepared turns, query options, approvals, and session updates.
 - `providers/` defines registries, capabilities, model routing, environment, settings projection, and workspace-service contracts.
+- `attachments/` owns the content-addressed store for image attachment bytes, plus the scaling
+  policy applied before they are stored. Provider-neutral: every provider reads the same files.
 - `bootstrap/` owns provider-neutral session metadata storage and shared app-storage contracts.
 - `debug/` owns sanitized file logging. Debug logs must be opt-in and must not include prompts, answers, note content, paths, environment values, or secrets.
 - `mcp/` owns provider-neutral MCP config parsing, testing, and coordination.

--- a/src/core/attachments/AttachmentStore.ts
+++ b/src/core/attachments/AttachmentStore.ts
@@ -1,0 +1,111 @@
+import { createHash } from 'crypto';
+
+import type { ImageMediaType } from '../types';
+
+/** Grimoire-owned vault folder holding attachment bytes, addressed by content. */
+export const ATTACHMENTS_FOLDER = '.grimoire/attachments';
+
+const EXTENSIONS: Record<ImageMediaType, string> = {
+  'image/png': 'png',
+  'image/jpeg': 'jpg',
+  'image/gif': 'gif',
+  'image/webp': 'webp',
+};
+
+/** The slice of the vault adapter the store needs. */
+export interface AttachmentFileStore {
+  exists(path: string): Promise<boolean>;
+  readBinary(path: string): Promise<ArrayBuffer>;
+  writeBinary(path: string, data: ArrayBuffer): Promise<void>;
+  delete(path: string): Promise<void>;
+  listFiles(folder: string): Promise<string[]>;
+  getResourcePath(path: string): string;
+}
+
+export interface StoredAttachment {
+  hash: string;
+  mediaType: ImageMediaType;
+  size: number;
+}
+
+export function attachmentFileName(hash: string, mediaType: ImageMediaType): string {
+  return `${hash}.${EXTENSIONS[mediaType] ?? 'bin'}`;
+}
+
+export function attachmentPath(hash: string, mediaType: ImageMediaType): string {
+  return `${ATTACHMENTS_FOLDER}/${attachmentFileName(hash, mediaType)}`;
+}
+
+/** The hash a stored file name carries, or null when the name is not one of ours. */
+export function hashFromAttachmentPath(path: string): string | null {
+  const name = path.slice(path.lastIndexOf('/') + 1);
+  const match = /^([0-9a-f]{64})\.[a-z]+$/.exec(name);
+  return match ? match[1] : null;
+}
+
+/**
+ * Attachment bytes, stored once per distinct content.
+ *
+ * Addressing by hash makes writes idempotent and deduplicates the same
+ * screenshot across conversations, which matters because a message keeps only
+ * the reference: the bytes stop travelling through session metadata on every
+ * save, and stop being the largest thing a conversation holds in memory.
+ */
+export class AttachmentStore {
+  constructor(private readonly files: AttachmentFileStore) {}
+
+  /** Writes the bytes unless that content is already stored. */
+  async put(bytes: ArrayBuffer, mediaType: ImageMediaType): Promise<StoredAttachment> {
+    const hash = hashBytes(bytes);
+    const path = attachmentPath(hash, mediaType);
+
+    if (!(await this.files.exists(path))) {
+      await this.files.writeBinary(path, bytes);
+    }
+
+    return { hash, mediaType, size: bytes.byteLength };
+  }
+
+  async read(hash: string, mediaType: ImageMediaType): Promise<ArrayBuffer | null> {
+    const path = attachmentPath(hash, mediaType);
+    if (!(await this.files.exists(path))) {
+      return null;
+    }
+
+    try {
+      return await this.files.readBinary(path);
+    } catch {
+      return null;
+    }
+  }
+
+  /** A URL the renderer can display without decoding the file into a data URI. */
+  resourcePath(hash: string, mediaType: ImageMediaType): string {
+    return this.files.getResourcePath(attachmentPath(hash, mediaType));
+  }
+
+  /**
+   * Deletes stored files no conversation references any more, and reports how
+   * many went. Callers pass every hash still reachable, so a hash they forgot
+   * is a deleted attachment - collect only when the set is known to be complete.
+   */
+  async collectGarbage(referenced: ReadonlySet<string>): Promise<number> {
+    const stored = await this.files.listFiles(ATTACHMENTS_FOLDER);
+    let removed = 0;
+
+    for (const path of stored) {
+      const hash = hashFromAttachmentPath(path);
+      if (!hash || referenced.has(hash)) {
+        continue;
+      }
+      await this.files.delete(path);
+      removed += 1;
+    }
+
+    return removed;
+  }
+}
+
+export function hashBytes(bytes: ArrayBuffer): string {
+  return createHash('sha256').update(Buffer.from(bytes)).digest('hex');
+}

--- a/src/core/attachments/hydrateImages.ts
+++ b/src/core/attachments/hydrateImages.ts
@@ -1,0 +1,50 @@
+import type { ChatMessage } from '../types';
+import type { AttachmentStore } from './AttachmentStore';
+
+/**
+ * Refills the in-memory bytes of attachments whose data was left out of
+ * session metadata.
+ *
+ * Called when a conversation becomes the active one, so only its attachments
+ * are held - rather than those of every conversation in the vault, which is
+ * what loading metadata used to bring in.
+ *
+ * An attachment whose file is gone keeps its empty data instead of failing the
+ * load: the rest of the conversation is still worth opening.
+ */
+export async function hydrateImageAttachments(
+  messages: ChatMessage[] | undefined,
+  store: AttachmentStore,
+): Promise<void> {
+  for (const message of messages ?? []) {
+    for (const image of message.images ?? []) {
+      if (!image.hash || image.data) {
+        continue;
+      }
+
+      const bytes = await store.read(image.hash, image.mediaType);
+      if (bytes) {
+        image.data = Buffer.from(bytes).toString('base64');
+      }
+    }
+  }
+}
+
+/** Every attachment hash the given conversations still reference. */
+export function collectReferencedHashes(
+  conversations: readonly { messages?: ChatMessage[] }[],
+): Set<string> {
+  const hashes = new Set<string>();
+
+  for (const conversation of conversations) {
+    for (const message of conversation.messages ?? []) {
+      for (const image of message.images ?? []) {
+        if (image.hash) {
+          hashes.add(image.hash);
+        }
+      }
+    }
+  }
+
+  return hashes;
+}

--- a/src/core/attachments/hydrateImages.ts
+++ b/src/core/attachments/hydrateImages.ts
@@ -1,4 +1,4 @@
-import type { ChatMessage } from '../types';
+import type { ChatMessage, ImageAttachment } from '../types';
 import type { AttachmentStore } from './AttachmentStore';
 
 /**
@@ -17,15 +17,23 @@ export async function hydrateImageAttachments(
   store: AttachmentStore,
 ): Promise<void> {
   for (const message of messages ?? []) {
-    for (const image of message.images ?? []) {
-      if (!image.hash || image.data) {
-        continue;
-      }
+    await hydrateImages(message.images, store);
+  }
+}
 
-      const bytes = await store.read(image.hash, image.mediaType);
-      if (bytes) {
-        image.data = Buffer.from(bytes).toString('base64');
-      }
+/** Refills one batch of attachments - the images of a turn about to be sent. */
+export async function hydrateImages(
+  images: ImageAttachment[] | undefined,
+  store: AttachmentStore,
+): Promise<void> {
+  for (const image of images ?? []) {
+    if (!image.hash || image.data) {
+      continue;
+    }
+
+    const bytes = await store.read(image.hash, image.mediaType);
+    if (bytes) {
+      image.data = Buffer.from(bytes).toString('base64');
     }
   }
 }

--- a/src/core/attachments/imageEncoder.ts
+++ b/src/core/attachments/imageEncoder.ts
@@ -1,0 +1,81 @@
+import type { ImageMediaType } from '../types';
+import {
+  fitWithin,
+  type ImageDimensions,
+  MAX_ATTACHMENT_EDGE,
+  RESCALE_QUALITY,
+  RESCALED_MEDIA_TYPE,
+} from './imageScaling';
+
+export interface EncodedImage {
+  bytes: ArrayBuffer;
+  mediaType: ImageMediaType;
+  width: number;
+  height: number;
+}
+
+/**
+ * Decoding and re-encoding an image needs the renderer's canvas APIs, which
+ * exist in Obsidian but not under a plain Node test runner. Keeping the two
+ * calls behind this seam lets the surrounding policy be tested without them.
+ */
+export interface ImageCodec {
+  decode(bytes: ArrayBuffer, mediaType: ImageMediaType): Promise<ImageDimensions & { source: unknown }>;
+  encode(
+    source: unknown,
+    size: ImageDimensions,
+    mediaType: ImageMediaType,
+    quality: number,
+  ): Promise<ArrayBuffer>;
+}
+
+/** The codec Obsidian's renderer provides. */
+export const canvasImageCodec: ImageCodec = {
+  async decode(bytes, mediaType) {
+    const bitmap = await createImageBitmap(new Blob([bytes], { type: mediaType }));
+    return { width: bitmap.width, height: bitmap.height, source: bitmap };
+  },
+
+  async encode(source, size, mediaType, quality) {
+    const canvas = new OffscreenCanvas(size.width, size.height);
+    const context = canvas.getContext('2d');
+    if (!context) {
+      throw new Error('2d canvas context unavailable');
+    }
+    context.drawImage(source as CanvasImageSource, 0, 0, size.width, size.height);
+    const blob = await canvas.convertToBlob({ type: mediaType, quality });
+    return blob.arrayBuffer();
+  },
+};
+
+/**
+ * Returns the image scaled to fit `maxEdge`, or null when it does not need
+ * scaling and when the environment cannot do it. A null answer means "store
+ * what the user gave us".
+ */
+export async function rescaleImage(
+  bytes: ArrayBuffer,
+  mediaType: ImageMediaType,
+  maxEdge: number = MAX_ATTACHMENT_EDGE,
+  codec: ImageCodec = canvasImageCodec,
+): Promise<EncodedImage | null> {
+  try {
+    const decoded = await codec.decode(bytes, mediaType);
+    const target = fitWithin(decoded, maxEdge);
+    if (target.width === decoded.width && target.height === decoded.height) {
+      return null;
+    }
+
+    const encoded = await codec.encode(decoded.source, target, RESCALED_MEDIA_TYPE, RESCALE_QUALITY);
+    return {
+      bytes: encoded,
+      mediaType: RESCALED_MEDIA_TYPE,
+      width: target.width,
+      height: target.height,
+    };
+  } catch {
+    // A decode or encode this build cannot do is not a reason to lose the
+    // attachment - the original bytes are still perfectly usable.
+    return null;
+  }
+}

--- a/src/core/attachments/imageScaling.ts
+++ b/src/core/attachments/imageScaling.ts
@@ -1,0 +1,63 @@
+import type { ImageMediaType } from '../types';
+
+/**
+ * Longest edge an attachment is stored at.
+ *
+ * Above this, provider vision pipelines downscale server-side anyway, so the
+ * extra pixels only cost memory, disk and upload time. 2000 is also the width
+ * Anthropic documents for staying under the stricter per-image dimension limit
+ * that applies once a request carries more than 20 image blocks - and every
+ * turn of a conversation resends the images of the turns before it.
+ */
+export const MAX_ATTACHMENT_EDGE = 2000;
+
+/** What a re-encode produces. Lossy at a quality that keeps screenshot text legible. */
+export const RESCALED_MEDIA_TYPE: ImageMediaType = 'image/webp';
+export const RESCALE_QUALITY = 0.92;
+
+export interface ImageDimensions {
+  width: number;
+  height: number;
+}
+
+export function exceedsMaxEdge(size: ImageDimensions, maxEdge: number): boolean {
+  return size.width > maxEdge || size.height > maxEdge;
+}
+
+/**
+ * The largest size that fits within `maxEdge` on both sides while keeping the
+ * aspect ratio. A size already within the limit is returned unchanged.
+ */
+export function fitWithin(size: ImageDimensions, maxEdge: number): ImageDimensions {
+  if (maxEdge <= 0) {
+    return { width: 1, height: 1 };
+  }
+  if (!exceedsMaxEdge(size, maxEdge)) {
+    return { width: size.width, height: size.height };
+  }
+
+  const scale = maxEdge / Math.max(size.width, size.height);
+  return {
+    width: Math.max(1, Math.round(size.width * scale)),
+    height: Math.max(1, Math.round(size.height * scale)),
+  };
+}
+
+/**
+ * Whether this type may go through a canvas at all.
+ *
+ * GIF may not: the round-trip keeps only the first frame, which would silently
+ * turn the user's animation into a still.
+ */
+export function isRescalableType(mediaType: ImageMediaType): boolean {
+  return mediaType !== 'image/gif';
+}
+
+/** Whether an attachment of this type and size is worth re-encoding. */
+export function shouldRescale(
+  mediaType: ImageMediaType,
+  size: ImageDimensions,
+  maxEdge: number = MAX_ATTACHMENT_EDGE,
+): boolean {
+  return isRescalableType(mediaType) && exceedsMaxEdge(size, maxEdge);
+}

--- a/src/core/attachments/prepareImage.ts
+++ b/src/core/attachments/prepareImage.ts
@@ -1,0 +1,52 @@
+import type { ImageMediaType } from '../types';
+import { canvasImageCodec, type ImageCodec,rescaleImage } from './imageEncoder';
+import { isRescalableType, MAX_ATTACHMENT_EDGE } from './imageScaling';
+
+export interface PreparedAttachment {
+  bytes: ArrayBuffer;
+  mediaType: ImageMediaType;
+  width?: number;
+  height?: number;
+  /** True when the stored bytes differ from what the user supplied. */
+  rescaled: boolean;
+}
+
+export interface PrepareImageOptions {
+  maxEdge?: number;
+  codec?: ImageCodec;
+}
+
+/**
+ * Decides what an attachment is stored as.
+ *
+ * A rescale is taken only when it actually produces fewer bytes, so the store
+ * never holds more than the user supplied, and a build that cannot re-encode
+ * simply keeps the original.
+ */
+export async function prepareImageForStore(
+  bytes: ArrayBuffer,
+  mediaType: ImageMediaType,
+  options: PrepareImageOptions = {},
+): Promise<PreparedAttachment> {
+  const original: PreparedAttachment = { bytes, mediaType, rescaled: false };
+
+  // An animated GIF must not reach a canvas, and that is decided by type alone
+  // - no point decoding first.
+  if (!isRescalableType(mediaType)) {
+    return original;
+  }
+
+  const maxEdge = options.maxEdge ?? MAX_ATTACHMENT_EDGE;
+  const rescaled = await rescaleImage(bytes, mediaType, maxEdge, options.codec ?? canvasImageCodec);
+  if (!rescaled || rescaled.bytes.byteLength >= bytes.byteLength) {
+    return original;
+  }
+
+  return {
+    bytes: rescaled.bytes,
+    mediaType: rescaled.mediaType,
+    width: rescaled.width,
+    height: rescaled.height,
+    rescaled: true,
+  };
+}

--- a/src/core/bootstrap/SessionStorage.ts
+++ b/src/core/bootstrap/SessionStorage.ts
@@ -66,10 +66,30 @@ function cloneMessagesForMetadata(
   }
 
   try {
-    return JSON.parse(JSON.stringify(messages)) as ChatMessage[];
+    const cloned = JSON.parse(JSON.stringify(messages)) as ChatMessage[];
+    return dropStoredImageData(cloned);
   } catch {
     return undefined;
   }
+}
+
+/**
+ * Leaves out the bytes of attachments the store already holds.
+ *
+ * Metadata is rewritten whole on every conversation update, so a megabyte of
+ * base64 here is a megabyte written again on each of them. An attachment
+ * without a hash keeps its data - that is the only copy there is.
+ */
+function dropStoredImageData(messages: ChatMessage[]): ChatMessage[] {
+  for (const message of messages) {
+    for (const image of message.images ?? []) {
+      if (image.hash) {
+        image.data = '';
+      }
+    }
+  }
+
+  return messages;
 }
 
 export function clonePersistedMessages(

--- a/src/core/bootstrap/storage.ts
+++ b/src/core/bootstrap/storage.ts
@@ -1,3 +1,4 @@
+import type { AttachmentStore } from '../attachments/AttachmentStore';
 import type { AppSessionStorage, AppTabManagerState } from '../providers/types';
 import type { VaultFileAdapter } from '../storage/VaultFileAdapter';
 
@@ -16,5 +17,7 @@ export interface SharedAppStorage {
   setTabManagerState(state: AppTabManagerState): Promise<void>;
   getTabManagerState(): Promise<AppTabManagerState | null>;
   sessions: AppSessionStorage;
+  /** Attachment bytes, shared by every provider and addressed by content. */
+  attachments: AttachmentStore;
   getAdapter(): VaultFileAdapter;
 }

--- a/src/core/storage/VaultFileAdapter.ts
+++ b/src/core/storage/VaultFileAdapter.ts
@@ -40,6 +40,23 @@ export class VaultFileAdapter {
     await this.writeQueue;
   }
 
+  async readBinary(path: string): Promise<ArrayBuffer> {
+    return this.app.vault.adapter.readBinary(path);
+  }
+
+  async writeBinary(path: string, data: ArrayBuffer): Promise<void> {
+    await this.ensureParentFolder(path);
+    await this.app.vault.adapter.writeBinary(path, data);
+  }
+
+  /**
+   * A URL the renderer can put in an `img` src. Lets a stored attachment be
+   * displayed without decoding it into a data URI first.
+   */
+  getResourcePath(path: string): string {
+    return this.app.vault.adapter.getResourcePath(path);
+  }
+
   async delete(path: string): Promise<void> {
     if (await this.exists(path)) {
       await this.app.vault.adapter.remove(path);

--- a/src/core/types/chat.ts
+++ b/src/core/types/chat.ts
@@ -20,8 +20,16 @@ export interface ImageAttachment {
   id: string;
   name: string;
   mediaType: ImageMediaType;
-  /** Base64 encoded image data - single source of truth. */
+  /**
+   * Base64 encoded image data.
+   *
+   * When `hash` is set the store holds the bytes and this is only an in-memory
+   * copy - it is dropped from session metadata and refilled on demand, so a
+   * caller that has just loaded a conversation must not assume it is present.
+   */
   data: string;
+  /** Content hash of the stored bytes, when the attachment store holds them. */
+  hash?: string;
   width?: number;
   height?: number;
   size: number;

--- a/src/features/chat/GrimoireView.ts
+++ b/src/features/chat/GrimoireView.ts
@@ -27,6 +27,7 @@ import { TabBar } from './tabs/TabBar';
 import { TabManager } from './tabs/TabManager';
 import type { ClosedTabSnapshot, TabData, TabId } from './tabs/types';
 import { normalizeMaxTabs } from './tabs/types';
+import { closeTopmostImageViewer } from './ui/imageViewerStack';
 import { ContextUsageMeter, getNextPermissionMode } from './ui/InputToolbar';
 import { requestTabRename } from './ui/RenameTabModal';
 import { buildAssistantResponseMetadata } from './utils/assistantResponseMetadata';
@@ -927,6 +928,11 @@ export class GrimoireView extends ItemView {
     this.scope = new Scope(this.app.scope);
     this.scope.register([], 'Escape', (e: KeyboardEvent) => {
       if (e.isComposing) return;
+      // A full-size image spoken for this Escape: closing it must not also
+      // cost the user the turn that is streaming behind it.
+      if (closeTopmostImageViewer()) {
+        return false;
+      }
       if (!e.defaultPrevented) {
         const activeTab = this.tabManager?.getActiveTab();
         if (activeTab?.state.isStreaming) {

--- a/src/features/chat/GrimoireView.ts
+++ b/src/features/chat/GrimoireView.ts
@@ -928,12 +928,12 @@ export class GrimoireView extends ItemView {
     this.scope = new Scope(this.app.scope);
     this.scope.register([], 'Escape', (e: KeyboardEvent) => {
       if (e.isComposing) return;
-      // A full-size image spoken for this Escape: closing it must not also
-      // cost the user the turn that is streaming behind it.
-      if (closeTopmostImageViewer()) {
-        return false;
-      }
       if (!e.defaultPrevented) {
+        // A full-size image spoken for this Escape: closing it must not also
+        // cost the user the turn that is streaming behind it.
+        if (closeTopmostImageViewer()) {
+          return false;
+        }
         const activeTab = this.tabManager?.getActiveTab();
         if (activeTab?.state.isStreaming) {
           activeTab.controllers.inputController?.cancelStreaming();

--- a/src/features/chat/controllers/InputController.ts
+++ b/src/features/chat/controllers/InputController.ts
@@ -1,5 +1,6 @@
 import { Notice } from 'obsidian';
 
+import { hydrateImages } from '../../../core/attachments/hydrateImages';
 import {
   type BuiltInCommand,
   detectBuiltInCommand,
@@ -423,6 +424,12 @@ export class InputController {
     // SDK handles expansion, $ARGUMENTS, @file references, and frontmatter options
     const images = imageOverride ?? imageContextManager?.getAttachedImages() ?? [];
     const imagesForMessage = images.length > 0 ? [...images] : undefined;
+    // A resend or a queued turn carries attachments straight off an existing
+    // message, whose bytes are left out of session metadata. The provider is
+    // about to write them to a file for the CLI, so refill them first.
+    if (plugin.storage?.attachments) {
+      await hydrateImages(imagesForMessage, plugin.storage.attachments);
+    }
     const isCompact = /^\/compact(\s|$)/i.test(content);
     plugin.recordDebugLog?.({
       data: {

--- a/src/features/chat/rendering/MessageRenderer.ts
+++ b/src/features/chat/rendering/MessageRenderer.ts
@@ -22,7 +22,7 @@ import {
   normalizeLatexDelimiters,
 } from '../../../utils/markdownMath';
 import { findRewindContext } from '../rewind';
-import { registerOpenImageViewer } from '../ui/imageViewerStack';
+import { closeTopmostImageViewer, registerOpenImageViewer } from '../ui/imageViewerStack';
 import { renderVaultSearchSources } from '../ui/VaultSearchSources';
 import { getAssistantResponseProviderLabel } from '../utils/assistantResponseMetadata';
 import { localizeReasoningLevel } from '../utils/reasoningDisplay';
@@ -946,16 +946,16 @@ export class MessageRenderer {
     const closeBtn = modal.createDiv({ cls: 'grimoire-image-modal-close' });
     closeBtn.setText('\u00D7');
 
-    // See the same handler in ImageContext: closing the viewer must not cost
-    // the user the streaming turn, which the viewer stack guarantees no
-    // matter which Escape listener the browser reaches first.
+    // See the same handler in ImageContext: the stack decides which viewer
+    // closes, and consuming the key here keeps it from also cancelling the
+    // streaming turn behind the overlay.
     const handleEsc = (e: KeyboardEvent) => {
       if (e.key !== 'Escape') {
         return;
       }
       e.preventDefault();
-      e.stopPropagation();
-      close();
+      e.stopImmediatePropagation();
+      closeTopmostImageViewer();
     };
 
     const unregisterViewer = registerOpenImageViewer(() => close());

--- a/src/features/chat/rendering/MessageRenderer.ts
+++ b/src/features/chat/rendering/MessageRenderer.ts
@@ -930,7 +930,7 @@ export class MessageRenderer {
    * Shows full-size image in modal overlay.
    */
   showFullImage(image: ImageAttachment): void {
-    const dataUri = `data:${image.mediaType};base64,${image.data}`;
+    const dataUri = this.imageSrc(image);
 
     const ownerDocument = this.messagesEl.ownerDocument ?? window.document;
     const overlay = ownerDocument.body.createDiv({ cls: 'grimoire-image-modal-overlay' });
@@ -977,8 +977,23 @@ export class MessageRenderer {
    * Sets image src from attachment data.
    */
   setImageSrc(imgEl: HTMLImageElement, image: ImageAttachment): void {
-    const dataUri = `data:${image.mediaType};base64,${image.data}`;
-    imgEl.setAttribute('src', dataUri);
+    imgEl.setAttribute('src', this.imageSrc(image));
+  }
+
+  /**
+   * Prefers the stored file over a data URI: the browser then caches one URL
+   * instead of the renderer rebuilding a megabyte of base64 on every click,
+   * and the image still resolves when the in-memory copy was never refilled.
+   */
+  private imageSrc(image: ImageAttachment): string {
+    if (image.hash) {
+      const stored = this.plugin.storage?.attachments?.resourcePath(image.hash, image.mediaType);
+      if (stored) {
+        return stored;
+      }
+    }
+
+    return `data:${image.mediaType};base64,${image.data}`;
   }
 
   // ============================================

--- a/src/features/chat/rendering/MessageRenderer.ts
+++ b/src/features/chat/rendering/MessageRenderer.ts
@@ -22,6 +22,7 @@ import {
   normalizeLatexDelimiters,
 } from '../../../utils/markdownMath';
 import { findRewindContext } from '../rewind';
+import { registerOpenImageViewer } from '../ui/imageViewerStack';
 import { renderVaultSearchSources } from '../ui/VaultSearchSources';
 import { getAssistantResponseProviderLabel } from '../utils/assistantResponseMetadata';
 import { localizeReasoningLevel } from '../utils/reasoningDisplay';
@@ -945,14 +946,23 @@ export class MessageRenderer {
     const closeBtn = modal.createDiv({ cls: 'grimoire-image-modal-close' });
     closeBtn.setText('\u00D7');
 
+    // See the same handler in ImageContext: closing the viewer must not cost
+    // the user the streaming turn, which the viewer stack guarantees no
+    // matter which Escape listener the browser reaches first.
     const handleEsc = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') {
-        close();
+      if (e.key !== 'Escape') {
+        return;
       }
+      e.preventDefault();
+      e.stopPropagation();
+      close();
     };
 
+    const unregisterViewer = registerOpenImageViewer(() => close());
+
     const close = () => {
-      ownerDocument.removeEventListener('keydown', handleEsc);
+      unregisterViewer();
+      ownerDocument.removeEventListener('keydown', handleEsc, true);
       overlay.remove();
     };
 
@@ -960,7 +970,7 @@ export class MessageRenderer {
     overlay.addEventListener('click', (e) => {
       if (e.target === overlay) close();
     });
-    ownerDocument.addEventListener('keydown', handleEsc);
+    ownerDocument.addEventListener('keydown', handleEsc, true);
   }
 
   /**

--- a/src/features/chat/tabs/Tab.ts
+++ b/src/features/chat/tabs/Tab.ts
@@ -50,6 +50,7 @@ import { SubagentManager } from '../services/SubagentManager';
 import { ChatState } from '../state/ChatState';
 import { BangBashModeManager as BangBashModeManagerClass } from '../ui/BangBashModeManager';
 import { RuntimeContextActivityView } from '../ui/context/RuntimeContextActivity';
+import { closeTopmostImageViewer } from '../ui/imageViewerStack';
 import { createInputToolbar } from '../ui/InputToolbar';
 import { InstructionModeManager as InstructionModeManagerClass } from '../ui/InstructionModeManager';
 import { NavigationSidebar } from '../ui/NavigationSidebar';
@@ -1545,10 +1546,17 @@ export function wireTabInputEvents(tab: TabData, plugin: GrimoirePlugin): void {
     }
 
     // Check !e.isComposing for IME support (Chinese, Japanese, Korean, etc.)
-    if (e.key === 'Escape' && !e.isComposing && state.isStreaming) {
-      e.preventDefault();
-      controllers.inputController?.cancelStreaming();
-      return;
+    if (e.key === 'Escape' && !e.isComposing) {
+      // An open image viewer owns Escape until it is closed.
+      if (closeTopmostImageViewer()) {
+        e.preventDefault();
+        return;
+      }
+      if (state.isStreaming) {
+        e.preventDefault();
+        controllers.inputController?.cancelStreaming();
+        return;
+      }
     }
 
     if (shouldSendMessageFromEnterKey(e, plugin.settings)) {

--- a/src/features/chat/tabs/tabContextUI.ts
+++ b/src/features/chat/tabs/tabContextUI.ts
@@ -339,7 +339,8 @@ export function initializeContextManagers(tab: TabData, plugin: GrimoirePlugin):
         tab.renderer?.scrollToBottomIfNeeded();
       },
     },
-    dom.contextRowEl
+    dom.contextRowEl,
+    plugin.storage?.attachments,
   );
 }
 

--- a/src/features/chat/ui/ImageContext.ts
+++ b/src/features/chat/ui/ImageContext.ts
@@ -1,6 +1,8 @@
 import { Notice } from 'obsidian';
 import * as path from 'path';
 
+import type { AttachmentStore } from '../../../core/attachments/AttachmentStore';
+import { prepareImageForStore } from '../../../core/attachments/prepareImage';
 import type { ImageAttachment, ImageMediaType } from '../../../core/types';
 import { t } from '../../../i18n/i18n';
 import { closeTopmostImageViewer, registerOpenImageViewer } from './imageViewerStack';
@@ -36,13 +38,16 @@ export class ImageContextManager {
   private attachedImages: Map<string, ImageAttachment> = new Map();
   private enabled = true;
   private fullImageClose: (() => void) | null = null;
+  private readonly attachments: AttachmentStore | null;
 
   constructor(
     containerEl: HTMLElement,
     inputEl: HTMLTextAreaElement,
     callbacks: ImageContextCallbacks,
-    previewContainerEl?: HTMLElement
+    previewContainerEl?: HTMLElement,
+    attachments?: AttachmentStore,
   ) {
+    this.attachments = attachments ?? null;
     this.containerEl = containerEl;
     this.previewContainerEl = previewContainerEl ?? containerEl;
     this.inputEl = inputEl;
@@ -250,16 +255,7 @@ export class ImageContextManager {
     }
 
     try {
-      const base64 = await this.fileToBase64(file);
-
-      const attachment: ImageAttachment = {
-        id: this.generateId(),
-        name: file.name || `image-${Date.now()}.${mediaType.split('/')[1]}`,
-        mediaType,
-        data: base64,
-        size: file.size,
-        source,
-      };
+      const attachment = await this.buildAttachment(file, mediaType, source);
 
       this.attachedImages.set(attachment.id, attachment);
       this.updateImagePreview();
@@ -271,10 +267,46 @@ export class ImageContextManager {
     }
   }
 
-  private async fileToBase64(file: File): Promise<string> {
-    const arrayBuffer = await file.arrayBuffer();
-    const buffer = Buffer.from(arrayBuffer);
-    return buffer.toString('base64');
+  /**
+   * Scales the image down to what a provider will actually look at, hands the
+   * bytes to the store, and keeps only a reference plus an in-memory copy.
+   *
+   * Without a store - the shape the unit tests construct - the attachment keeps
+   * the original bytes and behaves as it always did.
+   */
+  private async buildAttachment(
+    file: File,
+    mediaType: ImageMediaType,
+    source: 'paste' | 'drop',
+  ): Promise<ImageAttachment> {
+    const name = file.name || `image-${Date.now()}.${mediaType.split('/')[1]}`;
+
+    if (!this.attachments) {
+      const bytes = await file.arrayBuffer();
+      return {
+        id: this.generateId(),
+        name,
+        mediaType,
+        data: Buffer.from(bytes).toString('base64'),
+        size: file.size,
+        source,
+      };
+    }
+
+    const prepared = await prepareImageForStore(await file.arrayBuffer(), mediaType);
+    const stored = await this.attachments.put(prepared.bytes, prepared.mediaType);
+
+    return {
+      id: this.generateId(),
+      name: prepared.rescaled ? renameForMediaType(name, prepared.mediaType) : name,
+      mediaType: prepared.mediaType,
+      data: Buffer.from(prepared.bytes).toString('base64'),
+      hash: stored.hash,
+      size: stored.size,
+      width: prepared.width,
+      height: prepared.height,
+      source,
+    };
   }
 
   // ============================================
@@ -422,4 +454,11 @@ export class ImageContextManager {
     }
     new Notice(userMessage);
   }
+}
+
+/** Keeps the displayed file name honest when a re-encode changed the format. */
+function renameForMediaType(name: string, mediaType: ImageMediaType): string {
+  const extension = mediaType.split('/')[1];
+  const dot = name.lastIndexOf('.');
+  return dot > 0 ? `${name.slice(0, dot)}.${extension}` : `${name}.${extension}`;
 }

--- a/src/features/chat/ui/ImageContext.ts
+++ b/src/features/chat/ui/ImageContext.ts
@@ -3,7 +3,7 @@ import * as path from 'path';
 
 import type { ImageAttachment, ImageMediaType } from '../../../core/types';
 import { t } from '../../../i18n/i18n';
-import { registerOpenImageViewer } from './imageViewerStack';
+import { closeTopmostImageViewer, registerOpenImageViewer } from './imageViewerStack';
 
 const MAX_IMAGE_SIZE = 5 * 1024 * 1024;
 
@@ -362,16 +362,16 @@ export class ImageContextManager {
     closeBtn.setText('\u00D7');
 
     // Escape closes the viewer and must not also cancel the streaming turn.
-    // This listener is only one of the two ways that happens: the chat's own
-    // Escape handlers consult the viewer stack before cancelling, so the turn
-    // survives whichever listener the browser reaches first.
+    // The stack, not this listener, decides which viewer closes: every viewer
+    // registers one of these on the same document, and `stopImmediatePropagation`
+    // keeps the siblings from closing a second viewer on one key press.
     const handleEsc = (e: KeyboardEvent) => {
       if (e.key !== 'Escape') {
         return;
       }
       e.preventDefault();
-      e.stopPropagation();
-      close();
+      e.stopImmediatePropagation();
+      closeTopmostImageViewer();
     };
 
     const unregisterViewer = registerOpenImageViewer(() => close());

--- a/src/features/chat/ui/ImageContext.ts
+++ b/src/features/chat/ui/ImageContext.ts
@@ -7,7 +7,16 @@ import type { ImageAttachment, ImageMediaType } from '../../../core/types';
 import { t } from '../../../i18n/i18n';
 import { closeTopmostImageViewer, registerOpenImageViewer } from './imageViewerStack';
 
+/** Largest attachment that may be stored and sent. */
 const MAX_IMAGE_SIZE = 5 * 1024 * 1024;
+/**
+ * Largest file worth opening at all.
+ *
+ * Scaling happens before the stored size is judged, so a 15 MB screenshot is
+ * now fine - it becomes a few hundred kilobytes. This cap only keeps a file
+ * that could never help from being read into memory to find that out.
+ */
+const MAX_SOURCE_IMAGE_SIZE = 25 * 1024 * 1024;
 
 const IMAGE_EXTENSIONS: Record<string, ImageMediaType> = {
   '.jpg': 'image/jpeg',
@@ -243,8 +252,8 @@ export class ImageContextManager {
       return false;
     }
 
-    if (file.size > MAX_IMAGE_SIZE) {
-      this.notifyImageError(t('chat.ui.images.sizeLimit', { size: this.formatSize(MAX_IMAGE_SIZE) }));
+    if (file.size > MAX_SOURCE_IMAGE_SIZE) {
+      this.notifyImageError(t('chat.ui.images.sizeLimit', { size: this.formatSize(MAX_SOURCE_IMAGE_SIZE) }));
       return false;
     }
 
@@ -256,6 +265,12 @@ export class ImageContextManager {
 
     try {
       const attachment = await this.buildAttachment(file, mediaType, source);
+      if (!attachment) {
+        // Scaling could not bring it under the limit - a format we must not
+        // re-encode, or an image whose pixels are simply that heavy.
+        this.notifyImageError(t('chat.ui.images.sizeLimit', { size: this.formatSize(MAX_IMAGE_SIZE) }));
+        return false;
+      }
 
       this.attachedImages.set(attachment.id, attachment);
       this.updateImagePreview();
@@ -278,10 +293,13 @@ export class ImageContextManager {
     file: File,
     mediaType: ImageMediaType,
     source: 'paste' | 'drop',
-  ): Promise<ImageAttachment> {
+  ): Promise<ImageAttachment | null> {
     const name = file.name || `image-${Date.now()}.${mediaType.split('/')[1]}`;
 
     if (!this.attachments) {
+      if (file.size > MAX_IMAGE_SIZE) {
+        return null;
+      }
       const bytes = await file.arrayBuffer();
       return {
         id: this.generateId(),
@@ -294,6 +312,10 @@ export class ImageContextManager {
     }
 
     const prepared = await prepareImageForStore(await file.arrayBuffer(), mediaType);
+    if (prepared.bytes.byteLength > MAX_IMAGE_SIZE) {
+      return null;
+    }
+
     const stored = await this.attachments.put(prepared.bytes, prepared.mediaType);
 
     return {

--- a/src/features/chat/ui/ImageContext.ts
+++ b/src/features/chat/ui/ImageContext.ts
@@ -3,6 +3,7 @@ import * as path from 'path';
 
 import type { ImageAttachment, ImageMediaType } from '../../../core/types';
 import { t } from '../../../i18n/i18n';
+import { registerOpenImageViewer } from './imageViewerStack';
 
 const MAX_IMAGE_SIZE = 5 * 1024 * 1024;
 
@@ -360,14 +361,24 @@ export class ImageContextManager {
     });
     closeBtn.setText('\u00D7');
 
+    // Escape closes the viewer and must not also cancel the streaming turn.
+    // This listener is only one of the two ways that happens: the chat's own
+    // Escape handlers consult the viewer stack before cancelling, so the turn
+    // survives whichever listener the browser reaches first.
     const handleEsc = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') {
-        close();
+      if (e.key !== 'Escape') {
+        return;
       }
+      e.preventDefault();
+      e.stopPropagation();
+      close();
     };
 
+    const unregisterViewer = registerOpenImageViewer(() => close());
+
     const close = () => {
-      ownerDocument.removeEventListener('keydown', handleEsc);
+      unregisterViewer();
+      ownerDocument.removeEventListener('keydown', handleEsc, true);
       overlay.remove();
       if (this.fullImageClose === close) {
         this.fullImageClose = null;
@@ -379,7 +390,7 @@ export class ImageContextManager {
     overlay.addEventListener('click', (e) => {
       if (e.target === overlay) close();
     });
-    ownerDocument.addEventListener('keydown', handleEsc);
+    ownerDocument.addEventListener('keydown', handleEsc, true);
   }
 
   private generateId(): string {

--- a/src/features/chat/ui/imageViewerStack.ts
+++ b/src/features/chat/ui/imageViewerStack.ts
@@ -1,0 +1,65 @@
+/**
+ * Who owns Escape while a full-size image is open.
+ *
+ * Escape has two meanings in the chat view: close the image viewer, and
+ * cancel the streaming turn. The viewer's meaning must win while it is open,
+ * and the first attempt to arrange that - a capture-phase document listener
+ * that called `preventDefault` - did not, because it still depended on
+ * running before Obsidian's own document listener, which is registered when
+ * the app boots and which this plugin does not control.
+ *
+ * Racing that listener is the wrong shape of solution: whoever wins is a
+ * property of registration order rather than of what the key means. So the
+ * cancel paths ask this module instead. An open viewer is registered here,
+ * and every Escape handler that would cancel a turn closes the topmost viewer
+ * first and stops. The outcome no longer depends on which listener runs
+ * first: if the viewer's own listener wins it closes and consumes the key,
+ * and if the cancel path wins it closes the viewer and declines to cancel.
+ *
+ * The stack, rather than a single slot, keeps nesting honest - Escape closes
+ * one viewer at a time, in reverse order of opening.
+ */
+
+type CloseViewer = () => void;
+
+const openViewers: CloseViewer[] = [];
+
+/**
+ * Registers an open viewer and returns the function that unregisters it.
+ * The returned function is safe to call more than once.
+ */
+export function registerOpenImageViewer(close: CloseViewer): () => void {
+  openViewers.push(close);
+  return () => {
+    const index = openViewers.lastIndexOf(close);
+    if (index !== -1) {
+      openViewers.splice(index, 1);
+    }
+  };
+}
+
+/** True when at least one full-size viewer is open. */
+export function hasOpenImageViewer(): boolean {
+  return openViewers.length > 0;
+}
+
+/**
+ * Closes the most recently opened viewer.
+ *
+ * Returns true when a viewer was closed, which the caller reads as "Escape is
+ * spoken for - do not also cancel the turn".
+ */
+export function closeTopmostImageViewer(): boolean {
+  const close = openViewers[openViewers.length - 1];
+  if (!close) {
+    return false;
+  }
+  // `close` unregisters itself; popping here too would drop a second viewer.
+  close();
+  return true;
+}
+
+/** Test seam: drops any viewer left registered by a previous case. */
+export function resetOpenImageViewers(): void {
+  openViewers.length = 0;
+}

--- a/src/features/chat/ui/imageViewerStack.ts
+++ b/src/features/chat/ui/imageViewerStack.ts
@@ -9,12 +9,11 @@
  * the app boots and which this plugin does not control.
  *
  * Racing that listener is the wrong shape of solution: whoever wins is a
- * property of registration order rather than of what the key means. So the
- * cancel paths ask this module instead. An open viewer is registered here,
- * and every Escape handler that would cancel a turn closes the topmost viewer
- * first and stops. The outcome no longer depends on which listener runs
- * first: if the viewer's own listener wins it closes and consumes the key,
- * and if the cancel path wins it closes the viewer and declines to cancel.
+ * property of registration order rather than of what the key means. So every
+ * Escape handler - the viewers' own included - asks this module instead. The
+ * outcome no longer depends on which listener runs first: whoever gets there
+ * closes the topmost viewer, and a cancel path that finds one open declines
+ * to cancel.
  *
  * The stack, rather than a single slot, keeps nesting honest - Escape closes
  * one viewer at a time, in reverse order of opening.
@@ -38,11 +37,6 @@ export function registerOpenImageViewer(close: CloseViewer): () => void {
   };
 }
 
-/** True when at least one full-size viewer is open. */
-export function hasOpenImageViewer(): boolean {
-  return openViewers.length > 0;
-}
-
 /**
  * Closes the most recently opened viewer.
  *
@@ -50,11 +44,16 @@ export function hasOpenImageViewer(): boolean {
  * spoken for - do not also cancel the turn".
  */
 export function closeTopmostImageViewer(): boolean {
-  const close = openViewers[openViewers.length - 1];
+  // Popped before closing so that a `close` which fails to unregister itself
+  // cannot leave a dead entry behind - one would swallow every later Escape,
+  // and the turn could no longer be cancelled at all. The viewer's own
+  // unregister looks the entry up by identity and finds nothing, so removing
+  // it here drops no other viewer.
+  const close = openViewers.pop();
   if (!close) {
     return false;
   }
-  // `close` unregisters itself; popping here too would drop a second viewer.
+
   close();
   return true;
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,6 +13,7 @@ import { readBundledChangelog } from './app/changelog/source';
 import type { ChangelogRelease } from './app/changelog/types';
 import { DEFAULT_GRIMOIRE_SETTINGS } from './app/settings/defaultSettings';
 import { SharedStorageService } from './app/storage/SharedStorageService';
+import { collectReferencedHashes, hydrateImageAttachments } from './core/attachments/hydrateImages';
 import {
   applyAssistantResponseMetadataToMessages,
   applyVaultSearchContextsToMessages,
@@ -846,6 +847,9 @@ export default class GrimoirePlugin extends Plugin {
     await ProviderRegistry
       .getConversationHistoryService(conversation.providerId)
       .hydrateConversationHistory(conversation, getVaultPath(this.app));
+    // Attachment bytes are left out of metadata, so they come back here rather
+    // than for every conversation in the vault at startup.
+    await hydrateImageAttachments(conversation.messages, this.storage.attachments);
     applyVaultSearchContextsToMessages(
       conversation.messages,
       conversation.vaultSearchContexts,
@@ -904,6 +908,7 @@ export default class GrimoirePlugin extends Plugin {
       .deleteConversationSession(conversation, getVaultPath(this.app));
 
     await this.storage.sessions.deleteMetadata(id);
+    await this.collectAttachmentGarbage();
 
     for (const view of this.getAllViews()) {
       const tabManager = view.getTabManager();
@@ -948,17 +953,22 @@ export default class GrimoirePlugin extends Plugin {
     await this.storage.sessions.saveMetadata(
       this.storage.sessions.toSessionMetadata(conversation)
     );
+  }
 
-    // Clear image data from memory after save (data is persisted by SDK).
-    // Skip for pending forks: their deep-cloned images aren't in SDK storage yet.
-    if (!ProviderRegistry.getConversationHistoryService(conversation.providerId).isPendingForkConversation(conversation)) {
-      for (const msg of conversation.messages) {
-        if (msg.images) {
-          for (const img of msg.images) {
-            img.data = '';
-          }
-        }
-      }
+  /**
+   * Drops stored attachment files nothing references any more.
+   *
+   * The reachable set is read from metadata rather than from the in-memory
+   * conversations: transcript hydration replaces a conversation's messages with
+   * provider-derived ones that carry no hash, so memory is not a complete
+   * record of what is still referenced.
+   */
+  private async collectAttachmentGarbage(): Promise<void> {
+    try {
+      const metadata = await this.storage.sessions.listMetadata();
+      await this.storage.attachments.collectGarbage(collectReferencedHashes(metadata));
+    } catch {
+      // Reclaiming disk is never worth failing a delete over.
     }
   }
 

--- a/src/providers/antigravity/runtime/AntigravityImageAttachments.ts
+++ b/src/providers/antigravity/runtime/AntigravityImageAttachments.ts
@@ -179,7 +179,9 @@ export function attachAntigravityImages(
     return noop;
   }
 
-  const usable = images.filter((image) => image.mediaType.startsWith('image/'));
+  // Without bytes there is nothing to write: `Buffer.from('', 'base64')` would
+  // put a zero-byte file in front of agy and call it a screenshot.
+  const usable = images.filter((image) => image.mediaType.startsWith('image/') && !!image.data);
   if (usable.length === 0) {
     return noop;
   }

--- a/src/providers/codex/runtime/CodexChatRuntime.ts
+++ b/src/providers/codex/runtime/CodexChatRuntime.ts
@@ -1381,7 +1381,9 @@ export class CodexChatRuntime implements ChatRuntime {
         tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'grimoire-codex-images-'));
         for (let i = 0; i < images.length; i++) {
           const img = images[i];
-          if (!img.mediaType.startsWith('image/')) continue;
+          // No bytes means no attachment: writing `Buffer.from('', 'base64')`
+          // would hand Codex a zero-byte file as though it were an image.
+          if (!img.mediaType.startsWith('image/') || !img.data) continue;
 
           const filename = toAttachmentFilename(img, i);
           const filePath = path.join(tempDir, `${i + 1}-${filename}`);

--- a/tests/helpers/mockElement.ts
+++ b/tests/helpers/mockElement.ts
@@ -82,8 +82,8 @@ export interface MockElement {
     };
     activeElement?: any;
     body?: any;
-    addEventListener?: (event: string, handler: (...args: any[]) => void) => void;
-    removeEventListener?: (event: string, handler: (...args: any[]) => void) => void;
+    addEventListener?: (event: string, handler: (...args: any[]) => void, options?: any) => void;
+    removeEventListener?: (event: string, handler: (...args: any[]) => void, options?: any) => void;
     dispatchEvent?: (eventOrType: string | { type: string; [key: string]: any }) => void;
     createElement: (tagName: string) => MockElement;
     createElementNS: (namespace: string, tagName: string) => MockElement;
@@ -218,20 +218,24 @@ export function createMockEl(tag = 'div'): any {
     get body() {
       return currentDocument()?.body ?? createMockEl('body');
     },
-    addEventListener(event: string, handler: (...args: any[]) => void) {
+    // `options` is forwarded rather than dropped: capture-phase registration
+    // is the difference between a handler that sees a key first and one that
+    // sees it after the app has acted on it, and a helper that swallows the
+    // argument makes that difference invisible to every test.
+    addEventListener(event: string, handler: (...args: any[]) => void, options?: any) {
       const document = currentDocument();
       if (document?.addEventListener) {
-        document.addEventListener(event, handler);
+        document.addEventListener(event, handler, options);
         return;
       }
       const handlers = documentEventListeners.get(event) ?? [];
       handlers.push(handler);
       documentEventListeners.set(event, handlers);
     },
-    removeEventListener(event: string, handler: (...args: any[]) => void) {
+    removeEventListener(event: string, handler: (...args: any[]) => void, options?: any) {
       const document = currentDocument();
       if (document?.removeEventListener) {
-        document.removeEventListener(event, handler);
+        document.removeEventListener(event, handler, options);
         return;
       }
       const handlers = documentEventListeners.get(event) ?? [];

--- a/tests/unit/core/attachments/AttachmentStore.test.ts
+++ b/tests/unit/core/attachments/AttachmentStore.test.ts
@@ -1,0 +1,134 @@
+import {
+  type AttachmentFileStore,
+  attachmentPath,
+  ATTACHMENTS_FOLDER,
+  AttachmentStore,
+  hashBytes,
+  hashFromAttachmentPath,
+} from '@/core/attachments/AttachmentStore';
+
+function createFiles(): AttachmentFileStore & { written: Map<string, ArrayBuffer> } {
+  const written = new Map<string, ArrayBuffer>();
+  return {
+    written,
+    exists: jest.fn(async (path: string) => written.has(path)),
+    readBinary: jest.fn(async (path: string) => {
+      const data = written.get(path);
+      if (!data) throw new Error(`missing ${path}`);
+      return data;
+    }),
+    writeBinary: jest.fn(async (path: string, data: ArrayBuffer) => {
+      written.set(path, data);
+    }),
+    delete: jest.fn(async (path: string) => {
+      written.delete(path);
+    }),
+    listFiles: jest.fn(async () => Array.from(written.keys())),
+    getResourcePath: jest.fn((path: string) => `app://vault/${path}`),
+  };
+}
+
+const bytesOf = (text: string): ArrayBuffer => {
+  const buffer = Buffer.from(text, 'utf-8');
+  return buffer.buffer.slice(buffer.byteOffset, buffer.byteOffset + buffer.byteLength);
+};
+
+describe('AttachmentStore', () => {
+  it('writes the bytes under their content hash', async () => {
+    const files = createFiles();
+    const store = new AttachmentStore(files);
+    const data = bytesOf('screenshot');
+
+    const stored = await store.put(data, 'image/webp');
+
+    expect(stored.hash).toBe(hashBytes(data));
+    expect(stored.size).toBe(data.byteLength);
+    expect(files.written.has(attachmentPath(stored.hash, 'image/webp'))).toBe(true);
+  });
+
+  it('stores the same content once, however many conversations use it', async () => {
+    const files = createFiles();
+    const store = new AttachmentStore(files);
+
+    const first = await store.put(bytesOf('same'), 'image/png');
+    const second = await store.put(bytesOf('same'), 'image/png');
+
+    expect(second.hash).toBe(first.hash);
+    expect(files.writeBinary).toHaveBeenCalledTimes(1);
+    expect(files.written.size).toBe(1);
+  });
+
+  it('reads back what it stored', async () => {
+    const files = createFiles();
+    const store = new AttachmentStore(files);
+    const stored = await store.put(bytesOf('payload'), 'image/png');
+
+    const read = await store.read(stored.hash, 'image/png');
+
+    expect(read && Buffer.from(read).toString('utf-8')).toBe('payload');
+  });
+
+  it('returns null for content it does not hold', async () => {
+    const store = new AttachmentStore(createFiles());
+
+    expect(await store.read('a'.repeat(64), 'image/png')).toBeNull();
+  });
+
+  it('returns null rather than throwing when the file cannot be read', async () => {
+    const files = createFiles();
+    files.exists = jest.fn().mockResolvedValue(true);
+    files.readBinary = jest.fn().mockRejectedValue(new Error('disk gone'));
+
+    const read = await new AttachmentStore(files).read('b'.repeat(64), 'image/png');
+
+    expect(read).toBeNull();
+  });
+
+  it('hands the renderer a resource URL instead of a data URI', async () => {
+    const files = createFiles();
+    const store = new AttachmentStore(files);
+
+    expect(store.resourcePath('c'.repeat(64), 'image/webp'))
+      .toBe(`app://vault/${ATTACHMENTS_FOLDER}/${'c'.repeat(64)}.webp`);
+  });
+
+  describe('collectGarbage', () => {
+    it('deletes only what nothing references', async () => {
+      const files = createFiles();
+      const store = new AttachmentStore(files);
+      const kept = await store.put(bytesOf('kept'), 'image/png');
+      const dropped = await store.put(bytesOf('dropped'), 'image/png');
+
+      const removed = await store.collectGarbage(new Set([kept.hash]));
+
+      expect(removed).toBe(1);
+      expect(files.written.has(attachmentPath(kept.hash, 'image/png'))).toBe(true);
+      expect(files.written.has(attachmentPath(dropped.hash, 'image/png'))).toBe(false);
+    });
+
+    it('leaves files it does not recognise alone', async () => {
+      const files = createFiles();
+      files.written.set(`${ATTACHMENTS_FOLDER}/notes.md`, bytesOf('x'));
+      const store = new AttachmentStore(files);
+
+      const removed = await store.collectGarbage(new Set());
+
+      expect(removed).toBe(0);
+      expect(files.delete).not.toHaveBeenCalled();
+    });
+  });
+});
+
+describe('hashFromAttachmentPath', () => {
+  it('reads the hash out of a stored file name', () => {
+    const hash = 'd'.repeat(64);
+
+    expect(hashFromAttachmentPath(`${ATTACHMENTS_FOLDER}/${hash}.webp`)).toBe(hash);
+  });
+
+  it('rejects a name that is not ours', () => {
+    expect(hashFromAttachmentPath(`${ATTACHMENTS_FOLDER}/notes.md`)).toBeNull();
+    expect(hashFromAttachmentPath(`${ATTACHMENTS_FOLDER}/short.png`)).toBeNull();
+    expect(hashFromAttachmentPath(`${ATTACHMENTS_FOLDER}/${'D'.repeat(64)}.png`)).toBeNull();
+  });
+});

--- a/tests/unit/core/attachments/hydrateImages.test.ts
+++ b/tests/unit/core/attachments/hydrateImages.test.ts
@@ -1,5 +1,9 @@
 import type { AttachmentStore } from '@/core/attachments/AttachmentStore';
-import { collectReferencedHashes, hydrateImageAttachments } from '@/core/attachments/hydrateImages';
+import {
+  collectReferencedHashes,
+  hydrateImageAttachments,
+  hydrateImages,
+} from '@/core/attachments/hydrateImages';
 import type { ChatMessage } from '@/core/types';
 
 const HASH = 'a'.repeat(64);
@@ -69,6 +73,24 @@ describe('hydrateImageAttachments', () => {
     const store = { read: jest.fn() } as unknown as AttachmentStore;
 
     await expect(hydrateImageAttachments(undefined, store)).resolves.toBeUndefined();
+  });
+});
+
+describe('hydrateImages', () => {
+  it('refills the attachments of a turn before a provider writes them to disk', async () => {
+    const store = { read: jest.fn().mockResolvedValue(bytesOf('bytes')) } as unknown as AttachmentStore;
+    const images = messageWithImage({ hash: HASH }).images!;
+
+    await hydrateImages(images, store);
+
+    expect(Buffer.from(images[0].data, 'base64').toString()).toBe('bytes');
+  });
+
+  it('tolerates a turn with no attachments', async () => {
+    const store = { read: jest.fn() } as unknown as AttachmentStore;
+
+    await expect(hydrateImages(undefined, store)).resolves.toBeUndefined();
+    expect(store.read).not.toHaveBeenCalled();
   });
 });
 

--- a/tests/unit/core/attachments/hydrateImages.test.ts
+++ b/tests/unit/core/attachments/hydrateImages.test.ts
@@ -1,0 +1,95 @@
+import type { AttachmentStore } from '@/core/attachments/AttachmentStore';
+import { collectReferencedHashes, hydrateImageAttachments } from '@/core/attachments/hydrateImages';
+import type { ChatMessage } from '@/core/types';
+
+const HASH = 'a'.repeat(64);
+
+const bytesOf = (text: string): ArrayBuffer => {
+  const buffer = Buffer.from(text, 'utf-8');
+  return buffer.buffer.slice(buffer.byteOffset, buffer.byteOffset + buffer.byteLength);
+};
+
+function messageWithImage(overrides: Record<string, unknown>): ChatMessage {
+  return {
+    id: 'm1',
+    role: 'user',
+    content: 'look',
+    timestamp: 0,
+    images: [{
+      id: 'img-1',
+      name: 'shot.webp',
+      mediaType: 'image/webp',
+      data: '',
+      size: 5,
+      source: 'paste',
+      ...overrides,
+    }],
+  } as unknown as ChatMessage;
+}
+
+describe('hydrateImageAttachments', () => {
+  it('refills the bytes a stored attachment left out of metadata', async () => {
+    const store = { read: jest.fn().mockResolvedValue(bytesOf('hello')) } as unknown as AttachmentStore;
+    const messages = [messageWithImage({ hash: HASH })];
+
+    await hydrateImageAttachments(messages, store);
+
+    expect(store.read).toHaveBeenCalledWith(HASH, 'image/webp');
+    expect(Buffer.from(messages[0].images![0].data, 'base64').toString()).toBe('hello');
+  });
+
+  it('leaves an attachment that still carries its own bytes alone', async () => {
+    const store = { read: jest.fn() } as unknown as AttachmentStore;
+    const messages = [messageWithImage({ hash: HASH, data: 'aGk=' })];
+
+    await hydrateImageAttachments(messages, store);
+
+    expect(store.read).not.toHaveBeenCalled();
+    expect(messages[0].images![0].data).toBe('aGk=');
+  });
+
+  it('ignores an attachment the store never held', async () => {
+    const store = { read: jest.fn() } as unknown as AttachmentStore;
+    const messages = [messageWithImage({})];
+
+    await hydrateImageAttachments(messages, store);
+
+    expect(store.read).not.toHaveBeenCalled();
+  });
+
+  it('opens the conversation anyway when the stored file is gone', async () => {
+    const store = { read: jest.fn().mockResolvedValue(null) } as unknown as AttachmentStore;
+    const messages = [messageWithImage({ hash: HASH })];
+
+    await expect(hydrateImageAttachments(messages, store)).resolves.toBeUndefined();
+    expect(messages[0].images![0].data).toBe('');
+  });
+
+  it('tolerates a conversation with no messages', async () => {
+    const store = { read: jest.fn() } as unknown as AttachmentStore;
+
+    await expect(hydrateImageAttachments(undefined, store)).resolves.toBeUndefined();
+  });
+});
+
+describe('collectReferencedHashes', () => {
+  it('gathers every hash still referenced, across conversations', () => {
+    const other = 'b'.repeat(64);
+
+    const hashes = collectReferencedHashes([
+      { messages: [messageWithImage({ hash: HASH })] },
+      { messages: [messageWithImage({ hash: other })] },
+      { messages: [messageWithImage({ hash: HASH })] },
+    ]);
+
+    expect(hashes).toEqual(new Set([HASH, other]));
+  });
+
+  it('skips attachments that were never stored', () => {
+    expect(collectReferencedHashes([{ messages: [messageWithImage({})] }])).toEqual(new Set());
+  });
+
+  it('handles conversations without messages', () => {
+    expect(collectReferencedHashes([{}, { messages: [] }])).toEqual(new Set());
+  });
+});

--- a/tests/unit/core/attachments/imageScaling.test.ts
+++ b/tests/unit/core/attachments/imageScaling.test.ts
@@ -1,0 +1,72 @@
+import {
+  exceedsMaxEdge,
+  fitWithin,
+  MAX_ATTACHMENT_EDGE,
+  shouldRescale,
+} from '@/core/attachments/imageScaling';
+
+describe('fitWithin', () => {
+  it('leaves an image already within the limit untouched', () => {
+    expect(fitWithin({ width: 1200, height: 800 }, 2000)).toEqual({ width: 1200, height: 800 });
+  });
+
+  it('leaves an image exactly on the limit untouched', () => {
+    expect(fitWithin({ width: 2000, height: 1125 }, 2000)).toEqual({ width: 2000, height: 1125 });
+  });
+
+  it('scales a landscape image by its width', () => {
+    expect(fitWithin({ width: 3840, height: 2160 }, 2000)).toEqual({ width: 2000, height: 1125 });
+  });
+
+  it('scales a portrait image by its height', () => {
+    expect(fitWithin({ width: 2160, height: 3840 }, 2000)).toEqual({ width: 1125, height: 2000 });
+  });
+
+  it('keeps the aspect ratio of an extreme panorama', () => {
+    const fitted = fitWithin({ width: 10000, height: 200 }, 2000);
+
+    expect(fitted.width).toBe(2000);
+    expect(fitted.height).toBe(40);
+  });
+
+  it('never returns a zero dimension', () => {
+    const fitted = fitWithin({ width: 100000, height: 3 }, 2000);
+
+    expect(fitted.width).toBe(2000);
+    expect(fitted.height).toBeGreaterThanOrEqual(1);
+  });
+
+  it('degrades safely on a nonsensical limit', () => {
+    expect(fitWithin({ width: 100, height: 100 }, 0)).toEqual({ width: 1, height: 1 });
+  });
+});
+
+describe('exceedsMaxEdge', () => {
+  it('is true when either side is over the limit', () => {
+    expect(exceedsMaxEdge({ width: 2001, height: 10 }, 2000)).toBe(true);
+    expect(exceedsMaxEdge({ width: 10, height: 2001 }, 2000)).toBe(true);
+  });
+
+  it('is false on the limit', () => {
+    expect(exceedsMaxEdge({ width: 2000, height: 2000 }, 2000)).toBe(false);
+  });
+});
+
+describe('shouldRescale', () => {
+  it('rescales an oversized screenshot', () => {
+    expect(shouldRescale('image/png', { width: 3840, height: 2160 })).toBe(true);
+  });
+
+  it('leaves an image within the budget alone', () => {
+    expect(shouldRescale('image/png', { width: 1600, height: 900 })).toBe(false);
+  });
+
+  it('never rescales a GIF, because the round-trip would drop the animation', () => {
+    expect(shouldRescale('image/gif', { width: 4000, height: 4000 })).toBe(false);
+  });
+
+  it('defaults to the shared budget', () => {
+    expect(shouldRescale('image/jpeg', { width: MAX_ATTACHMENT_EDGE + 1, height: 10 })).toBe(true);
+    expect(shouldRescale('image/jpeg', { width: MAX_ATTACHMENT_EDGE, height: 10 })).toBe(false);
+  });
+});

--- a/tests/unit/core/attachments/prepareImage.test.ts
+++ b/tests/unit/core/attachments/prepareImage.test.ts
@@ -1,0 +1,97 @@
+import type { ImageCodec } from '@/core/attachments/imageEncoder';
+import { prepareImageForStore } from '@/core/attachments/prepareImage';
+
+const bytes = (length: number): ArrayBuffer => new Uint8Array(length).buffer;
+
+function createCodec(
+  decoded: { width: number; height: number },
+  encodedLength: number,
+): ImageCodec & { encode: jest.Mock } {
+  return {
+    decode: jest.fn().mockResolvedValue({ ...decoded, source: 'bitmap' }),
+    encode: jest.fn().mockResolvedValue(bytes(encodedLength)),
+  };
+}
+
+describe('prepareImageForStore', () => {
+  it('rescales an oversized screenshot and reports the stored size', async () => {
+    const codec = createCodec({ width: 3840, height: 2160 }, 300);
+
+    const prepared = await prepareImageForStore(bytes(5_000_000), 'image/png', { codec });
+
+    expect(prepared.rescaled).toBe(true);
+    expect(prepared.mediaType).toBe('image/webp');
+    expect(prepared.width).toBe(2000);
+    expect(prepared.height).toBe(1125);
+    expect(prepared.bytes.byteLength).toBe(300);
+  });
+
+  it('keeps an image already within the budget untouched', async () => {
+    const codec = createCodec({ width: 1600, height: 900 }, 10);
+    const source = bytes(400);
+
+    const prepared = await prepareImageForStore(source, 'image/png', { codec });
+
+    expect(prepared.rescaled).toBe(false);
+    expect(prepared.bytes).toBe(source);
+    expect(prepared.mediaType).toBe('image/png');
+    expect(codec.encode).not.toHaveBeenCalled();
+  });
+
+  it('keeps the original when the re-encode came out no smaller', async () => {
+    const codec = createCodec({ width: 4000, height: 4000 }, 900);
+    const source = bytes(800);
+
+    const prepared = await prepareImageForStore(source, 'image/png', { codec });
+
+    expect(prepared.rescaled).toBe(false);
+    expect(prepared.bytes).toBe(source);
+  });
+
+  it('never sends a GIF through the codec, so the animation survives', async () => {
+    const codec = createCodec({ width: 4000, height: 4000 }, 10);
+    const source = bytes(900);
+
+    const prepared = await prepareImageForStore(source, 'image/gif', { codec });
+
+    expect(prepared.rescaled).toBe(false);
+    expect(prepared.bytes).toBe(source);
+    expect(codec.decode).not.toHaveBeenCalled();
+  });
+
+  it('keeps the attachment when the environment cannot decode it', async () => {
+    const codec: ImageCodec = {
+      decode: jest.fn().mockRejectedValue(new Error('no canvas here')),
+      encode: jest.fn(),
+    };
+    const source = bytes(5_000_000);
+
+    const prepared = await prepareImageForStore(source, 'image/png', { codec });
+
+    expect(prepared.rescaled).toBe(false);
+    expect(prepared.bytes).toBe(source);
+  });
+
+  it('keeps the attachment when the encode fails', async () => {
+    const codec: ImageCodec = {
+      decode: jest.fn().mockResolvedValue({ width: 4000, height: 4000, source: 'bitmap' }),
+      encode: jest.fn().mockRejectedValue(new Error('webp unsupported')),
+    };
+    const source = bytes(5_000_000);
+
+    const prepared = await prepareImageForStore(source, 'image/png', { codec });
+
+    expect(prepared.rescaled).toBe(false);
+    expect(prepared.bytes).toBe(source);
+  });
+
+  it('honours a custom edge budget', async () => {
+    const codec = createCodec({ width: 1600, height: 900 }, 10);
+
+    const prepared = await prepareImageForStore(bytes(400), 'image/png', { codec, maxEdge: 800 });
+
+    expect(prepared.rescaled).toBe(true);
+    expect(prepared.width).toBe(800);
+    expect(prepared.height).toBe(450);
+  });
+});

--- a/tests/unit/features/chat/rendering/MessageRenderer.test.ts
+++ b/tests/unit/features/chat/rendering/MessageRenderer.test.ts
@@ -2218,14 +2218,15 @@ describe('MessageRenderer', () => {
         const keydownHandlers = docListeners.get('keydown');
         expect(keydownHandlers).toBeDefined();
         expect(keydownHandlers!.length).toBeGreaterThan(0);
-        const event = { key: 'Escape', preventDefault: jest.fn(), stopPropagation: jest.fn() };
+        const event = { key: 'Escape', preventDefault: jest.fn(), stopImmediatePropagation: jest.fn() };
         keydownHandlers![0](event);
 
         expect(removeSpy).toHaveBeenCalled();
         // Escape belongs to the overlay alone: the view scope's own handler
-        // cancels the streaming turn, so the key must not travel any further.
+        // cancels the streaming turn, so the key must not travel any further,
+        // and no sibling viewer's listener may close a second overlay.
         expect(event.preventDefault).toHaveBeenCalled();
-        expect(event.stopPropagation).toHaveBeenCalled();
+        expect(event.stopImmediatePropagation).toHaveBeenCalled();
         // After close, the keydown handler should be removed
         expect(document.removeEventListener).toHaveBeenCalledWith(
           'keydown',

--- a/tests/unit/features/chat/rendering/MessageRenderer.test.ts
+++ b/tests/unit/features/chat/rendering/MessageRenderer.test.ts
@@ -2218,11 +2218,20 @@ describe('MessageRenderer', () => {
         const keydownHandlers = docListeners.get('keydown');
         expect(keydownHandlers).toBeDefined();
         expect(keydownHandlers!.length).toBeGreaterThan(0);
-        keydownHandlers![0]({ key: 'Escape' });
+        const event = { key: 'Escape', preventDefault: jest.fn(), stopPropagation: jest.fn() };
+        keydownHandlers![0](event);
 
         expect(removeSpy).toHaveBeenCalled();
+        // Escape belongs to the overlay alone: the view scope's own handler
+        // cancels the streaming turn, so the key must not travel any further.
+        expect(event.preventDefault).toHaveBeenCalled();
+        expect(event.stopPropagation).toHaveBeenCalled();
         // After close, the keydown handler should be removed
-        expect(document.removeEventListener).toHaveBeenCalledWith('keydown', expect.any(Function));
+        expect(document.removeEventListener).toHaveBeenCalledWith(
+          'keydown',
+          expect.any(Function),
+          true,
+        );
       } finally {
         (globalThis as any).document = origDocument;
       }

--- a/tests/unit/features/chat/ui/ImageContext.test.ts
+++ b/tests/unit/features/chat/ui/ImageContext.test.ts
@@ -1,6 +1,7 @@
 import { createMockEl } from '@test/helpers/mockElement';
 import { Notice } from 'obsidian';
 
+import * as prepareImage from '@/core/attachments/prepareImage';
 import type { ImageAttachment } from '@/core/types';
 import { ImageContextManager } from '@/features/chat/ui/ImageContext';
 import { resetOpenImageViewers } from '@/features/chat/ui/imageViewerStack';
@@ -839,21 +840,61 @@ describe('ImageContextManager - Private Helpers', () => {
     });
   });
 
-  describe('fileToBase64', () => {
-    it('should convert file to base64 string', async () => {
-      const textEncoder = new TextEncoder();
-      const bytes = textEncoder.encode('hello');
-      const mockBuffer = bytes.buffer;
-      const file = {
-        arrayBuffer: jest.fn().mockResolvedValue(mockBuffer),
-      } as unknown as File;
+  describe('buildAttachment', () => {
+    const fileOf = (text: string, name = 'shot.png'): File => ({
+      name,
+      size: text.length,
+      arrayBuffer: jest.fn().mockResolvedValue(new TextEncoder().encode(text).buffer),
+    } as unknown as File);
 
-      const result = await manager['fileToBase64'](file);
-      expect(typeof result).toBe('string');
-      expect(result.length).toBeGreaterThan(0);
-      // Verify it's valid base64
-      const decoded = Buffer.from(result, 'base64').toString();
-      expect(decoded).toBe('hello');
+    const managerWithStore = (put: jest.Mock): any => new ImageContextManager(
+      createContainerWithInputWrapper().container,
+      createMockTextArea(),
+      createMockCallbacks(),
+      undefined,
+      { put } as any,
+    );
+
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    it('base64-encodes the bytes when no attachment store is wired', async () => {
+      const attachment = await manager['buildAttachment'](fileOf('hello'), 'image/png', 'paste');
+
+      expect(Buffer.from(attachment.data, 'base64').toString()).toBe('hello');
+      expect(attachment.hash).toBeUndefined();
+      expect(attachment.mediaType).toBe('image/png');
+    });
+
+    it('stores the bytes and keeps only a reference when a store is wired', async () => {
+      const put = jest.fn().mockResolvedValue({ hash: 'a'.repeat(64), size: 5 });
+      const stored = managerWithStore(put);
+
+      const attachment = await stored['buildAttachment'](fileOf('hello'), 'image/png', 'paste');
+
+      expect(put).toHaveBeenCalledTimes(1);
+      expect(attachment.hash).toBe('a'.repeat(64));
+      expect(attachment.size).toBe(5);
+      expect(Buffer.from(attachment.data, 'base64').toString()).toBe('hello');
+    });
+
+    it('renames the attachment when the re-encode changed its format', async () => {
+      const put = jest.fn().mockResolvedValue({ hash: 'b'.repeat(64), size: 3 });
+      const stored = managerWithStore(put);
+      jest.spyOn(prepareImage, 'prepareImageForStore').mockResolvedValue({
+        bytes: new TextEncoder().encode('abc').buffer,
+        mediaType: 'image/webp',
+        width: 2000,
+        height: 1125,
+        rescaled: true,
+      });
+
+      const attachment = await stored['buildAttachment'](fileOf('x', 'screen.png'), 'image/png', 'drop');
+
+      expect(attachment.name).toBe('screen.webp');
+      expect(attachment.mediaType).toBe('image/webp');
+      expect(attachment.width).toBe(2000);
     });
   });
 });

--- a/tests/unit/features/chat/ui/ImageContext.test.ts
+++ b/tests/unit/features/chat/ui/ImageContext.test.ts
@@ -879,6 +879,38 @@ describe('ImageContextManager - Private Helpers', () => {
       expect(Buffer.from(attachment.data, 'base64').toString()).toBe('hello');
     });
 
+    it('refuses an image scaling could not bring under the limit', async () => {
+      const put = jest.fn();
+      const stored = managerWithStore(put);
+      jest.spyOn(prepareImage, 'prepareImageForStore').mockResolvedValue({
+        bytes: new ArrayBuffer(6 * 1024 * 1024),
+        mediaType: 'image/gif',
+        rescaled: false,
+      });
+
+      const attachment = await stored['buildAttachment'](fileOf('x', 'huge.gif'), 'image/gif', 'drop');
+
+      expect(attachment).toBeNull();
+      expect(put).not.toHaveBeenCalled();
+    });
+
+    it('accepts a heavy source once scaling has shrunk it', async () => {
+      const put = jest.fn().mockResolvedValue({ hash: 'c'.repeat(64), size: 300 });
+      const stored = managerWithStore(put);
+      jest.spyOn(prepareImage, 'prepareImageForStore').mockResolvedValue({
+        bytes: new ArrayBuffer(300),
+        mediaType: 'image/webp',
+        width: 2000,
+        height: 1125,
+        rescaled: true,
+      });
+
+      const attachment = await stored['buildAttachment'](fileOf('x', 'shot.png'), 'image/png', 'drop');
+
+      expect(attachment).not.toBeNull();
+      expect(attachment!.size).toBe(300);
+    });
+
     it('renames the attachment when the re-encode changed its format', async () => {
       const put = jest.fn().mockResolvedValue({ hash: 'b'.repeat(64), size: 3 });
       const stored = managerWithStore(put);

--- a/tests/unit/features/chat/ui/ImageContext.test.ts
+++ b/tests/unit/features/chat/ui/ImageContext.test.ts
@@ -3,6 +3,7 @@ import { Notice } from 'obsidian';
 
 import type { ImageAttachment } from '@/core/types';
 import { ImageContextManager } from '@/features/chat/ui/ImageContext';
+import { resetOpenImageViewers } from '@/features/chat/ui/imageViewerStack';
 
 jest.mock('obsidian', () => ({
   Notice: jest.fn(),
@@ -761,6 +762,7 @@ describe('ImageContextManager - Private Helpers', () => {
     let removeEventSpy: jest.Mock;
 
     beforeEach(() => {
+      resetOpenImageViewers();
       overlayEl = createMockEl();
       addEventSpy = jest.fn();
       removeEventSpy = jest.fn();
@@ -795,7 +797,7 @@ describe('ImageContextManager - Private Helpers', () => {
       expect(addEventSpy).toHaveBeenCalledWith('keydown', expect.any(Function), true);
 
       const escHandler = addEventSpy.mock.calls[0][1];
-      escHandler({ key: 'Escape', preventDefault: jest.fn(), stopPropagation: jest.fn() });
+      escHandler({ key: 'Escape', preventDefault: jest.fn(), stopImmediatePropagation: jest.fn() });
 
       expect(removeEventSpy).toHaveBeenCalledWith('keydown', escHandler, true);
     });
@@ -805,11 +807,11 @@ describe('ImageContextManager - Private Helpers', () => {
       manager['showFullImage'](image);
 
       const escHandler = addEventSpy.mock.calls[0][1];
-      const event = { key: 'Escape', preventDefault: jest.fn(), stopPropagation: jest.fn() };
+      const event = { key: 'Escape', preventDefault: jest.fn(), stopImmediatePropagation: jest.fn() };
       escHandler(event);
 
       expect(event.preventDefault).toHaveBeenCalled();
-      expect(event.stopPropagation).toHaveBeenCalled();
+      expect(event.stopImmediatePropagation).toHaveBeenCalled();
     });
 
     it('should leave other keys alone', () => {
@@ -817,7 +819,7 @@ describe('ImageContextManager - Private Helpers', () => {
       manager['showFullImage'](image);
 
       const escHandler = addEventSpy.mock.calls[0][1];
-      const event = { key: 'a', preventDefault: jest.fn(), stopPropagation: jest.fn() };
+      const event = { key: 'a', preventDefault: jest.fn(), stopImmediatePropagation: jest.fn() };
       escHandler(event);
 
       expect(event.preventDefault).not.toHaveBeenCalled();

--- a/tests/unit/features/chat/ui/ImageContext.test.ts
+++ b/tests/unit/features/chat/ui/ImageContext.test.ts
@@ -789,12 +789,39 @@ describe('ImageContextManager - Private Helpers', () => {
       const image = createImageAttachment();
       manager['showFullImage'](image);
 
-      expect(addEventSpy).toHaveBeenCalledWith('keydown', expect.any(Function));
+      // Capture phase: Obsidian's own document keydown listener is registered
+      // when the app boots, so a bubble-phase handler added now would run after
+      // the view scope has already acted on Escape.
+      expect(addEventSpy).toHaveBeenCalledWith('keydown', expect.any(Function), true);
 
       const escHandler = addEventSpy.mock.calls[0][1];
-      escHandler({ key: 'Escape' });
+      escHandler({ key: 'Escape', preventDefault: jest.fn(), stopPropagation: jest.fn() });
 
-      expect(removeEventSpy).toHaveBeenCalledWith('keydown', escHandler);
+      expect(removeEventSpy).toHaveBeenCalledWith('keydown', escHandler, true);
+    });
+
+    it('should consume Escape so it does not reach the chat and cancel the turn', () => {
+      const image = createImageAttachment();
+      manager['showFullImage'](image);
+
+      const escHandler = addEventSpy.mock.calls[0][1];
+      const event = { key: 'Escape', preventDefault: jest.fn(), stopPropagation: jest.fn() };
+      escHandler(event);
+
+      expect(event.preventDefault).toHaveBeenCalled();
+      expect(event.stopPropagation).toHaveBeenCalled();
+    });
+
+    it('should leave other keys alone', () => {
+      const image = createImageAttachment();
+      manager['showFullImage'](image);
+
+      const escHandler = addEventSpy.mock.calls[0][1];
+      const event = { key: 'a', preventDefault: jest.fn(), stopPropagation: jest.fn() };
+      escHandler(event);
+
+      expect(event.preventDefault).not.toHaveBeenCalled();
+      expect(removeEventSpy).not.toHaveBeenCalled();
     });
 
     it('should close modal when clicking on overlay background', () => {

--- a/tests/unit/features/chat/ui/imageViewerStack.test.ts
+++ b/tests/unit/features/chat/ui/imageViewerStack.test.ts
@@ -1,0 +1,58 @@
+import {
+  closeTopmostImageViewer,
+  hasOpenImageViewer,
+  registerOpenImageViewer,
+  resetOpenImageViewers,
+} from '@/features/chat/ui/imageViewerStack';
+
+describe('imageViewerStack', () => {
+  beforeEach(() => {
+    resetOpenImageViewers();
+  });
+
+  it('reports no open viewer on a quiet chat', () => {
+    expect(hasOpenImageViewer()).toBe(false);
+    expect(closeTopmostImageViewer()).toBe(false);
+  });
+
+  it('closes a registered viewer and says so', () => {
+    const close = jest.fn();
+    registerOpenImageViewer(close);
+
+    expect(hasOpenImageViewer()).toBe(true);
+    expect(closeTopmostImageViewer()).toBe(true);
+    expect(close).toHaveBeenCalledTimes(1);
+  });
+
+  it('closes viewers one at a time, most recent first', () => {
+    const order: string[] = [];
+    const first = jest.fn(() => { order.push('first'); });
+    const second = jest.fn(() => { order.push('second'); });
+    const unregisterFirst = registerOpenImageViewer(first);
+    const unregisterSecond = registerOpenImageViewer(second);
+
+    closeTopmostImageViewer();
+    unregisterSecond();
+    closeTopmostImageViewer();
+    unregisterFirst();
+
+    expect(order).toEqual(['second', 'first']);
+    expect(hasOpenImageViewer()).toBe(false);
+  });
+
+  it('stops reporting a viewer that closed itself', () => {
+    const unregister = registerOpenImageViewer(jest.fn());
+    unregister();
+
+    expect(hasOpenImageViewer()).toBe(false);
+    expect(closeTopmostImageViewer()).toBe(false);
+  });
+
+  it('tolerates a repeated unregister', () => {
+    const unregister = registerOpenImageViewer(jest.fn());
+    unregister();
+
+    expect(() => unregister()).not.toThrow();
+    expect(hasOpenImageViewer()).toBe(false);
+  });
+});

--- a/tests/unit/features/chat/ui/imageViewerStack.test.ts
+++ b/tests/unit/features/chat/ui/imageViewerStack.test.ts
@@ -1,6 +1,5 @@
 import {
   closeTopmostImageViewer,
-  hasOpenImageViewer,
   registerOpenImageViewer,
   resetOpenImageViewers,
 } from '@/features/chat/ui/imageViewerStack';
@@ -10,8 +9,7 @@ describe('imageViewerStack', () => {
     resetOpenImageViewers();
   });
 
-  it('reports no open viewer on a quiet chat', () => {
-    expect(hasOpenImageViewer()).toBe(false);
+  it('reports nothing to close on a quiet chat', () => {
     expect(closeTopmostImageViewer()).toBe(false);
   });
 
@@ -19,7 +17,6 @@ describe('imageViewerStack', () => {
     const close = jest.fn();
     registerOpenImageViewer(close);
 
-    expect(hasOpenImageViewer()).toBe(true);
     expect(closeTopmostImageViewer()).toBe(true);
     expect(close).toHaveBeenCalledTimes(1);
   });
@@ -28,23 +25,22 @@ describe('imageViewerStack', () => {
     const order: string[] = [];
     const first = jest.fn(() => { order.push('first'); });
     const second = jest.fn(() => { order.push('second'); });
-    const unregisterFirst = registerOpenImageViewer(first);
-    const unregisterSecond = registerOpenImageViewer(second);
+    registerOpenImageViewer(first);
+    registerOpenImageViewer(second);
 
-    closeTopmostImageViewer();
-    unregisterSecond();
-    closeTopmostImageViewer();
-    unregisterFirst();
+    expect(closeTopmostImageViewer()).toBe(true);
+    expect(order).toEqual(['second']);
 
+    expect(closeTopmostImageViewer()).toBe(true);
     expect(order).toEqual(['second', 'first']);
-    expect(hasOpenImageViewer()).toBe(false);
+
+    expect(closeTopmostImageViewer()).toBe(false);
   });
 
   it('stops reporting a viewer that closed itself', () => {
     const unregister = registerOpenImageViewer(jest.fn());
     unregister();
 
-    expect(hasOpenImageViewer()).toBe(false);
     expect(closeTopmostImageViewer()).toBe(false);
   });
 
@@ -53,6 +49,29 @@ describe('imageViewerStack', () => {
     unregister();
 
     expect(() => unregister()).not.toThrow();
-    expect(hasOpenImageViewer()).toBe(false);
+    expect(closeTopmostImageViewer()).toBe(false);
+  });
+
+  it('does not keep a dead entry when a viewer fails to unregister itself', () => {
+    // The production `close` unregisters first, but a stale entry would make
+    // every later Escape close a phantom and stop cancelling the turn.
+    registerOpenImageViewer(jest.fn());
+
+    expect(closeTopmostImageViewer()).toBe(true);
+    expect(closeTopmostImageViewer()).toBe(false);
+  });
+
+  it('drops only the viewer it closed when that viewer unregisters itself', () => {
+    const first = jest.fn();
+    registerOpenImageViewer(first);
+    let unregisterSecond = (): void => {};
+    const second = jest.fn(() => { unregisterSecond(); });
+    unregisterSecond = registerOpenImageViewer(second);
+
+    expect(closeTopmostImageViewer()).toBe(true);
+    expect(second).toHaveBeenCalledTimes(1);
+
+    expect(closeTopmostImageViewer()).toBe(true);
+    expect(first).toHaveBeenCalledTimes(1);
   });
 });

--- a/tests/unit/providers/antigravity/AntigravityImageAttachments.test.ts
+++ b/tests/unit/providers/antigravity/AntigravityImageAttachments.test.ts
@@ -96,6 +96,30 @@ describe('attachAntigravityImages', () => {
     }
   });
 
+  it('skips an attachment whose bytes were never restored', () => {
+    // An empty `data` decodes to zero bytes, and agy would be handed a
+    // zero-byte file described as a screenshot.
+    const bundle = attachAntigravityImages('Read this', [
+      createImage({ data: '', name: 'lost.png' }),
+      createImage({ id: 'img-2', name: 'photo.png' }),
+    ]);
+
+    try {
+      expect(bundle.paths).toHaveLength(1);
+      expect(bundle.paths[0]).toContain('photo.png');
+    } finally {
+      bundle.cleanup();
+    }
+  });
+
+  it('writes nothing at all when no attachment has bytes', () => {
+    const bundle = attachAntigravityImages('Read this', [createImage({ data: '' })]);
+
+    expect(bundle.paths).toEqual([]);
+    expect(bundle.directory).toBeNull();
+    expect(bundle.prompt).toBe('Read this');
+  });
+
   it('keeps the turn alive when one attachment cannot be written', () => {
     const failing = jest
       .spyOn(fs, 'writeFileSync')

--- a/tests/unit/providers/claude/storage/SessionStorage.test.ts
+++ b/tests/unit/providers/claude/storage/SessionStorage.test.ts
@@ -272,6 +272,54 @@ describe('SessionStorage', () => {
     });
   });
 
+  describe('toSessionMetadata - attachment bytes', () => {
+    const conversationWithImage = (hash?: string): Conversation => ({
+      id: 'conv-images',
+      providerId: 'claude',
+      title: 'Screenshot',
+      createdAt: 1,
+      updatedAt: 2,
+      sessionId: null,
+      messages: [{
+        id: 'm1',
+        role: 'user',
+        content: 'look',
+        timestamp: 3,
+        images: [{
+          id: 'img-1',
+          name: 'shot.webp',
+          mediaType: 'image/webp',
+          data: 'YmFzZTY0',
+          size: 6,
+          source: 'paste',
+          ...(hash ? { hash } : {}),
+        }],
+      }],
+    } as unknown as Conversation);
+
+    it('leaves out bytes the attachment store already holds', () => {
+      const metadata = storage.toSessionMetadata(conversationWithImage('a'.repeat(64)));
+
+      const image = metadata.messages![0].images![0];
+      expect(image.data).toBe('');
+      expect(image.hash).toBe('a'.repeat(64));
+    });
+
+    it('keeps the bytes of an attachment nothing else holds', () => {
+      const metadata = storage.toSessionMetadata(conversationWithImage());
+
+      expect(metadata.messages![0].images![0].data).toBe('YmFzZTY0');
+    });
+
+    it('does not empty the conversation still in memory', () => {
+      const conversation = conversationWithImage('b'.repeat(64));
+
+      storage.toSessionMetadata(conversation);
+
+      expect(conversation.messages[0].images![0].data).toBe('YmFzZTY0');
+    });
+  });
+
   describe('toSessionMetadata - round trip', () => {
     it('round-trips providerState through save and load', async () => {
       const conversation: Conversation = {

--- a/tests/unit/providers/codex/runtime/CodexChatRuntime.test.ts
+++ b/tests/unit/providers/codex/runtime/CodexChatRuntime.test.ts
@@ -1590,6 +1590,24 @@ describe('CodexChatRuntime', () => {
       );
     });
 
+    it('skips an attachment whose bytes were never restored', async () => {
+      // An empty `data` decodes to zero bytes, and Codex would be handed a
+      // zero-byte file described as an image.
+      const turn = createTurn('describe this');
+      turn.request.images = [
+        { id: 'img1', name: 'lost.png', data: '', mediaType: 'image/png', size: 0, source: 'file' as const },
+      ];
+
+      await collectChunks(runtime.query(turn));
+
+      const turnStartCall = findCall('turn/start');
+      const input = turnStartCall[1].input;
+      expect(input.some((item: Record<string, unknown>) => item.type === 'localImage')).toBe(false);
+      expect(input).toEqual(
+        expect.arrayContaining([expect.objectContaining({ type: 'text', text: 'describe this' })]),
+      );
+    });
+
     it('cleans up temporary image files after the turn completes', async () => {
       const turn = createTurn('describe this');
       turn.request.images = [


### PR DESCRIPTION
Supersedes #119, and carries over the half of it that this does not replace.

## Why

`ImageAttachment.data` was documented as the single source of truth, so the bytes
travelled everywhere. `toSessionMetadata` serialised them into
`.grimoire/sessions/*.meta.json` through `JSON.parse(JSON.stringify(messages))`,
`saveMetadata` rewrote that file whole, and `updateConversation` calls it on every
field change — a title-generation status update rewrote every attachment in the
conversation. Startup then loaded every conversation's copy back into memory. A
5 MB screenshot is ~6.8 MB of base64 doing all of that.

`updateConversation` tried to bound it by clearing `data` after each save, on the
premise that the provider could restore it. That premise held for one provider,
and lost the image for the rest.

## What changed

Bytes live once in `.grimoire/attachments/<sha256>.<ext>`, and a message keeps a
reference.

**Scaled on the way in.** At most 2000 px on the long edge, re-encoded to WebP.
Above that, provider vision pipelines downscale server-side anyway, and 2000 px is
the width Anthropic documents for staying under the stricter per-image dimension
limit that applies once a request carries more than 20 image blocks — which every
turn of a long conversation does, since each turn resends the images before it.
The re-encode is kept only when it is smaller, GIF never goes through a canvas
(the round trip would drop the animation), and a build that cannot decode keeps
the original. The store never holds more than arrived.

**Out of metadata.** Metadata carries the hash, not the data, so a conversation
update no longer rewrites megabytes. Bytes come back when a conversation is
opened, so memory holds the active conversation's attachments rather than every
conversation in the vault.

**Read directly.** The renderer displays stored files through `getResourcePath`,
so a click on a thumbnail no longer rebuilds a data URI out of base64.

**Reclaimed.** Deleting a conversation drops files nothing references. The
reachable set is read from metadata rather than memory: transcript hydration
replaces a conversation's messages with provider-derived ones that carry no hash,
so memory is not a complete record.

Content addressing deduplicates for free — the same screenshot in ten
conversations is one file, and a fork references the same one.

## Two defects fixed along the way

**Zero-byte attachments.** Codex and Antigravity both write an attachment to a
temp file for the CLI, and neither checked there were bytes to write.
`Buffer.from('', 'base64')` produces a zero-byte file, described to the agent as a
screenshot. Reachable before this branch: the clearing in `updateConversation` ran
for every provider, so any resend after a conversation update wrote empty files.
Both providers now skip an attachment with no bytes, and the send path refills
them from the store first — a resend or a queued turn takes images straight off an
existing message, whose bytes metadata leaves out.

**Escape closing more than one viewer.** Carried over from #119 with its commit
intact, plus review fixes: `closeTopmostImageViewer` pops before closing so a
`close` that fails to unregister cannot leave an entry that swallows every later
Escape and stops the turn from ever being cancelled; both viewers delegate to the
stack and use `stopImmediatePropagation`, since they register on the same document
and `stopPropagation` does not stop siblings on the same node — one Escape closed
every open viewer, oldest first, against what the module promised; and the view
scope consults the stack only for an Escape nobody consumed.

## What this replaces in #119

`restoresImageAttachmentData` is not needed: nothing releases the bytes, so no
provider has to declare whether it could put them back. The capability would not
have helped Claude either — the release ran while the conversation was open, and
`hydrateConversationHistory` returns early for a conversation already in
`hydratedConversationIds`, so the viewer stayed empty for the rest of the session
even after switching away and back.

## Also

Size is judged after scaling rather than before. A 15 MB screenshot is a few
hundred kilobytes once stored, so refusing it up front was refusing work we can
do; 25 MB is the point past which a file is not opened at all, and anything
scaling cannot bring under 5 MB — a GIF, which must not be re-encoded — is still
refused.

Attachments that predate the store keep their inline data and behave as before.
There is no migration pass.

## Verification

`npm test` (424 suites, 7744 tests), `npm run typecheck`, `npm run lint`,
`review:source`, `review:css`, `review:deps` — all clean.

38 new tests: resize geometry, the store-or-keep policy against a stubbed codec
(there is no canvas under the Node test runner), the store with deduplication and
GC, hydration, metadata byte stripping, the viewer stack, and the zero-byte guard
in both providers.

`build:release` was not run — it deploys into a live vault via `OBSIDIAN_VAULT`.
