### PR TITLE
fix(claude): stop reopening a conversation from duplicating every message

### DIFF
--- a/src/providers/claude/history/ClaudeConversationHistoryService.ts
+++ b/src/providers/claude/history/ClaudeConversationHistoryService.ts
@@ -163,13 +163,47 @@ function ensureTaskToolCall(
   return taskToolCall;
 }
 
+/**
+ * The identifiers under which a message can be recognised again.
+ *
+ * A message reaches the merge from two namespaces: Grimoire's own `msg-…` ids,
+ * and the transcript's uuids. The same exchange therefore arrives under two
+ * different `id`s, and only the SDK-side identifiers tie them together - a user
+ * message's transcript uuid is its `userMessageId`, and both copies of an
+ * assistant message carry the same `assistantMessageId`.
+ */
+function messageIdentities(message: ChatMessage): string[] {
+  const identities = [message.id];
+  if (message.userMessageId) {
+    identities.push(message.userMessageId);
+  }
+  if (message.assistantMessageId) {
+    identities.push(message.assistantMessageId);
+  }
+
+  return identities;
+}
+
+/**
+ * Keeps the first copy of each message.
+ *
+ * Order matters: the conversation's own messages come first, so the surviving
+ * copy is the one the UI already refers to by id for rewind and fork, and the
+ * one whose attachments point at the store.
+ *
+ * Matching on identifiers rather than on content is deliberate - a repeated
+ * prompt is a legitimately distinct message, not a duplicate.
+ */
 function dedupeMessages(messages: ChatMessage[]): ChatMessage[] {
   const seen = new Set<string>();
   const result: ChatMessage[] = [];
 
   for (const message of messages) {
-    if (seen.has(message.id)) continue;
-    seen.add(message.id);
+    const identities = messageIdentities(message);
+    if (identities.some(identity => seen.has(identity))) continue;
+    for (const identity of identities) {
+      seen.add(identity);
+    }
     result.push(message);
   }
 

--- a/tests/unit/providers/claude/history/ClaudeConversationHistoryService.test.ts
+++ b/tests/unit/providers/claude/history/ClaudeConversationHistoryService.test.ts
@@ -1,0 +1,156 @@
+import type { ChatMessage, Conversation } from '@/core/types';
+import { ClaudeConversationHistoryService } from '@/providers/claude/history/ClaudeConversationHistoryService';
+
+jest.mock('@/providers/claude/history/ClaudeHistoryStore', () => ({
+  deleteSDKSession: jest.fn(),
+  loadSDKSessionMessages: jest.fn(),
+  loadSubagentToolCalls: jest.fn().mockResolvedValue([]),
+  locateSDKSessions: jest.fn(),
+}));
+
+jest.mock('@/core/providers/ProviderWorkspaceRegistry', () => ({
+  ProviderWorkspaceRegistry: { getServices: jest.fn().mockReturnValue(null) },
+}));
+
+import {
+  loadSDKSessionMessages,
+  locateSDKSessions,
+} from '@/providers/claude/history/ClaudeHistoryStore';
+
+const USER_UUID = 'f428a7aa-c360-4b0f-9d1e-000000000001';
+const ASSISTANT_UUID = 'ecb3966c-cfdb-4790-8a2b-000000000002';
+
+function message(overrides: Partial<ChatMessage>): ChatMessage {
+  return {
+    id: 'x',
+    role: 'user',
+    content: 'who are you?',
+    timestamp: 1000,
+    ...overrides,
+  };
+}
+
+function conversation(messages: ChatMessage[]): Conversation {
+  return {
+    id: 'conv-1',
+    providerId: 'claude',
+    title: 'Session',
+    createdAt: 0,
+    updatedAt: 0,
+    sessionId: 'session-1',
+    messages,
+  };
+}
+
+function transcriptReturns(messages: ChatMessage[]): void {
+  (locateSDKSessions as jest.Mock).mockResolvedValue(
+    new Map([['session-1', { availability: 'present', sessionPath: '/tmp/session-1.jsonl' }]]),
+  );
+  (loadSDKSessionMessages as jest.Mock).mockResolvedValue({ messages, error: null });
+}
+
+describe('ClaudeConversationHistoryService.hydrateConversationHistory', () => {
+  let service: ClaudeConversationHistoryService;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    service = new ClaudeConversationHistoryService();
+  });
+
+  it('does not append a second copy of a message the transcript already describes', async () => {
+    // The transcript keys a message by its own uuid, which never equals the id
+    // Grimoire gave it, so only the SDK-side identifiers tie the two together.
+    const conv = conversation([
+      message({ id: 'msg-1', role: 'user', userMessageId: USER_UUID }),
+      message({ id: 'msg-2', role: 'assistant', content: 'I am Claude', timestamp: 1001, assistantMessageId: ASSISTANT_UUID }),
+    ]);
+    transcriptReturns([
+      message({ id: USER_UUID, role: 'user', userMessageId: USER_UUID, timestamp: 1002 }),
+      message({ id: 'b9d8d624-1d51-4f46-b000-000000000003', role: 'assistant', content: 'I am Claude', timestamp: 1003, assistantMessageId: ASSISTANT_UUID }),
+    ]);
+
+    await service.hydrateConversationHistory(conv, '/vault');
+
+    expect(conv.messages.map(m => m.id)).toEqual(['msg-1', 'msg-2']);
+  });
+
+  it('keeps the conversation copy, which is the one the UI and the attachment store refer to', async () => {
+    const conv = conversation([
+      message({
+        id: 'msg-1',
+        role: 'user',
+        userMessageId: USER_UUID,
+        images: [{ id: 'i1', name: 'shot.webp', mediaType: 'image/webp', data: '', hash: 'a'.repeat(64), size: 10, source: 'paste' }],
+      }),
+    ]);
+    transcriptReturns([
+      message({
+        id: USER_UUID,
+        role: 'user',
+        userMessageId: USER_UUID,
+        timestamp: 1002,
+        images: [{ id: 'sdk-img', name: 'image-1', mediaType: 'image/webp', data: 'YmFzZTY0', size: 10, source: 'paste' }],
+      }),
+    ]);
+
+    await service.hydrateConversationHistory(conv, '/vault');
+
+    expect(conv.messages).toHaveLength(1);
+    expect(conv.messages[0].id).toBe('msg-1');
+    expect(conv.messages[0].images?.[0].hash).toBe('a'.repeat(64));
+  });
+
+  it('collapses a conversation that was already saved with duplicates', async () => {
+    // What a vault holds today: both copies persisted, sharing an identifier.
+    const conv = conversation([
+      message({ id: 'msg-1', role: 'user', userMessageId: USER_UUID }),
+      message({ id: 'msg-2', role: 'assistant', content: 'I am Claude', timestamp: 1001, assistantMessageId: ASSISTANT_UUID }),
+      message({ id: USER_UUID, role: 'user', userMessageId: USER_UUID, timestamp: 1002 }),
+      message({ id: 'b9d8d624-1d51-4f46-b000-000000000003', role: 'assistant', content: 'I am Claude', timestamp: 1003, assistantMessageId: ASSISTANT_UUID }),
+    ]);
+    transcriptReturns([]);
+
+    await service.hydrateConversationHistory(conv, '/vault');
+
+    expect(conv.messages.map(m => m.id)).toEqual(['msg-1', 'msg-2']);
+  });
+
+  it('still adds transcript messages the conversation has never seen', async () => {
+    const conv = conversation([
+      message({ id: 'msg-1', role: 'user', userMessageId: USER_UUID }),
+    ]);
+    transcriptReturns([
+      message({ id: USER_UUID, role: 'user', userMessageId: USER_UUID, timestamp: 1002 }),
+      message({ id: 'later-uuid', role: 'assistant', content: 'resumed elsewhere', timestamp: 1004 }),
+    ]);
+
+    await service.hydrateConversationHistory(conv, '/vault');
+
+    expect(conv.messages.map(m => m.id)).toEqual(['msg-1', 'later-uuid']);
+  });
+
+  it('keeps two genuinely repeated prompts apart', async () => {
+    // Identical content, different turns: matching on text would lose one.
+    const conv = conversation([
+      message({ id: 'msg-1', role: 'user', content: 'what is this?', userMessageId: USER_UUID }),
+      message({ id: 'msg-3', role: 'user', content: 'what is this?', timestamp: 1005, userMessageId: 'aaaaaaaa-0000-0000-0000-000000000009' }),
+    ]);
+    transcriptReturns([]);
+
+    await service.hydrateConversationHistory(conv, '/vault');
+
+    expect(conv.messages).toHaveLength(2);
+  });
+
+  it('leaves a message with no SDK identifier alone rather than merging it into another', async () => {
+    const conv = conversation([
+      message({ id: 'msg-1', role: 'assistant', content: 'interrupted', timestamp: 1000 }),
+      message({ id: 'msg-2', role: 'assistant', content: 'also interrupted', timestamp: 1001 }),
+    ]);
+    transcriptReturns([]);
+
+    await service.hydrateConversationHistory(conv, '/vault');
+
+    expect(conv.messages.map(m => m.id)).toEqual(['msg-1', 'msg-2']);
+  });
+});


### PR DESCRIPTION
Closes #127

## Cause

`dedupeMessages` (`ClaudeConversationHistoryService.ts:166`) keyed only on `message.id`, and the merge feeds it two sets whose ids come from different namespaces — the conversation's own `msg-<timestamp>-<rand>` ids and the transcript's `sdkMsg.uuid`. They never collide, so every hydration appended a second copy of the whole exchange, which was then saved back into `.grimoire/sessions/<id>.meta.json`.

It stopped at ×2 rather than growing, because the saved list then held the uuid-keyed copies, which do dedupe against the transcript on the next pass. That is why it read as a long conversation rather than a bug.

Claude only: it is the only provider that merges an external transcript into `conversation.messages`.

## Fix

The identifiers needed were already stored. `ChatMessage.userMessageId` / `assistantMessageId` are filled in `InputController.ts:635-636` from the turn metadata Claude's runtime records, and vault data shows both halves of each pair sharing a key:

```
user      id=msg-1786188398292-x8   userMessageId=f428a7aa-c360-4b0f-9
user      id=f428a7aa-c360-4b0f-9   userMessageId=f428a7aa-c360-4b0f-9

assistant id=msg-1786188398314-wv   assistantMessageId=ecb3966c-cfdb-4790-8
assistant id=b9d8d624-1d51-4f46-b   assistantMessageId=ecb3966c-cfdb-4790-8
```

Deduping on the union of `{id, userMessageId, assistantMessageId}` collapses each pair. The first copy wins, which keeps the conversation's own message — the UI refers to it by id for rewind and fork, and its attachments carry the attachment-store hash.

Matching on content was not an option: a repeated prompt ("what is this?") is a legitimately distinct message.

## Already-duplicated conversations

They repair themselves on the next open, because both stored copies share an identifier. No migration pass.

A message that never received turn metadata — an interrupted turn — has neither identifier and is left alone rather than merged into a neighbour.

## Tests

No test opened a Claude conversation against a transcript, which is how this survived since at least 1 August. Six now do: the duplicate is not appended, the conversation's copy is the survivor (with its attachment hash intact), an already-duplicated conversation collapses, genuinely new transcript messages are still added, two identical prompts stay apart, and a message with no SDK identifier is left alone.

Verified they fail without the fix: **4 of 6 fail** on the unpatched service, all 6 pass with it.

`npm test` (425 suites, 7750 tests), `typecheck`, `lint` — clean.
