### PR TITLE
chore: keep a local CodeGraph index out of git

### DIFF
--- a/.codegraph/.gitignore
+++ b/.codegraph/.gitignore
@@ -1,0 +1,5 @@
+# CodeGraph data files — local to each machine, not for committing.
+# Ignore everything in .codegraph/ except this file itself, so transient
+# files (the database, daemon.pid, sockets, logs) never show up in git.
+*
+!.gitignore


### PR DESCRIPTION
### Problem

`codegraph init` writes its index to `.codegraph/` at the repo root — a SQLite
database near 100 MB, plus a daemon pid and sockets. The directory is untracked
and nothing in the repo's `.gitignore` covers it, so it shows up in `git status`
and a `git add -A` would sweep it in.

### Fix

CodeGraph ships an ignore file inside that directory for exactly this reason:

```
*
!.gitignore
```

Everything in `.codegraph/` is excluded except the file itself. Committing it is
what makes that true for every clone rather than only for whoever ran
`codegraph init`.

### Scope

Indexing stays an opt-in local choice, the same way RTK is: nothing in the build,
the tests, or CI depends on it. No source, config, or tooling change — this adds
one 229-byte file.

### Verification

Run with the index present in the working tree:

```
npx jest --selectProjects unit   426 suites, 7613 tests, all passing
npm run lint                     clean
npm run review:source            clean
```