### PR TITLE
fix(gemini,qwen): surface new models after a CLI upgrade, and let the user ask for them

### DIFF
--- a/src/providers/gemini/modelCatalogFingerprint.ts
+++ b/src/providers/gemini/modelCatalogFingerprint.ts
@@ -1,3 +1,4 @@
+import { getCliBinaryFingerprint } from '../../core/providers/cliBinaryFingerprint';
 import type GrimoirePlugin from '../../main';
 import type { GeminiProviderSettings } from './settings';
 
@@ -6,6 +7,11 @@ import type { GeminiProviderSettings } from './settings';
  * runs and which environment it reads. The model catalog keys its refresh cache
  * on this, and every discovery persists a digest of it so a later load can tell
  * a list discovered under this configuration from one merely assumed to match.
+ *
+ * The binary's identity is part of that, not just its path: a CLI release can
+ * change which models it offers, and an upgrade in place leaves the path
+ * untouched. Without it a catalog discovered before the upgrade stays settled
+ * and the new models never reach the picker.
  */
 export function buildGeminiModelCatalogFingerprint(
   settings: GeminiProviderSettings,
@@ -13,6 +19,7 @@ export function buildGeminiModelCatalogFingerprint(
   environmentVariables: string,
 ): string {
   return JSON.stringify({
+    cliBinary: getCliBinaryFingerprint(cliPath),
     cliPath,
     cliPathsByHost: settings.cliPathsByHost,
     environmentVariables,

--- a/src/providers/gemini/ui/GeminiSettingsTab.ts
+++ b/src/providers/gemini/ui/GeminiSettingsTab.ts
@@ -1,5 +1,5 @@
 import * as fs from 'fs';
-import { Setting } from 'obsidian';
+import { Notice, Setting } from 'obsidian';
 
 import type { ProviderSettingsTabRenderer } from '../../../core/providers/types';
 import { renderEnvironmentSettingsSection } from '../../../features/settings/ui/EnvironmentSettingsSection';
@@ -96,6 +96,48 @@ export const geminiSettingsTabRenderer: ProviderSettingsTabRenderer = {
       cliPathInputEl = text.inputEl;
       updateCliPathValidation(currentValue, text.inputEl);
     });
+
+    // --- Models ---
+
+    new Setting(container).setName(t('settings.models')).setHeading();
+
+    // A settled catalog is never re-probed in the background, and the binary
+    // fingerprint only notices an upgrade that changed the file Grimoire resolved.
+    // This is the one place a user can ask the CLI for its current list.
+    new Setting(container)
+      .setName(t('settings.refreshModels.name'))
+      .setDesc(t('settings.refreshModels.desc', { provider: 'Gemini CLI' }))
+      .addButton((button) => {
+        button
+          .setButtonText(t('settings.refreshModels.button'))
+          .onClick(async () => {
+            const catalog = geminiWorkspace?.modelCatalog;
+            if (!catalog) {
+              return;
+            }
+
+            button.setDisabled(true);
+            try {
+              await catalog.refreshModels({
+                force: true,
+                plugin: context.plugin,
+                settings: settingsBag,
+              });
+              const modelCount = getGeminiProviderSettings(settingsBag).discoveredModels.length;
+              if (modelCount === 0) {
+                new Notice(t('settings.provider.loadModelsFailed'));
+                return;
+              }
+
+              context.refreshModelSelectors();
+              new Notice(t('settings.refreshModels.done', { count: modelCount }));
+            } catch {
+              new Notice(t('settings.provider.loadModelsFailed'));
+            } finally {
+              button.setDisabled(false);
+            }
+          });
+      });
 
     const advancedContainer = context.renderAdvancedSection(container, {
       count: 6,

--- a/src/providers/qwen/modelCatalogFingerprint.ts
+++ b/src/providers/qwen/modelCatalogFingerprint.ts
@@ -1,3 +1,4 @@
+import { getCliBinaryFingerprint } from '../../core/providers/cliBinaryFingerprint';
 import type GrimoirePlugin from '../../main';
 import type { QwenProviderSettings } from './settings';
 
@@ -6,6 +7,11 @@ import type { QwenProviderSettings } from './settings';
  * runs and which environment it reads. The model catalog keys its refresh cache
  * on this, and every discovery persists a digest of it so a later load can tell
  * a list discovered under this configuration from one merely assumed to match.
+ *
+ * The binary's identity is part of that, not just its path: a CLI release can
+ * change which models it offers, and an upgrade in place leaves the path
+ * untouched. Without it a catalog discovered before the upgrade stays settled
+ * and the new models never reach the picker.
  */
 export function buildQwenModelCatalogFingerprint(
   settings: QwenProviderSettings,
@@ -13,6 +19,7 @@ export function buildQwenModelCatalogFingerprint(
   environmentVariables: string,
 ): string {
   return JSON.stringify({
+    cliBinary: getCliBinaryFingerprint(cliPath),
     cliPath,
     cliPathsByHost: settings.cliPathsByHost,
     environmentVariables,

--- a/src/providers/qwen/ui/QwenSettingsTab.ts
+++ b/src/providers/qwen/ui/QwenSettingsTab.ts
@@ -1,5 +1,5 @@
 import * as fs from 'fs';
-import { Setting } from 'obsidian';
+import { Notice, Setting } from 'obsidian';
 
 import type { ProviderSettingsTabRenderer } from '../../../core/providers/types';
 import { renderEnvironmentSettingsSection } from '../../../features/settings/ui/EnvironmentSettingsSection';
@@ -104,6 +104,48 @@ export const qwenSettingsTabRenderer: ProviderSettingsTabRenderer = {
       cliPathInputEl = text.inputEl;
       updateCliPathValidation(currentValue, text.inputEl);
     });
+
+    // --- Models ---
+
+    new Setting(container).setName(t('settings.models')).setHeading();
+
+    // A settled catalog is never re-probed in the background, and the binary
+    // fingerprint only notices an upgrade that changed the file Grimoire resolved.
+    // This is the one place a user can ask the CLI for its current list.
+    new Setting(container)
+      .setName(t('settings.refreshModels.name'))
+      .setDesc(t('settings.refreshModels.desc', { provider: 'Qwen Code' }))
+      .addButton((button) => {
+        button
+          .setButtonText(t('settings.refreshModels.button'))
+          .onClick(async () => {
+            const catalog = qwenWorkspace?.modelCatalog;
+            if (!catalog) {
+              return;
+            }
+
+            button.setDisabled(true);
+            try {
+              await catalog.refreshModels({
+                force: true,
+                plugin: context.plugin,
+                settings: settingsBag,
+              });
+              const modelCount = getQwenProviderSettings(settingsBag).discoveredModels.length;
+              if (modelCount === 0) {
+                new Notice(t('settings.provider.loadModelsFailed'));
+                return;
+              }
+
+              context.refreshModelSelectors();
+              new Notice(t('settings.refreshModels.done', { count: modelCount }));
+            } catch {
+              new Notice(t('settings.provider.loadModelsFailed'));
+            } finally {
+              button.setDisabled(false);
+            }
+          });
+      });
 
     const advancedContainer = context.renderAdvancedSection(container, {
       count: 5,

--- a/tests/__mocks__/obsidian.ts
+++ b/tests/__mocks__/obsidian.ts
@@ -212,6 +212,13 @@ export class ButtonComponent {
     return this;
   }
 
+  setDisabled(disabled: boolean): this {
+    if (this.buttonEl) {
+      this.buttonEl.disabled = disabled;
+    }
+    return this;
+  }
+
   onClick(handler: () => void | Promise<void>): this {
     this.buttonEl?.addEventListener?.('click', handler);
     return this;

--- a/tests/unit/providers/gemini/modelCatalogFingerprint.test.ts
+++ b/tests/unit/providers/gemini/modelCatalogFingerprint.test.ts
@@ -1,0 +1,38 @@
+import { getCliBinaryFingerprint } from '@/core/providers/cliBinaryFingerprint';
+import { buildGeminiModelCatalogFingerprint } from '@/providers/gemini/modelCatalogFingerprint';
+import { getGeminiProviderSettings } from '@/providers/gemini/settings';
+
+jest.mock('@/core/providers/cliBinaryFingerprint', () => ({
+  getCliBinaryFingerprint: jest.fn().mockReturnValue(''),
+}));
+
+const mockedFingerprint = getCliBinaryFingerprint as jest.MockedFunction<
+  typeof getCliBinaryFingerprint
+>;
+
+describe('buildGeminiModelCatalogFingerprint', () => {
+  beforeEach(() => mockedFingerprint.mockReset());
+
+  it('changes when the CLI is upgraded in place', () => {
+    const settings = getGeminiProviderSettings({});
+
+    mockedFingerprint.mockReturnValue('4096:1700000000000');
+    const before = buildGeminiModelCatalogFingerprint(settings, '/usr/local/bin/gemini', '');
+
+    // An upgrade over the same path is the whole reason this exists: without the
+    // binary in the key a settled catalog keeps the previous release's models.
+    mockedFingerprint.mockReturnValue('5120:1700000999999');
+    const after = buildGeminiModelCatalogFingerprint(settings, '/usr/local/bin/gemini', '');
+
+    expect(mockedFingerprint).toHaveBeenCalledWith('/usr/local/bin/gemini');
+    expect(after).not.toBe(before);
+  });
+
+  it('stays stable while the same build sits at the same path', () => {
+    const settings = getGeminiProviderSettings({});
+    mockedFingerprint.mockReturnValue('4096:1700000000000');
+
+    expect(buildGeminiModelCatalogFingerprint(settings, '/usr/local/bin/gemini', ''))
+      .toBe(buildGeminiModelCatalogFingerprint(settings, '/usr/local/bin/gemini', ''));
+  });
+});

--- a/tests/unit/providers/gemini/ui/GeminiSettingsTab.test.ts
+++ b/tests/unit/providers/gemini/ui/GeminiSettingsTab.test.ts
@@ -1,0 +1,142 @@
+import { createMockEl } from '@test/helpers/mockElement';
+import { ButtonComponent, Notice } from 'obsidian';
+
+import { getGeminiProviderSettings } from '@/providers/gemini/settings';
+import { geminiSettingsTabRenderer } from '@/providers/gemini/ui/GeminiSettingsTab';
+
+const mockRefreshModels = jest.fn().mockResolvedValue(true);
+
+jest.mock('fs', () => ({
+  existsSync: jest.fn().mockReturnValue(true),
+  statSync: jest.fn().mockReturnValue({ isFile: () => true }),
+}));
+
+jest.mock('@/i18n/i18n', () => ({
+  t: (key: string, params?: Record<string, string | number>) =>
+    (params ? `${key}:${JSON.stringify(params)}` : key),
+}));
+
+jest.mock('@/providers/gemini/app/GeminiWorkspaceServices', () => ({
+  maybeGetGeminiWorkspaceServices: jest.fn(() => ({
+    commandCatalog: null,
+    modelCatalog: {
+      isAvailable: () => true,
+      refreshModels: (...args: unknown[]) => mockRefreshModels(...args),
+    },
+  })),
+}));
+
+jest.mock('@/features/settings/ui/EnvironmentSettingsSection', () => ({
+  renderEnvironmentSettingsSection: jest.fn(),
+}));
+jest.mock('@/features/settings/ui/ProviderDisabledNotice', () => ({
+  renderProviderDisabledNotice: jest.fn(),
+}));
+jest.mock('@/features/settings/ui/ProviderSkillSettings', () => ({
+  ProviderSkillSettings: jest.fn(),
+}));
+jest.mock('@/features/settings/ui/McpSettingsManager', () => ({
+  McpSettingsManager: jest.fn(),
+}));
+jest.mock('@/providers/gemini/ui/GeminiAgentSettings', () => ({
+  GeminiAgentSettings: jest.fn(),
+}));
+jest.mock('@/providers/gemini/ui/GeminiCommandSettings', () => ({
+  GeminiCommandSettings: jest.fn(),
+}));
+
+const mockNotice = Notice as unknown as jest.Mock;
+
+function createContext(discoveredModels: unknown[]) {
+  const plugin = {
+    app: { vault: { adapter: { basePath: '/vault' } } },
+    getAllViews: jest.fn(() => []),
+    saveSettings: jest.fn().mockResolvedValue(undefined),
+    settings: {
+      providerConfigs: {
+        gemini: { enabled: true, discoveredModels },
+      },
+    },
+  } as any;
+
+  return {
+    plugin,
+    context: {
+      plugin,
+      createWorkspaceSection: jest.fn((container: any) => container),
+      renderAdvancedSection: jest.fn((container: any) => container),
+      renderCustomContextLimits: jest.fn(),
+      renderHiddenProviderCommandSetting: jest.fn(),
+      refreshModelSelectors: jest.fn(),
+      suppressAutomaticDiscovery: false,
+    } as any,
+  };
+}
+
+/** Renders the tab and hands back the one button it builds, with its click handler. */
+function renderTab(discoveredModels: unknown[]) {
+  const handlers: Array<(evt: MouseEvent) => unknown> = [];
+  const onClick = jest.spyOn(ButtonComponent.prototype, 'onClick')
+    .mockImplementation(function mockOnClick(this: ButtonComponent, handler) {
+      handlers.push(handler);
+      return this;
+    });
+  const setDisabled = jest.spyOn(ButtonComponent.prototype, 'setDisabled');
+  const setButtonText = jest.spyOn(ButtonComponent.prototype, 'setButtonText');
+
+  const { plugin, context } = createContext(discoveredModels);
+  geminiSettingsTabRenderer.render(createMockEl(), context);
+  onClick.mockRestore();
+
+  return { context, handlers, plugin, setButtonText, setDisabled };
+}
+
+describe('GeminiSettingsTab model refresh', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockRefreshModels.mockResolvedValue(true);
+  });
+
+  it('lets the user ask the CLI for its current model list', async () => {
+    const { context, handlers, plugin, setButtonText, setDisabled } = renderTab([
+      { rawId: 'model-a', label: 'Model A' },
+      { rawId: 'model-b', label: 'Model B' },
+    ]);
+
+    expect(setButtonText).toHaveBeenCalledWith('settings.refreshModels.button');
+
+    await handlers[0]?.({} as MouseEvent);
+
+    // Background picker refreshes never force; this button is the one explicit path.
+    expect(mockRefreshModels).toHaveBeenCalledWith({
+      force: true,
+      plugin,
+      settings: plugin.settings,
+    });
+    expect(getGeminiProviderSettings(plugin.settings).discoveredModels).toHaveLength(2);
+    expect(context.refreshModelSelectors).toHaveBeenCalledTimes(1);
+    expect(mockNotice).toHaveBeenCalledWith('settings.refreshModels.done:{"count":2}');
+    expect(setDisabled).toHaveBeenLastCalledWith(false);
+  });
+
+  it('warns and re-enables the button when a refresh finds nothing', async () => {
+    const { context, handlers, setDisabled } = renderTab([]);
+
+    await handlers[0]?.({} as MouseEvent);
+
+    expect(mockNotice).toHaveBeenCalledWith('settings.provider.loadModelsFailed');
+    expect(context.refreshModelSelectors).not.toHaveBeenCalled();
+    expect(setDisabled).toHaveBeenLastCalledWith(false);
+  });
+
+  it('warns and re-enables the button when the refresh throws', async () => {
+    mockRefreshModels.mockRejectedValueOnce(new Error('CLI missing'));
+    const { context, handlers, setDisabled } = renderTab([{ rawId: 'model-a', label: 'Model A' }]);
+
+    await handlers[0]?.({} as MouseEvent);
+
+    expect(mockNotice).toHaveBeenCalledWith('settings.provider.loadModelsFailed');
+    expect(context.refreshModelSelectors).not.toHaveBeenCalled();
+    expect(setDisabled).toHaveBeenLastCalledWith(false);
+  });
+});

--- a/tests/unit/providers/qwen/modelCatalogFingerprint.test.ts
+++ b/tests/unit/providers/qwen/modelCatalogFingerprint.test.ts
@@ -1,0 +1,38 @@
+import { getCliBinaryFingerprint } from '@/core/providers/cliBinaryFingerprint';
+import { buildQwenModelCatalogFingerprint } from '@/providers/qwen/modelCatalogFingerprint';
+import { getQwenProviderSettings } from '@/providers/qwen/settings';
+
+jest.mock('@/core/providers/cliBinaryFingerprint', () => ({
+  getCliBinaryFingerprint: jest.fn().mockReturnValue(''),
+}));
+
+const mockedFingerprint = getCliBinaryFingerprint as jest.MockedFunction<
+  typeof getCliBinaryFingerprint
+>;
+
+describe('buildQwenModelCatalogFingerprint', () => {
+  beforeEach(() => mockedFingerprint.mockReset());
+
+  it('changes when the CLI is upgraded in place', () => {
+    const settings = getQwenProviderSettings({});
+
+    mockedFingerprint.mockReturnValue('4096:1700000000000');
+    const before = buildQwenModelCatalogFingerprint(settings, '/usr/local/bin/qwen', '');
+
+    // An upgrade over the same path is the whole reason this exists: without the
+    // binary in the key a settled catalog keeps the previous release's models.
+    mockedFingerprint.mockReturnValue('5120:1700000999999');
+    const after = buildQwenModelCatalogFingerprint(settings, '/usr/local/bin/qwen', '');
+
+    expect(mockedFingerprint).toHaveBeenCalledWith('/usr/local/bin/qwen');
+    expect(after).not.toBe(before);
+  });
+
+  it('stays stable while the same build sits at the same path', () => {
+    const settings = getQwenProviderSettings({});
+    mockedFingerprint.mockReturnValue('4096:1700000000000');
+
+    expect(buildQwenModelCatalogFingerprint(settings, '/usr/local/bin/qwen', ''))
+      .toBe(buildQwenModelCatalogFingerprint(settings, '/usr/local/bin/qwen', ''));
+  });
+});

--- a/tests/unit/providers/qwen/ui/QwenSettingsTab.test.ts
+++ b/tests/unit/providers/qwen/ui/QwenSettingsTab.test.ts
@@ -1,0 +1,142 @@
+import { createMockEl } from '@test/helpers/mockElement';
+import { ButtonComponent, Notice } from 'obsidian';
+
+import { getQwenProviderSettings } from '@/providers/qwen/settings';
+import { qwenSettingsTabRenderer } from '@/providers/qwen/ui/QwenSettingsTab';
+
+const mockRefreshModels = jest.fn().mockResolvedValue(true);
+
+jest.mock('fs', () => ({
+  existsSync: jest.fn().mockReturnValue(true),
+  statSync: jest.fn().mockReturnValue({ isFile: () => true }),
+}));
+
+jest.mock('@/i18n/i18n', () => ({
+  t: (key: string, params?: Record<string, string | number>) =>
+    (params ? `${key}:${JSON.stringify(params)}` : key),
+}));
+
+jest.mock('@/providers/qwen/app/QwenWorkspaceServices', () => ({
+  maybeGetQwenWorkspaceServices: jest.fn(() => ({
+    commandCatalog: null,
+    modelCatalog: {
+      isAvailable: () => true,
+      refreshModels: (...args: unknown[]) => mockRefreshModels(...args),
+    },
+  })),
+}));
+
+jest.mock('@/features/settings/ui/EnvironmentSettingsSection', () => ({
+  renderEnvironmentSettingsSection: jest.fn(),
+}));
+jest.mock('@/features/settings/ui/ProviderDisabledNotice', () => ({
+  renderProviderDisabledNotice: jest.fn(),
+}));
+jest.mock('@/features/settings/ui/ProviderSkillSettings', () => ({
+  ProviderSkillSettings: jest.fn(),
+}));
+jest.mock('@/features/settings/ui/McpSettingsManager', () => ({
+  McpSettingsManager: jest.fn(),
+}));
+jest.mock('@/providers/qwen/ui/QwenAgentSettings', () => ({
+  QwenAgentSettings: jest.fn(),
+}));
+jest.mock('@/providers/qwen/ui/QwenCommandSettings', () => ({
+  QwenCommandSettings: jest.fn(),
+}));
+
+const mockNotice = Notice as unknown as jest.Mock;
+
+function createContext(discoveredModels: unknown[]) {
+  const plugin = {
+    app: { vault: { adapter: { basePath: '/vault' } } },
+    getAllViews: jest.fn(() => []),
+    saveSettings: jest.fn().mockResolvedValue(undefined),
+    settings: {
+      providerConfigs: {
+        qwen: { enabled: true, discoveredModels },
+      },
+    },
+  } as any;
+
+  return {
+    plugin,
+    context: {
+      plugin,
+      createWorkspaceSection: jest.fn((container: any) => container),
+      renderAdvancedSection: jest.fn((container: any) => container),
+      renderCustomContextLimits: jest.fn(),
+      renderHiddenProviderCommandSetting: jest.fn(),
+      refreshModelSelectors: jest.fn(),
+      suppressAutomaticDiscovery: false,
+    } as any,
+  };
+}
+
+/** Renders the tab and hands back the one button it builds, with its click handler. */
+function renderTab(discoveredModels: unknown[]) {
+  const handlers: Array<(evt: MouseEvent) => unknown> = [];
+  const onClick = jest.spyOn(ButtonComponent.prototype, 'onClick')
+    .mockImplementation(function mockOnClick(this: ButtonComponent, handler) {
+      handlers.push(handler);
+      return this;
+    });
+  const setDisabled = jest.spyOn(ButtonComponent.prototype, 'setDisabled');
+  const setButtonText = jest.spyOn(ButtonComponent.prototype, 'setButtonText');
+
+  const { plugin, context } = createContext(discoveredModels);
+  qwenSettingsTabRenderer.render(createMockEl(), context);
+  onClick.mockRestore();
+
+  return { context, handlers, plugin, setButtonText, setDisabled };
+}
+
+describe('QwenSettingsTab model refresh', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockRefreshModels.mockResolvedValue(true);
+  });
+
+  it('lets the user ask the CLI for its current model list', async () => {
+    const { context, handlers, plugin, setButtonText, setDisabled } = renderTab([
+      { rawId: 'model-a', label: 'Model A' },
+      { rawId: 'model-b', label: 'Model B' },
+    ]);
+
+    expect(setButtonText).toHaveBeenCalledWith('settings.refreshModels.button');
+
+    await handlers[0]?.({} as MouseEvent);
+
+    // Background picker refreshes never force; this button is the one explicit path.
+    expect(mockRefreshModels).toHaveBeenCalledWith({
+      force: true,
+      plugin,
+      settings: plugin.settings,
+    });
+    expect(getQwenProviderSettings(plugin.settings).discoveredModels).toHaveLength(2);
+    expect(context.refreshModelSelectors).toHaveBeenCalledTimes(1);
+    expect(mockNotice).toHaveBeenCalledWith('settings.refreshModels.done:{"count":2}');
+    expect(setDisabled).toHaveBeenLastCalledWith(false);
+  });
+
+  it('warns and re-enables the button when a refresh finds nothing', async () => {
+    const { context, handlers, setDisabled } = renderTab([]);
+
+    await handlers[0]?.({} as MouseEvent);
+
+    expect(mockNotice).toHaveBeenCalledWith('settings.provider.loadModelsFailed');
+    expect(context.refreshModelSelectors).not.toHaveBeenCalled();
+    expect(setDisabled).toHaveBeenLastCalledWith(false);
+  });
+
+  it('warns and re-enables the button when the refresh throws', async () => {
+    mockRefreshModels.mockRejectedValueOnce(new Error('CLI missing'));
+    const { context, handlers, setDisabled } = renderTab([{ rawId: 'model-a', label: 'Model A' }]);
+
+    await handlers[0]?.({} as MouseEvent);
+
+    expect(mockNotice).toHaveBeenCalledWith('settings.provider.loadModelsFailed');
+    expect(context.refreshModelSelectors).not.toHaveBeenCalled();
+    expect(setDisabled).toHaveBeenLastCalledWith(false);
+  });
+});


### PR DESCRIPTION
### Problem

The same defect #129 fixed for Codex, in the two providers that were left.

`buildGeminiModelCatalogFingerprint()` and `buildQwenModelCatalogFingerprint()`
were built from the CLI path, the per-host path map and the environment. An
upgrade over the same path touches none of them, and
`ProviderModelCatalogRefreshCache` never re-probes a catalog that already holds
models, so the list stayed at whatever the first discovery found. A release that
ships new models was invisible.

Qwen carries it in a worse form. A catalog persisted without a recorded digest is
trusted unconditionally — `seedFingerprintMatches` returns `true` for an empty
`recordedFingerprint`, deliberately, so a list persisted before digests existed
keeps the trust it always had. A real vault shows exactly that state:

```
claude       enabled=True  models= 5   fp=5e66a0ec
codex        enabled=True  models= 7   fp=a6eb94a4   ← fixed in #129
gemini       enabled=False models= 0   fp=-
qwen         enabled=True  models= 6   fp=-          ← pinned indefinitely
```

Nothing short of a path or environment change would ever dislodge those six.

### Fix

**1. Both keys carry the binary** (`f6cb589a`)

`cliBinary: getCliBinaryFingerprint(cliPath)` — the core helper #129 extracted —
joins both fingerprints. An upgrade now changes the key, the persisted digest
stops matching, and the next refresh runs discovery. The same build at the same
path still hashes to the same key, so an unchanged install costs no new probe.

**2. A manual refresh in both settings tabs** (`cd87a9d9`)

The binary fingerprint only notices an upgrade that changed the file Grimoire
resolved. A model added on the service side, a CLI reinstalled elsewhere, or a
digest-less catalog like the Qwen one above still needs a way in. Both tabs gain
the Models section with the same **Refresh models** button Claude and Codex have.

The shared Obsidian mock's `ButtonComponent` gained `setDisabled`. The real
component inherits it from `BaseComponent` and every one of these buttons calls
it; the mock simply never had it, which is why the existing tabs each carry their
own inline button mock.

### Tests

- `tests/unit/providers/{gemini,qwen}/modelCatalogFingerprint.test.ts` (new) — the
  key changes when the binary changes, stays stable when it does not. Both fail on
  `main`.
- `tests/unit/providers/{gemini,qwen}/ui/*SettingsTab.test.ts` (new) — the button
  forces a refresh and reports the count, and warns and re-enables itself both when
  a refresh finds nothing and when it throws. These are the first settings-tab tests
  for either provider.

```
npx jest --selectProjects unit   430 suites, 7623 tests, all passing
npm run typecheck                clean
npm run lint                     clean
npm run review:source            clean
npm run review:css               clean
```

### Scope

Every provider with a CLI-keyed model catalog now folds the binary into its key:
Claude, Codex, Gemini, Qwen. Grok discovers from files rather than a CLI spawn and
is unaffected.