### PR TITLE
fix(chat): stop cutting a model label in half at a bracketed qualifier

### DIFF
--- a/src/features/chat/ui/InputToolbar.ts
+++ b/src/features/chat/ui/InputToolbar.ts
@@ -56,19 +56,62 @@ function formatModelFallbackLabel(model: string): string {
     .replace(/\b\w/g, letter => letter.toUpperCase());
 }
 
-function formatModelButtonLabel(label: string): string {
-  const trimmed = label.trim();
-  const slashIndex = trimmed.lastIndexOf('/');
-  if (slashIndex <= 0 || slashIndex >= trimmed.length - 1) {
-    return trimmed;
+/**
+ * The last `/` that separates a vendor prefix from the model name, or -1.
+ *
+ * A slash inside a bracketed segment belongs to that segment's own text rather
+ * than separating anything: Qwen names its ModelStudio models
+ * `[ModelStudio Token Plan for Global/Intl] qwen3.7-plus`, and cutting there
+ * leaves half a bracket on each side.
+ */
+function findModelVendorSeparator(label: string): number {
+  let depth = 0;
+  let separator = -1;
+
+  for (let index = 0; index < label.length; index += 1) {
+    const char = label[index];
+    if (char === '[' || char === '(') {
+      depth += 1;
+    } else if (char === ']' || char === ')') {
+      depth = Math.max(0, depth - 1);
+    } else if (char === '/' && depth === 0) {
+      separator = index;
+    }
   }
 
-  return trimmed.slice(slashIndex + 1).trim() || trimmed;
+  return separator;
 }
 
+/** Splits `[qualifier] model` into its two parts, or null when that is not the shape. */
+function splitLeadingQualifier(label: string): { detail: string; label: string } | null {
+  if (!label.startsWith('[')) {
+    return null;
+  }
+
+  const end = label.indexOf(']');
+  if (end <= 1) {
+    return null;
+  }
+
+  const detail = label.slice(1, end).trim();
+  const modelLabel = label.slice(end + 1).trim();
+  return detail && modelLabel ? { detail, label: modelLabel } : null;
+}
+
+/**
+ * A model label can name the plan or vendor it comes from, either as a
+ * `<vendor>/<model>` prefix (`MiniMax Token Plan (minimax.io)/MiniMax-M2.7`) or as
+ * a leading `[qualifier]` (Qwen's `[Z.AI] GLM-5.2`). Both are the same thing to a
+ * reader: the model's name, and where it comes from.
+ */
 function splitModelOptionLabel(label: string): { detail: string | null; label: string } {
   const trimmed = label.trim();
-  const slashIndex = trimmed.lastIndexOf('/');
+  const qualified = splitLeadingQualifier(trimmed);
+  if (qualified) {
+    return qualified;
+  }
+
+  const slashIndex = findModelVendorSeparator(trimmed);
   if (slashIndex <= 0 || slashIndex >= trimmed.length - 1) {
     return { detail: null, label: trimmed };
   }
@@ -79,6 +122,11 @@ function splitModelOptionLabel(label: string): { detail: string | null; label: s
     detail: detail || null,
     label: modelLabel || trimmed,
   };
+}
+
+/** The collapsed button shows the model name alone; the qualifier lives in the dropdown. */
+function formatModelButtonLabel(label: string): string {
+  return splitModelOptionLabel(label).label;
 }
 
 const PLAN_USAGE_WARN_THRESHOLD = 80;

--- a/tests/unit/features/chat/ui/InputToolbar.test.ts
+++ b/tests/unit/features/chat/ui/InputToolbar.test.ts
@@ -755,6 +755,85 @@ describe('ModelSelector', () => {
     );
   });
 
+  it('keeps a bracketed qualifier whole when it contains a slash of its own', () => {
+    const uiConfig = createMockUIConfig();
+    const model = 'qwen3.7-plus(openai)';
+    uiConfig.getModelOptions.mockReturnValue([
+      {
+        value: model,
+        // Qwen's own naming: the plan is bracketed and the slash belongs to it.
+        label: '[ModelStudio Token Plan for Global/Intl] qwen3.7-plus',
+        group: 'Qwen Code',
+      },
+    ]);
+    callbacks.getUIConfig.mockReturnValue(uiConfig);
+
+    selector.renderOptions();
+
+    const copy = parentEl.querySelector('.grimoire-model-option')
+      ?.querySelector('.grimoire-model-option-copy');
+
+    expect(copy?.querySelector('.grimoire-model-option-label')?.textContent)
+      .toBe('qwen3.7-plus');
+    expect(copy?.querySelector('.grimoire-model-option-detail')?.textContent)
+      .toBe('ModelStudio Token Plan for Global/Intl');
+  });
+
+  it('reads a leading bracketed qualifier as the source of the model', () => {
+    const uiConfig = createMockUIConfig();
+    uiConfig.getModelOptions.mockReturnValue([
+      { value: 'GLM-5.2(openai)', label: '[Z.AI] GLM-5.2', group: 'Qwen Code' },
+    ]);
+    callbacks.getUIConfig.mockReturnValue(uiConfig);
+
+    selector.renderOptions();
+
+    const copy = parentEl.querySelector('.grimoire-model-option')
+      ?.querySelector('.grimoire-model-option-copy');
+
+    expect(copy?.querySelector('.grimoire-model-option-label')?.textContent).toBe('GLM-5.2');
+    expect(copy?.querySelector('.grimoire-model-option-detail')?.textContent).toBe('Z.AI');
+  });
+
+  it('leaves a bracket that is not a leading qualifier alone', () => {
+    const uiConfig = createMockUIConfig();
+    uiConfig.getModelOptions.mockReturnValue([
+      { value: 'opus[1m]', label: 'Opus (1M context)', group: 'Claude Code' },
+      { value: 'bare', label: '[unnamed]', group: 'Claude Code' },
+    ]);
+    callbacks.getUIConfig.mockReturnValue(uiConfig);
+
+    selector.renderOptions();
+
+    const labels = (Array.from<any>(parentEl.querySelectorAll('.grimoire-model-option-label')))
+      .map(el => el.textContent);
+    expect(labels).toEqual(['Opus (1M context)', '[unnamed]']);
+  });
+
+  it('shows the model name alone on the collapsed button', () => {
+    const uiConfig = createMockUIConfig();
+    const model = 'qwen3.7-plus(openai)';
+    uiConfig.getModelOptions.mockReturnValue([
+      {
+        value: model,
+        label: '[ModelStudio Token Plan for Global/Intl] qwen3.7-plus',
+        group: 'Qwen Code',
+      },
+    ]);
+    callbacks.getUIConfig.mockReturnValue(uiConfig);
+    callbacks.getSettings.mockReturnValue({
+      model,
+      thinkingBudget: 'low',
+      effortLevel: 'high',
+      serviceTier: 'default',
+      permissionMode: 'normal',
+    });
+
+    selector.updateDisplay();
+
+    expect(parentEl.querySelector('.grimoire-model-label')?.textContent).toBe('qwen3.7-plus');
+  });
+
   it('should not render group separators when models have no group field', () => {
     selector.renderOptions();
 


### PR DESCRIPTION
### Problem

The model picker splits a label at its last `/` to separate a vendor prefix from
the model name — the shape OpenCode and MiniMax use
(`MiniMax Token Plan (minimax.io)/MiniMax-M2.7-highspeed`).

Qwen names its ModelStudio models `[ModelStudio Token Plan for Global/Intl] qwen3.7-plus`,
where the slash belongs to the bracketed plan name. Splitting there cuts the
bracket in half, and the row renders:

```
Intl] qwen3.7-plus
[ModelStudio Token Plan for Global
```

Half a bracket on each line. The same split feeds the collapsed button, so a
selected ModelStudio model reads `Intl] qwen3.7-plus` there too.

Real labels from a vault's Qwen catalog:

```
[Z.AI] GLM-5.2
[ModelStudio Token Plan for Global/Intl] qwen3.7-plus
```

### Fix

Two changes to the same idea — a label names the model and where it comes from,
and neither part should be cut through the middle.

`findModelVendorSeparator()` ignores a slash inside brackets or parentheses, so
the vendor split only fires where a vendor prefix actually ends. The MiniMax
shape is unaffected: its parentheses close before the slash.

A leading `[qualifier]` is then read the same way a `<vendor>/` prefix already
was. `[Z.AI] GLM-5.2` renders GLM-5.2 with Z.AI on the detail line, and the
collapsed button shows the model name alone. Both shapes now render alike,
because they say the same thing.

`formatModelButtonLabel()` is now the label half of that one split rather than a
second copy of the parsing.

The full label stays in the row's tooltip, so nothing is hidden.

### Tests

`tests/unit/features/chat/ui/InputToolbar.test.ts` — four new cases: a bracketed
qualifier holding a slash of its own, a plain leading qualifier, a bracket that is
*not* a leading qualifier (`Opus (1M context)`, and `[unnamed]` with nothing after
it) left alone, and the collapsed button showing the model name alone. Three of
them fail on `main`; the existing MiniMax vendor-prefix case passes unchanged.

```
npx jest --selectProjects unit   426 suites, 7617 tests, all passing
npm run typecheck                clean
npm run lint                     clean
```