### PR TITLE
fix(tests): let the fake agent exit before the wire recorder removes its vault

### DIFF
--- a/tests/helpers/recordAcpWire.ts
+++ b/tests/helpers/recordAcpWire.ts
@@ -230,7 +230,17 @@ export async function recordAcpWire(
   }
 
   child.stdin.end();
+  const exited = new Promise<void>(resolve => {
+    if (child.exitCode !== null || child.signalCode !== null) {
+      resolve();
+      return;
+    }
+    child.once('exit', () => resolve());
+  });
   child.kill();
+  // Windows keeps a handle on a live process's cwd, so the vault cannot be
+  // removed until the child is actually gone. `kill` only asks.
+  await exited;
   rmSync(vault, { force: true, recursive: true });
 
   const fromAgent = exchanges.filter(exchange => exchange.direction === 'server->client');

--- a/tests/helpers/recordAcpWire.ts
+++ b/tests/helpers/recordAcpWire.ts
@@ -42,6 +42,8 @@ export interface AcpWireRecordingTimings {
   readonly turnMs: number;
   /** After the turn's own result, for whatever trails it. */
   readonly graceMs: number;
+  /** How long a killed CLI is given to leave before it is killed outright. */
+  readonly shutdownMs: number;
 }
 
 const DEFAULT_TIMINGS: AcpWireRecordingTimings = {
@@ -54,6 +56,7 @@ const DEFAULT_TIMINGS: AcpWireRecordingTimings = {
   // Kimi Code sends its `usage_update` after `session/prompt` returns, so
   // stopping at the result would drop the one frame that row is about.
   graceMs: 5_000,
+  shutdownMs: 5_000,
 };
 
 /** One line on the wire, in the shape every recording already uses. */
@@ -239,8 +242,19 @@ export async function recordAcpWire(
   });
   child.kill();
   // Windows keeps a handle on a live process's cwd, so the vault cannot be
-  // removed until the child is actually gone. `kill` only asks.
-  await exited;
+  // removed until the child is actually gone. `kill` only asks — and a CLI
+  // that traps SIGTERM to shut down gracefully answers it in its own time, or
+  // not at all. Every other wait here is bounded; this one is too.
+  await Promise.race([exited, new Promise<void>(resolve => {
+    // Unref'd because the loser of this race is still counting: a ref'd timer
+    // holds the event loop open for the rest of its wait after the child has
+    // already gone, which Jest reports as a handle the run leaked.
+    setTimeout(resolve, timings.shutdownMs).unref();
+  })]);
+  if (child.exitCode === null && child.signalCode === null) {
+    child.kill('SIGKILL');
+    await exited;
+  }
   rmSync(vault, { force: true, recursive: true });
 
   const fromAgent = exchanges.filter(exchange => exchange.direction === 'server->client');

--- a/tests/integration/providers/wire/AcpWireRecorder.integration.test.ts
+++ b/tests/integration/providers/wire/AcpWireRecorder.integration.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -54,7 +54,13 @@ process.stdin.on('data', chunk => {
       } });
     }
     if (request.method === 'session/prompt') {
-      if (mode === 'silent') continue;
+      if (mode === 'stubborn') {
+        // Traps the signal and stays up, the way a CLI with a graceful
+        // shutdown does. The interval keeps the loop alive once stdin ends.
+        process.on('SIGTERM', () => {});
+        setInterval(() => {}, 1000);
+      }
+      if (mode === 'silent' || mode === 'stubborn') continue;
       if (mode === 'answers') {
         send({ jsonrpc: '2.0', method: 'session/update', params: {
           sessionId: 'fake-session',
@@ -86,9 +92,16 @@ describe('the ACP wire recorder', () => {
   });
 
   /** Short enough to keep the suite quick; the recorder's own defaults are minutes. */
-  const timings = { handshakeMs: 200, sessionMs: 400, configMs: 100, turnMs: 4_000, graceMs: 200 };
+  const timings = {
+    handshakeMs: 200,
+    sessionMs: 400,
+    configMs: 100,
+    turnMs: 4_000,
+    graceMs: 200,
+    shutdownMs: 300,
+  };
 
-  function record(mode: 'answers' | 'empty' | 'silent'): Promise<Record<string, unknown>> {
+  function record(mode: 'answers' | 'empty' | 'silent' | 'stubborn'): Promise<Record<string, unknown>> {
     return recordAcpWire({
       providerId: 'fake',
       command: process.execPath,
@@ -143,6 +156,22 @@ describe('the ACP wire recorder', () => {
       + 'What the prompt would have produced is unrecorded, and unknown.',
       'The handshake is evidence; the turn needs a longer wait than this recording gave it.',
     ]);
+  });
+
+  it('stops waiting on a CLI that will not take the hint', async () => {
+    // `kill` only asks, and a CLI with a graceful shutdown can decline. The
+    // recorder used to remove the vault out from under a live process, which
+    // Windows refuses; waiting for the process instead is only safe if the
+    // wait ends. Without the escalation this row hangs until the suite's own
+    // timeout.
+    const vaults = (): string[] => readdirSync(tmpdir())
+      .filter(entry => entry.startsWith('grimoire-fake-wire-'));
+    const before = vaults();
+
+    const recording = await record('stubborn');
+
+    expect(recording.coverage).toBe('partial');
+    expect(vaults()).toEqual(before);
   });
 
   it('writes the recording where it was told to', async () => {


### PR DESCRIPTION
### Problem

`tests/helpers/recordAcpWire.ts` spawns the fake agent with `cwd: vault`, then
kills it and removes the vault in the very next statement:

```ts
child.stdin.end();
child.kill();
rmSync(vault, { force: true, recursive: true });
```

On Windows a live process holds a handle on its working directory, so the
removal raises `EPERM` before a single assertion runs. All five
`AcpWireRecorder.integration.test.ts` cases fail on the host OS:

```
EPERM, Permission denied: \?\C:\WINDOWS\TEMP\grimoire-fake-wire-NPqlaX
  at tests/helpers/recordAcpWire.ts:234:9
```

The recorder itself is fine — the failure is cleanup ordering in the helper,
and it hides whatever the assertions would have said. `kill` only asks a
process to leave; it does not wait for it.

### Fix

Wait for the child's `exit` event before removing the directory, with a guard
for a process that has already gone.

POSIX is unaffected: it already allowed removing a directory that a live
process was using, and now it simply waits for a process that was leaving
anyway.

### Verification

Windows 11, Node 24.19.0, at `65dc6775`.

- Before: `--selectProjects integration --runInBand` → 5 failed, 157 passed.
- After: same command → **162 passed, 0 failed**.
- `tsc --noEmit` and `eslint` clean.

Note for the matrix: `CodexPersistentProcessOwnership.integration.test.ts`
passes 5/5 in isolation but failed under the default parallel run. That looks
like cross-suite contention over the shared guardian cache rather than a
defect, and it is not addressed here.