### PR TITLE
fix(chat): keep restored conversations bound across projection hydration

### DIFF
--- a/src/features/chat/rendering/ChatProjectionRenderer.ts
+++ b/src/features/chat/rendering/ChatProjectionRenderer.ts
@@ -169,10 +169,16 @@ export class ChatProjectionRenderer {
     this.target.reset({
       conversationId: projection.conversationId,
       title: projection.title,
-      messages: withoutTurnAnswers(projection),
+      messages: withoutUnsavedTurnAnswers(projection),
     });
     for (const turn of projection.turns) {
-      this.openTurn(turn);
+      // A saved turn is already represented by its durable assistant message.
+      // Replaying its transient blocks after a full reset would draw the same
+      // answer twice; removing the durable message instead makes the answer
+      // disappear when those transient blocks are no longer renderable.
+      if (turn.persistence !== 'saved') {
+        this.openTurn(turn);
+      }
     }
     for (const interaction of projection.interactions) {
       if (isOpenInteraction(interaction)) {
@@ -371,8 +377,10 @@ function turnAnswerIds(projection: ChatProjection): Set<string> {
   return new Set(projection.turns.map(turn => turn.assistantMessageId));
 }
 
-function withoutTurnAnswers(projection: ChatProjection): readonly ChatMessage[] {
-  const answered = turnAnswerIds(projection);
+function withoutUnsavedTurnAnswers(projection: ChatProjection): readonly ChatMessage[] {
+  const answered = new Set(projection.turns
+    .filter(turn => turn.persistence !== 'saved')
+    .map(turn => turn.assistantMessageId));
   return answered.size === 0
     ? projection.messages
     : projection.messages.filter(message => !answered.has(message.id));

--- a/src/features/chat/rendering/ChatProjectionRenderer.ts
+++ b/src/features/chat/rendering/ChatProjectionRenderer.ts
@@ -76,6 +76,19 @@ export interface ChatRenderTarget {
   setTitle(title: string): void;
   appendMessage(message: ChatMessage): void;
   beginTurn(turn: ChatTurnView): void;
+  /**
+   * Binds a turn to the answer it already has, drawing nothing.
+   *
+   * `beginTurn` opens a new answer: it creates the assistant message and its
+   * bubble. A saved turn already has both in the transcript a redraw just
+   * reset from, so opening a second one is the duplicate this renderer avoids
+   * by not replaying the turn at all. But a turn nobody registered is a turn
+   * nothing can address later, and `reconcileTurn` is documented to arrive
+   * "sometimes much later" — after a redraw it had nowhere to land and was
+   * dropped in silence, leaving "could not establish whether this run
+   * completed" on screen as the last word.
+   */
+  adoptTurn(turn: ChatTurnView): void;
   /** A new block for this turn. The target finalizes whatever it had open. */
   openTurnBlock(runId: RunId, index: number, item: ChatLiveItem): void;
   /** More text into a block already open at this index. */
@@ -175,10 +188,14 @@ export class ChatProjectionRenderer {
       // A saved turn is already represented by its durable assistant message.
       // Replaying its transient blocks after a full reset would draw the same
       // answer twice; removing the durable message instead makes the answer
-      // disappear when those transient blocks are no longer renderable.
-      if (turn.persistence !== 'saved') {
-        this.openTurn(turn);
+      // disappear when those transient blocks are no longer renderable. So it
+      // is adopted rather than opened: nothing is drawn, and what arrives for
+      // this run afterwards still has a message to arrive at.
+      if (turn.persistence === 'saved') {
+        this.target.adoptTurn(turnView(turn));
+        continue;
       }
+      this.openTurn(turn);
     }
     for (const interaction of projection.interactions) {
       if (isOpenInteraction(interaction)) {
@@ -190,12 +207,7 @@ export class ChatProjectionRenderer {
   }
 
   private openTurn(turn: ChatTurnProjection): void {
-    this.target.beginTurn({
-      runId: turn.runId,
-      commandId: turn.commandId,
-      assistantMessageId: turn.assistantMessageId,
-      startedAt: turn.startedAt,
-    });
+    this.target.beginTurn(turnView(turn));
     for (const [index, item] of turn.live.entries()) {
       this.target.openTurnBlock(turn.runId, index, item);
     }
@@ -371,6 +383,15 @@ function extendedText(previous: ChatLiveItem, next: ChatLiveItem): string {
   return previous.kind === 'provider-content' || next.kind === 'provider-content'
     ? ''
     : next.text.slice(previous.text.length);
+}
+
+function turnView(turn: ChatTurnProjection): ChatTurnView {
+  return {
+    runId: turn.runId,
+    commandId: turn.commandId,
+    assistantMessageId: turn.assistantMessageId,
+    startedAt: turn.startedAt,
+  };
 }
 
 function turnAnswerIds(projection: ChatProjection): Set<string> {

--- a/src/features/chat/rendering/ChatSurfaceRenderTarget.ts
+++ b/src/features/chat/rendering/ChatSurfaceRenderTarget.ts
@@ -280,6 +280,19 @@ export class ChatSurfaceRenderTarget implements ChatRenderTarget {
     this.deps.stream.startTurnSilenceIndicator(this.deps.getProviderId());
   }
 
+  adoptTurn(turn: ChatTurnView): void {
+    // Whatever `reset` just put in the transcript is the answer this run
+    // wrote, so the run is bound to it rather than to a message of its own.
+    // A turn that said nothing names a message that was never created; then
+    // there is nothing to bind and nothing addresses it, as before.
+    const message = this.deps.state.messages.find(
+      candidate => candidate.id === turn.assistantMessageId,
+    );
+    if (message) {
+      this.turnMessages.set(turn.runId, message);
+    }
+  }
+
   openTurnBlock(runId: RunId, index: number, item: ChatLiveItem): void {
     const message = this.turnMessages.get(runId);
     if (!message) {

--- a/src/features/chat/tabs/TabManager.ts
+++ b/src/features/chat/tabs/TabManager.ts
@@ -365,8 +365,15 @@ export class TabManager implements TabManagerInterface {
       activateTab(tab);
       refreshRuntimeContextUI(tab, this.plugin);
 
-      // Load conversation if not already loaded
-      if (tab.conversationId && tab.state.messages.length === 0) {
+      // Bind by identity, not by whether projection hydration happened to draw
+      // messages first. A restored tab opens its projection asynchronously; if
+      // that reset wins this race, messages are already present while
+      // ChatState still has no conversation id. Treating message presence as
+      // proof of a binding leaves post-turn save to create a duplicate chat.
+      if (
+        tab.conversationId
+        && tab.state.currentConversationId !== tab.conversationId
+      ) {
         await tab.controllers.conversationController?.switchTo(tab.conversationId);
       } else if (
         tab.conversationId

--- a/tests/unit/features/chat/rendering/ChatProjectionRenderer.test.ts
+++ b/tests/unit/features/chat/rendering/ChatProjectionRenderer.test.ts
@@ -257,6 +257,52 @@ describe('chat projection renderer', () => {
     ]);
   });
 
+  it('keeps a saved turn answer when a later transcript rewrite forces a redraw', () => {
+    const target = recordingTarget();
+    const renderer = new ChatProjectionRenderer(target);
+    let projection = started(createChatProjection(conversation([message('msg-1', 'user', 'Hi')]), 1));
+    projection = envelope(projection, 1, {
+      kind: 'output-delta',
+      channel: 'assistant',
+      text: 'Hello.',
+    });
+    projection = envelope(projection, 2, {
+      kind: 'terminal',
+      terminal: 'succeeded',
+      reason: 'completed',
+    });
+    projection = reduceChatProjection(projection, {
+      kind: 'turn-completed',
+      runId: RUN_ID,
+      conversation: conversation([
+        message('msg-1', 'user', 'Hi'),
+        message('assistant-1', 'assistant', 'Hello.'),
+      ]),
+      revision: 2,
+      completedAt: 20,
+    });
+    renderer.render(projection);
+    target.calls.splice(0);
+
+    renderer.render(reduceChatProjection(projection, {
+      kind: 'conversation-loaded',
+      conversation: conversation([
+        message('msg-1-reloaded', 'user', 'Hi'),
+        message('assistant-1', 'assistant', 'Hello.'),
+      ]),
+      revision: 3,
+    }));
+
+    const reset = target.calls.find(call => call.method === 'reset');
+    expect(reset?.args[0]).toEqual(expect.objectContaining({
+      messages: [
+        expect.objectContaining({ id: 'msg-1-reloaded' }),
+        expect.objectContaining({ id: 'assistant-1' }),
+      ],
+    }));
+    expect(methods(target)).not.toContain('beginTurn');
+  });
+
   it('shows an interaction while it is open and takes it away when it is answered', () => {
     const target = recordingTarget();
     const renderer = new ChatProjectionRenderer(target);

--- a/tests/unit/features/chat/rendering/ChatProjectionRenderer.test.ts
+++ b/tests/unit/features/chat/rendering/ChatProjectionRenderer.test.ts
@@ -52,6 +52,7 @@ function recordingTarget(): ChatRenderTarget & { readonly calls: RecordedCall[] 
     setTitle: record('setTitle'),
     appendMessage: record('appendMessage'),
     beginTurn: record('beginTurn'),
+    adoptTurn: record('adoptTurn'),
     openTurnBlock: record('openTurnBlock'),
     extendTurnText: record('extendTurnText'),
     setTurnState: record('setTurnState'),
@@ -301,6 +302,66 @@ describe('chat projection renderer', () => {
       ],
     }));
     expect(methods(target)).not.toContain('beginTurn');
+  });
+
+  it('leaves a redrawn saved turn something for a late reconciliation to reach', () => {
+    // `reconcileTurn` is documented to arrive "sometimes much later", and it is
+    // the only thing that can replace "could not establish whether this run
+    // completed". A saved turn is not re-opened on redraw, so without adopting
+    // it the surface holds no message for this run and the evidence lands
+    // nowhere — the sentence stays on screen as the last word.
+    const target = recordingTarget();
+    const renderer = new ChatProjectionRenderer(target);
+    let projection = started(createChatProjection(conversation([message('msg-1', 'user', 'Hi')]), 1));
+    projection = envelope(projection, 1, {
+      kind: 'terminal',
+      terminal: 'indeterminate',
+      reason: 'cancellation-unknown',
+    });
+    projection = reduceChatProjection(projection, {
+      kind: 'turn-completed',
+      runId: RUN_ID,
+      conversation: conversation([
+        message('msg-1', 'user', 'Hi'),
+        message('assistant-1', 'assistant', ''),
+      ]),
+      revision: 2,
+      completedAt: 20,
+    });
+    renderer.render(projection);
+
+    // The redraw this PR is about: a transcript rewrite the renderer cannot
+    // express as an increment.
+    projection = reduceChatProjection(projection, {
+      kind: 'conversation-loaded',
+      conversation: conversation([
+        message('msg-1-reloaded', 'user', 'Hi'),
+        message('assistant-1', 'assistant', ''),
+      ]),
+      revision: 3,
+    });
+    renderer.render(projection);
+    expect(methods(target)).toContain('adoptTurn');
+    expect(target.calls.find(call => call.method === 'adoptTurn')?.args[0])
+      .toEqual(expect.objectContaining({ assistantMessageId: 'assistant-1', runId: RUN_ID }));
+    target.calls.splice(0);
+
+    renderer.render(reduceChatProjection(projection, {
+      kind: 'reconciliation-record',
+      record: {
+        reconciliationId: `rec-${'6'.repeat(32)}`,
+        runId: RUN_ID,
+        originalTerminal: 'indeterminate',
+        observedOutcome: 'succeeded',
+        evidence: { kind: 'native-history', evidenceRef: 'thread-1' },
+        recordedAt: 30,
+      },
+    }));
+
+    expect(target.calls).toEqual([{
+      method: 'reconcileTurn',
+      args: [RUN_ID, expect.objectContaining({ observedOutcome: 'succeeded' })],
+    }]);
   });
 
   it('shows an interaction while it is open and takes it away when it is answered', () => {

--- a/tests/unit/features/chat/rendering/ChatSurfaceRenderTarget.test.ts
+++ b/tests/unit/features/chat/rendering/ChatSurfaceRenderTarget.test.ts
@@ -548,6 +548,52 @@ describe('chat surface render target', () => {
       .toBe('This turn was later established to have succeeded.');
   });
 
+  it('adopts a redrawn turn onto the answer it already has, and draws nothing doing it', async () => {
+    // A saved turn is not re-opened after a redraw — `beginTurn` would put a
+    // second bubble beside the one the transcript already holds. Adopting binds
+    // the run to that message instead, so evidence arriving afterwards has
+    // somewhere to land. Without it `reconcileTurn` finds no message and the
+    // sentence it exists to replace stays on screen.
+    const chat = harness();
+    const answer = {
+      id: `assistant-${RUN_ID}`,
+      role: 'assistant' as const,
+      content: 'Hello.',
+      timestamp: 1,
+    };
+    chat.target.reset({
+      conversationId: 'conv-1',
+      title: 'Tomatoes',
+      messages: [{ id: 'msg-1', role: 'user', content: 'Hi', timestamp: 1 }, answer],
+    });
+    chat.clear();
+
+    chat.target.adoptTurn({
+      runId: RUN_ID,
+      commandId: 'cmd-1',
+      assistantMessageId: `assistant-${RUN_ID}`,
+      startedAt: 1,
+    });
+
+    await drained(chat.target);
+    // No bubble, no cursor, no indicators: adopting is bookkeeping.
+    expect(chat.methods()).toEqual([]);
+
+    chat.target.reconcileTurn(RUN_ID, {
+      reconciliationId: `rec-${'6'.repeat(32)}`,
+      observedOutcome: 'succeeded',
+      evidence: { kind: 'native-history', evidenceRef: 'thread-1' },
+      recordedAt: 20,
+    });
+
+    await drained(chat.target);
+    const chunk = chat.calls.find(call => call.method === 'handleStreamChunk');
+    expect((chunk?.args[0] as { content: string }).content)
+      .toBe('This turn was later established to have succeeded.');
+    // Into the transcript's own message, not a copy of it.
+    expect(chunk?.args[1]).toBe(chat.state.messages[1]);
+  });
+
   it('draws a conversation from nothing and forgets the turns it was holding', async () => {
     const chat = harness();
     beginTurn(chat.target);

--- a/tests/unit/features/chat/tabs/TabManager.test.ts
+++ b/tests/unit/features/chat/tabs/TabManager.test.ts
@@ -478,6 +478,34 @@ describe('TabManager - Tab Lifecycle', () => {
       // Service initialization is now lazy (on first query), not on switch
       expect(mockInitializeTabService).not.toHaveBeenCalled();
     });
+
+    it('restores the conversation binding when projection hydration wins the tab-load race', async () => {
+      const tab = createMockTabData({
+        id: 'restored-tab',
+        conversationId: 'conv-restored',
+        state: {
+          currentConversationId: null,
+          messages: [{ id: 'message-1', role: 'user', content: 'Already projected' }],
+        },
+      });
+      const manager = createManager({
+        callbacks,
+        plugin: createMockPlugin({
+          getConversationById: jest.fn().mockResolvedValue({
+            id: 'conv-restored',
+            providerId: 'claude',
+            messages: [],
+          }),
+        }),
+        tabFactory: () => tab,
+      });
+
+      await manager.createTab('conv-restored');
+
+      expect(tab.controllers.conversationController.switchTo).toHaveBeenCalledWith(
+        'conv-restored',
+      );
+    });
   });
 
   describe('closeTab', () => {
@@ -2945,6 +2973,7 @@ describe('TabManager - switchToTab Session Sync', () => {
       });
       // For tab-2, simulate already having messages loaded
       if (tabCounter === 2) {
+        tab.state.currentConversationId = 'conv-loaded';
         tab.state.messages = [{ id: 'msg-1', role: 'user', content: 'test' }] as any;
       }
       return tab;
@@ -2995,6 +3024,7 @@ describe('TabManager - switchToTab Session Sync', () => {
         service: mockService,
         serviceInitialized: true,
         state: {
+          currentConversationId: 'conv-streaming',
           isStreaming: true,
           messages: [{ id: 'msg-1', role: 'user', content: 'test' }],
         },
@@ -3049,6 +3079,7 @@ describe('TabManager - switchToTab Session Sync', () => {
         service: mockService,
         serviceInitialized: true,
         state: {
+          currentConversationId: 'conv-pending-save',
           hasPendingConversationSave: true,
           messages: [{ id: 'msg-1', role: 'user', content: 'test' }],
         },


### PR DESCRIPTION
## Problem

A restored conversation could look fully loaded while its mutable chat state was not bound to the conversation shown by the tab.

If projection hydration populated `state.messages` before `TabManager.switchToTab()` ran, the old restoration guard treated the non-empty message list as proof that loading had already completed. `state.currentConversationId` could therefore remain `null` while `tab.conversationId` still pointed to the restored conversation.

After the next terminal turn, the normal save path treated that split state as a new conversation. It created a duplicate record and rebound the tab to it. The original persistent transcript remained on disk, but the user saw the conversation disappear or change.

A related redraw path could also temporarily hide already-saved assistant answers. Runtime projection entries were excluded from the durable transcript even after their persistence state had become `saved`, so the answers disappeared until restart removed the runtime entries.

Fixes #138

## Root Cause

Two identity decisions relied on projection content rather than persistence state.

First, `TabManager.switchToTab()` restored a tab only when the target conversation existed and `state.messages.length === 0`. Projection hydration can legitimately win that race and populate the messages before the tab switch without setting `state.currentConversationId`. The indirect message-count check then skipped the required conversation load.

Second, `ChatProjectionRenderer.renderAll()` removed assistant messages for every runtime turn before rebuilding the projection. That was correct for unsaved live turns, whose assistant output is rendered from transient blocks, but not for turns already marked `persistence: 'saved'`. Their durable assistant messages were removed even though their transient blocks should no longer replace persisted content.

The reproduced split state was:

```text
tab.conversationId = restored conversation
state.currentConversationId = null
state.messages = hydrated conversation history
```

The transcript itself was not deleted.

## Approach

This PR keeps the changes within the shared chat owners of the two faulty decisions.

1. `TabManager.switchToTab()` now compares conversation identity directly. It loads the restored conversation whenever `state.currentConversationId !== tab.conversationId`, regardless of whether projection hydration has already populated messages.
2. `ChatProjectionRenderer` now excludes assistant messages only for runtime turns which are not yet saved.
3. Saved turns keep their assistant messages from the durable transcript and do not replay transient live blocks.
4. Unsaved turns continue to render from live blocks without duplicating assistant content.
5. Focused regression tests cover both race orderings and the forced-redraw case.

The alternative of making message hydration set `currentConversationId` was rejected because projection rendering should not take ownership of conversation identity. The tab/conversation controller remains the owner of that binding.

## Architecture

- [x] Provider-native behavior remains inside `src/providers/<provider>/`.
- [x] Shared code is provider-neutral and used by at least two providers, or the PR explains why it belongs there.
- [x] I checked sibling providers when changing a shared ACP or provider contract.

Architecture notes:

No provider or ACP contract changes. The defect reproduced with Grok and Antigravity because both consume the same provider-neutral tab and projection lifecycle. Conversation identity remains owned by `TabManager`; durable-versus-transient rendering remains owned by `ChatProjectionRenderer`.

## Security And Privacy

- [x] Provider/session/model data is treated as untrusted input.
- [x] Permission changes cannot silently widen persistent authorization.
- [x] Filesystem, process, credential, MCP, and external-path boundaries are unchanged or explained below.
- [x] Logs and fixtures contain no secrets, prompts, note contents, local paths, or unsanitized provider payloads.

Security notes:

No security boundary change. The patch changes neither authorization nor filesystem access. It binds restored UI state to an already selected persisted conversation ID and changes only which already-persisted assistant messages are included in a redraw. Tests use synthetic identifiers and content.

## Verification

Automated commands run on Windows from the main clone:

```text
node scripts/run-jest.js --selectProjects unit --runInBand --testPathPatterns "ChatProjectionRenderer.test.ts|TabManager.test.ts"
npx tsc --noEmit
npx eslint "src/features/chat/rendering/ChatProjectionRenderer.ts" "src/features/chat/tabs/TabManager.ts" "tests/unit/features/chat/rendering/ChatProjectionRenderer.test.ts" "tests/unit/features/chat/tabs/TabManager.test.ts" --max-warnings=0
node scripts/run-jest.js --selectProjects unit --runInBand
npm run build:release
```

Results:

- focused regression suites: `2/2` suites, `130/130` tests passed;
- typecheck: passed;
- focused ESLint: passed with zero warnings;
- release build: passed;
- Obsidian source, CSS, and dependency review gates invoked by the release build: passed;
- isolated release bundle load and `grimoire-view` smoke checks: passed;
- full Windows unit suite on this branch: `17` suites / `23` tests failed, `8997` passed;
- the exact `65dc6775` baseline in the same clone: the same `17` suites / `23` tests failed, `8995` passed;
- failure set is unchanged; this PR adds two passing regression tests and no Windows-unit regression.

Manual verification:

The two source commits were previously installed together with unrelated diagnostic fixes in a local Windows Obsidian test vault. After a normal restart, the original disappearing-conversation symptom has not reproduced again so far. Persistent history remained visible and no further tab rebind was observed during the available checks.

The release artifact built from this isolated PR branch was not installed separately. The manual result is therefore supporting evidence for the same two commits, not a claim that the exact isolated artifact received an independent end-to-end run.

## Generated Artifacts

- [x] `npm run build:release` recreates `dist/grimoire/main.js`, `manifest.json`, and `styles.css` from the submitted source.
- [x] `package-lock.json` matches `package.json` when dependencies change.
- [x] Generated root bundles, `dist/grimoire`, and local-only artifacts are not included.

No dependency or package metadata changed.

## Review Checklist

- [x] The PR is focused on one coherent problem.
- [x] Behavior changes have focused regression tests.
- [x] Protocol-test requirement reviewed; not applicable because this PR changes no provider protocol behavior.
- [x] Documentation and user-facing copy are in English.
- [x] The PR description accurately distinguishes automated tests from manual verification.