### PR TITLE
fix(antigravity): end a turn on its own evidence, not on the CLI process

### DIFF
--- a/src/providers/antigravity/execution/AntigravityExecutionComposition.ts
+++ b/src/providers/antigravity/execution/AntigravityExecutionComposition.ts
@@ -54,7 +54,23 @@ import {
 } from '../runtime/AntigravityImageAttachments';
 
 /** Combined stdout, stderr, and recovered-transcript ceiling for one run. */
-const OUTPUT_BYTE_LIMIT = 64_000;
+/**
+ * How much one print turn may say before the run is stopped.
+ *
+ * A ceiling on memory, not a budget for an answer: the runner keeps the whole
+ * stream so the transcript can be parsed, so something has to bound it.
+ *
+ * The number matters. It used to be `OUTPUT_BUFFER_LIMIT = 64_000` — the size
+ * of a *sliding* parse buffer (`.slice(-OUTPUT_BUFFER_LIMIT)`), which bounded
+ * memory while letting a turn print without end. Carried over to a cumulative
+ * budget, the same 64 KB stopped meaning "keep the last 64 KB" and started
+ * meaning "kill any turn that says more than 64 KB". A trivial agy probe
+ * already writes ~30 KB of stream-json, so real turns were terminated with
+ * `output-limit` and stored an empty answer under the question that asked for
+ * it.
+ */
+export const ANTIGRAVITY_OUTPUT_BYTE_LIMIT = 16 * 1024 * 1024;
+const OUTPUT_BYTE_LIMIT = ANTIGRAVITY_OUTPUT_BYTE_LIMIT;
 
 /**
  * Antigravity chat execution, assembled from the running plugin.

--- a/src/providers/antigravity/runtime/AntigravityPrintProcessRunner.ts
+++ b/src/providers/antigravity/runtime/AntigravityPrintProcessRunner.ts
@@ -67,6 +67,14 @@ export interface AntigravityPrintProcessRunnerOptions {
   readonly logSize?: (logFilePath: string) => Promise<number>;
   /** Combined stdout, stderr, and recovered-result byte ceiling. */
   readonly outputByteLimit?: number;
+  /**
+   * How long the pipes may keep talking after the process has gone.
+   *
+   * Not a timeout for the turn: the turn is over when `agy` exits. This only
+   * bounds the wait for buffered output that an orphaned grandchild may be
+   * holding open, so a finished run cannot hang on a pipe nobody will close.
+   */
+  readonly drainGraceMs?: number;
   readonly createLogPath?: () => string;
   readonly recoverTranscript?: (
     logFilePath: string,
@@ -182,6 +190,10 @@ export class AntigravityPrintProcessRunner implements AntigravityProcessRunner {
     };
   }
 
+  private drainGraceMs(): number {
+    return this.options.drainGraceMs ?? 2_000;
+  }
+
   private async observeCompletion(
     child: AntigravityManagedChildProcess,
     invocation: AntigravityInvocation,
@@ -194,13 +206,22 @@ export class AntigravityPrintProcessRunner implements AntigravityProcessRunner {
     const stderr = new LimitedBytes(outputLimit);
     const onActivity = hooks.onActivity;
     try {
-      const [exit] = await Promise.all([
-        child.exited,
+      // The process leaving is the event; the pipes closing is not. A grandchild
+      // that outlives `agy` keeps them open, and waiting on them with no
+      // deadline holds the run hostage: the answer is in, the process is gone,
+      // and the tab spins forever. So the streams get a grace period *after*
+      // exit and the outcome is built from whatever arrived by then — which is
+      // what 1.3.2 did by forcing the streams shut once `close` lagged `exit`.
+      const drained = Promise.all([
         parser
           ? consumeFrames(child.stdout, parser, outputLimit, onActivity)
           : consume(child.stdout, stdout, onActivity),
         consume(child.stderr, stderr, onActivity),
-      ]);
+        // A pipe that fails after the process already left says nothing about
+        // the turn, and must not replace its outcome with a rejection.
+      ]).catch(() => undefined);
+      const exit = await child.exited;
+      await Promise.race([drained, delay(this.drainGraceMs())]);
       // **The frame, not the pipe.** In stream-json the answer is one field of
       // the last `result` frame, and the frames around it are progress this
       // turn has already published. Accumulating the pipe instead would spend
@@ -335,6 +356,10 @@ async function consumeFrames(
     }
     parser.write(decoder.decode(chunk, { stream: true }));
   }
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise(resolve => { window.setTimeout(resolve, ms); });
 }
 
 function removeLog(logFilePath: string): Promise<void> {

--- a/src/providers/antigravity/runtime/AntigravityPrintProcessRunner.ts
+++ b/src/providers/antigravity/runtime/AntigravityPrintProcessRunner.ts
@@ -220,8 +220,22 @@ export class AntigravityPrintProcessRunner implements AntigravityProcessRunner {
         // A pipe that fails after the process already left says nothing about
         // the turn, and must not replace its outcome with a rejection.
       ]).catch(() => undefined);
-      const exit = await child.exited;
-      await Promise.race([drained, delay(this.drainGraceMs())]);
+      // **The frame, not the process.** Observed live: `agy` answers and stays
+      // resident, so waiting for it to leave leaves the tab spinning on an
+      // answer it already has. Whichever comes first ends the wait, and a CLI
+      // that overstayed its own answer is asked to go.
+      await Promise.race([drained, child.exited]);
+      let exit: { readonly code: number | null; readonly signal?: string } | undefined;
+      if (parser?.getResult()) {
+        void child.terminate('graceful');
+        exit = await Promise.race([
+          child.exited,
+          delay(this.drainGraceMs()).then(() => undefined),
+        ]);
+      } else {
+        exit = await child.exited;
+        await Promise.race([drained, delay(this.drainGraceMs())]);
+      }
       // **The frame, not the pipe.** In stream-json the answer is one field of
       // the last `result` frame, and the frames around it are progress this
       // turn has already published. Accumulating the pipe instead would spend
@@ -231,8 +245,8 @@ export class AntigravityPrintProcessRunner implements AntigravityProcessRunner {
         parser.end();
         const result = parser.getResult();
         return {
-          exitCode: exit.code,
-          ...(exit.signal ? { signal: exit.signal } : {}),
+          exitCode: exit?.code ?? 0,
+          ...(exit?.signal ? { signal: exit.signal } : {}),
           stdout: result?.response ?? '',
           stderr: stderr.value(),
           // Carried as its own fields rather than folded into `stderr`: the
@@ -245,7 +259,7 @@ export class AntigravityPrintProcessRunner implements AntigravityProcessRunner {
         };
       }
       const stdoutText = stdout.value();
-      const transcript = exit.code === 0 && !stdoutText && !outputLimit.didExceed
+      const transcript = (exit?.code ?? 0) === 0 && !stdoutText && !outputLimit.didExceed
         ? await (this.options.recoverTranscript ?? recoverAntigravityPrintTranscriptBounded)(
           logFilePath,
           invocation.environment,
@@ -259,8 +273,8 @@ export class AntigravityPrintProcessRunner implements AntigravityProcessRunner {
         outputLimit.consume(Buffer.byteLength(transcript.output, 'utf8'));
       }
       return {
-        exitCode: exit.code,
-        ...(exit.signal ? { signal: exit.signal } : {}),
+        exitCode: exit?.code ?? 0,
+        ...(exit?.signal ? { signal: exit.signal } : {}),
         stdout: stdoutText,
         stderr: stderr.value(),
         ...(transcript.output ? { transcriptOutput: transcript.output } : {}),
@@ -355,6 +369,11 @@ async function consumeFrames(
       return;
     }
     parser.write(decoder.decode(chunk, { stream: true }));
+    // agy emits `result` last, so the answer is complete here. Reading on would
+    // wait for a pipe the CLI is under no obligation to close.
+    if (parser.getResult()) {
+      return;
+    }
   }
 }
 

--- a/src/providers/antigravity/runtime/AntigravityPrintProcessRunner.ts
+++ b/src/providers/antigravity/runtime/AntigravityPrintProcessRunner.ts
@@ -117,12 +117,22 @@ export class AntigravityPrintProcessRunner implements AntigravityProcessRunner {
       shell: launch.shell,
       ...(streamJson ? { stdin: 'pipe' as const } : {}),
     });
+    // The calls this turn has started and not yet seen finish. `agy` brackets
+    // every call with an `ACTIVE`/`DONE` pair sharing one step id, so a
+    // non-empty set means the CLI owes this turn an answer it is still working
+    // on — which is exactly when its log growing is worth believing.
+    const openToolSteps = new Set<string>();
     const parser = streamJson
       ? createAntigravityStreamJsonParser({
         onEvent: (event) => {
           if (event.type === 'text') {
             hooks.onAssistantText?.(event.text);
             return;
+          }
+          if (event.type === 'tool_start') {
+            openToolSteps.add(event.stepId);
+          } else {
+            openToolSteps.delete(event.stepId);
           }
           hooks.onToolStep?.(event);
         },
@@ -140,7 +150,13 @@ export class AntigravityPrintProcessRunner implements AntigravityProcessRunner {
     }
     const outputLimit = new OutputLimitMonitor(this.options.outputByteLimit ?? 64_000);
     const stopLiveness = hooks.onActivity
-      ? this.watchLogLiveness(logFilePath, hooks.onActivity)
+      ? this.watchLogLiveness(
+        logFilePath,
+        hooks.onActivity,
+        // Without frames there is no call to be out, so a non-stream-json run
+        // keeps the unconditional watch it has always had.
+        parser ? () => openToolSteps.size > 0 : () => true,
+      )
       : () => undefined;
     return {
       started: child.started,
@@ -160,7 +176,11 @@ export class AntigravityPrintProcessRunner implements AntigravityProcessRunner {
    * minutes in the wild. The log keeps growing throughout, which is what tells
    * a long call apart from a hang (#70).
    */
-  private watchLogLiveness(logFilePath: string, onActivity: () => void): () => void {
+  private watchLogLiveness(
+    logFilePath: string,
+    onActivity: () => void,
+    isWorkOutstanding: () => boolean,
+  ): () => void {
     // `window`, per the popout-window rule: a timer from the wrong global stops
     // when that window closes, and this one has to outlive a popout the user
     // shuts while a turn is running.
@@ -176,7 +196,18 @@ export class AntigravityPrintProcessRunner implements AntigravityProcessRunner {
         if (stopped || size <= lastSize) {
           return;
         }
+        // Recorded even when it is not reported, so growth that happened while
+        // nothing was outstanding cannot arrive later as one large jump and be
+        // read as the run waking up.
         lastSize = size;
+        // **Process liveness is not turn liveness.** `agy` keeps writing to its
+        // own log after the answer is delivered, and reporting that as activity
+        // re-arms the inactivity timeout indefinitely — the run then has no
+        // boundary left but the absolute ceiling, which is the reported hang
+        // (#139). A growing log is evidence about a call that is still out.
+        if (!isWorkOutstanding()) {
+          return;
+        }
         onActivity();
       }).catch(() => undefined);
     }, this.options.livenessPollMs ?? 15_000);

--- a/tests/unit/providers/antigravity/AntigravityPrintProcessRunner.test.ts
+++ b/tests/unit/providers/antigravity/AntigravityPrintProcessRunner.test.ts
@@ -215,6 +215,31 @@ describe('AntigravityPrintProcessRunner', () => {
     expect(outcome.stdout).toHaveLength(spoken);
   });
 
+  it('finishes a turn whose pipes an orphan still holds after the process exited', async () => {
+    // 1.3.2 gave `close` a grace period after `exit` and then forced the
+    // streams shut, because "an orphaned grandchild holding the pipes would
+    // otherwise hold the whole run hostage". Waiting on the streams with no
+    // deadline brings the hostage back: agy answers, exits, and the tab spins
+    // forever on a pipe nobody will close.
+    const child = new FakeManagedChild();
+    // A stdout that never ends, the way a held pipe behaves.
+    (child as { stdout: AsyncIterable<Uint8Array> }).stdout = {
+      [Symbol.asyncIterator]: () => ({ next: () => new Promise<never>(() => {}) }),
+    } as AsyncIterable<Uint8Array>;
+    const runner = new AntigravityPrintProcessRunner({
+      transport: new FakeTransport(child),
+      outputByteLimit: ANTIGRAVITY_OUTPUT_BYTE_LIMIT,
+      drainGraceMs: 1,
+      createLogPath: () => '/tmp/antigravity.log',
+      removeLog: async () => undefined,
+      recoverTranscript: async () => ({ output: 'answered', outputLimitExceeded: false }),
+    });
+    const handle = runner.start(INVOCATION);
+    child.exit.resolve({ code: 0 });
+
+    await expect(handle.completed).resolves.toMatchObject({ exitCode: 0 });
+  });
+
   it('recovers the Windows transcript only after a successful empty stdout', async () => {
     const child = new FakeManagedChild();
     const recoverTranscript = jest.fn().mockResolvedValue({

--- a/tests/unit/providers/antigravity/AntigravityPrintProcessRunner.test.ts
+++ b/tests/unit/providers/antigravity/AntigravityPrintProcessRunner.test.ts
@@ -1,6 +1,7 @@
 import { executionSessionId, runId, sessionInstanceId } from '@/core/execution/ExecutionIds';
 import type { AntigravityInvocation } from '@/providers/antigravity/execution/AntigravityExecutionBackend';
 import { AntigravityExecutionBackend } from '@/providers/antigravity/execution/AntigravityExecutionBackend';
+import { ANTIGRAVITY_OUTPUT_BYTE_LIMIT } from '@/providers/antigravity/execution/AntigravityExecutionComposition';
 import {
   type AntigravityManagedChildProcess,
   AntigravityPrintProcessRunner,
@@ -188,6 +189,30 @@ describe('AntigravityPrintProcessRunner', () => {
       stdout: '123',
       outputLimitExceeded: true,
     });
+  });
+
+  it('lets a turn print far more than the old buffer size on the configured budget', async () => {
+    // The budget is what the product actually runs with, not a test value: it
+    // used to be a *sliding buffer* size (`.slice(-64_000)`), and carrying the
+    // number over to a cumulative budget turned "keep the last 64 KB" into
+    // "kill any turn that says more than 64 KB". A trivial agy probe already
+    // writes ~30 KB, so real turns died and stored an empty answer.
+    const spoken = 200_000;
+    const child = new FakeManagedChild({
+      stdout: ['x'.repeat(spoken)],
+    });
+    const runner = new AntigravityPrintProcessRunner({
+      transport: new FakeTransport(child),
+      outputByteLimit: ANTIGRAVITY_OUTPUT_BYTE_LIMIT,
+      createLogPath: () => '/tmp/antigravity.log',
+      removeLog: async () => undefined,
+    });
+    const handle = runner.start(INVOCATION);
+    child.exit.resolve({ code: 0 });
+
+    const outcome = await handle.completed;
+    expect(outcome.outputLimitExceeded).toBeUndefined();
+    expect(outcome.stdout).toHaveLength(spoken);
   });
 
   it('recovers the Windows transcript only after a successful empty stdout', async () => {

--- a/tests/unit/providers/antigravity/AntigravityPrintProcessRunner.test.ts
+++ b/tests/unit/providers/antigravity/AntigravityPrintProcessRunner.test.ts
@@ -266,6 +266,113 @@ describe('AntigravityPrintProcessRunner', () => {
     expect(child.terminationModes.length).toBeGreaterThan(0);
   });
 
+  it('ends a turn on the result frame while the CLI still holds its pipe open', async () => {
+    // The case the previous test cannot reach. Its fake stdout *ends* after the
+    // result frame, so the drain resolves and the wait is released by the pipe
+    // rather than by the frame. A resident `agy` closes neither: it answers,
+    // keeps stdout open, and does not exit. Then `Promise.race([drained,
+    // exited])` has nothing to settle it, the frame is parsed but never
+    // examined, and the run spins until the user cancels it — the reported
+    // symptom, with a visible complete answer and an active run (#139).
+    const child = new FakeManagedChild();
+    (child as { stdout: AsyncIterable<Uint8Array> }).stdout = residentStdout([
+      '{"event":"step_update","step_update":{"step_type":"text","text_delta":"done"}}\n',
+      '{"event":"result","result":{"status":"ok","response":"done","error":null}}\n',
+    ]);
+    // `exit` is never resolved and the pipe never closes: both boundaries the
+    // wait knows about are absent, which is what a resident CLI looks like.
+    const runner = new AntigravityPrintProcessRunner({
+      transport: new FakeTransport(child),
+      drainGraceMs: 1,
+      createLogPath: () => '/tmp/antigravity.log',
+      removeLog: async () => undefined,
+    });
+
+    const handle = runner.start({
+      ...INVOCATION,
+      cliCapabilities: { addDir: false, printTimeout: false, streamJson: true },
+    });
+
+    await expect(settledWithin(handle.completed, 250)).resolves.toMatchObject({
+      stdout: 'done',
+    });
+    expect(child.terminationModes.length).toBeGreaterThan(0);
+  });
+
+  it('stops calling a growing log a sign of life once no tool call is open', async () => {
+    // The log tells a long tool call apart from a hang (#70), but it is the
+    // CLI's own file: a resident `agy` keeps appending to it after the answer
+    // is delivered. Reported as activity regardless, it re-arms the backend's
+    // inactivity timeout forever, so the one mechanism that could end a turn
+    // with no `result` frame never fires and only cancellation ends the run
+    // (#139). Growth counts while a call is out; silence after it is silence.
+    const poll = new ManualPoll();
+    const child = new FakeManagedChild();
+    (child as { stdout: AsyncIterable<Uint8Array> }).stdout = residentStdout([
+      '{"event":"step_update","step_update":{"step_type":"text","text_delta":"done"}}\n',
+    ]);
+    let logBytes = 0;
+    const onActivity = jest.fn();
+    const runner = new AntigravityPrintProcessRunner({
+      transport: new FakeTransport(child),
+      drainGraceMs: 1,
+      createLogPath: () => '/tmp/antigravity.log',
+      removeLog: async () => undefined,
+      setPoll: poll.set,
+      clearPoll: poll.clear,
+      logSize: async () => logBytes,
+    });
+
+    runner.start(
+      { ...INVOCATION, cliCapabilities: { addDir: false, printTimeout: false, streamJson: true } },
+      { onActivity },
+    );
+    // Let the text frame arrive, then ignore the activity it legitimately
+    // reported: what follows is only the log growing on its own.
+    await flush();
+    onActivity.mockClear();
+
+    logBytes += 4_096;
+    await poll.fire();
+
+    expect(onActivity).not.toHaveBeenCalled();
+  });
+
+  it('still calls a growing log a sign of life while a tool call is out', async () => {
+    // The other half, and the reason the log is watched at all: a tool call can
+    // keep both pipes quiet for minutes (#70). While its `ACTIVE` frame has no
+    // `DONE`, growth is the only evidence the run is alive.
+    const poll = new ManualPoll();
+    const child = new FakeManagedChild();
+    (child as { stdout: AsyncIterable<Uint8Array> }).stdout = residentStdout([
+      '{"event":"step_update","step_update":{"step_type":"tool","state":"ACTIVE","step_index":1,'
+        + '"tool_name":"run","tool_info":{"parameters":{}}}}\n',
+    ]);
+    let logBytes = 0;
+    const onActivity = jest.fn();
+    const runner = new AntigravityPrintProcessRunner({
+      transport: new FakeTransport(child),
+      drainGraceMs: 1,
+      createLogPath: () => '/tmp/antigravity.log',
+      removeLog: async () => undefined,
+      setPoll: poll.set,
+      clearPoll: poll.clear,
+      logSize: async () => logBytes,
+    });
+
+    runner.start(
+      { ...INVOCATION, cliCapabilities: { addDir: false, printTimeout: false, streamJson: true } },
+      { onActivity },
+    );
+    await flush();
+    onActivity.mockClear();
+
+    logBytes += 4_096;
+    await poll.fire();
+
+    expect(onActivity).toHaveBeenCalled();
+  });
+
   it('recovers the Windows transcript only after a successful empty stdout', async () => {
     const child = new FakeManagedChild();
     const recoverTranscript = jest.fn().mockResolvedValue({
@@ -419,6 +526,65 @@ function chunks(values: readonly string[]): AsyncIterable<Uint8Array> {
       }
     },
   };
+}
+
+/**
+ * Frames on a pipe that never closes, the way a resident CLI leaves stdout.
+ *
+ * Deliberately different from `chunks`: that helper ends its iteration, which
+ * closes the stream and releases anything waiting on the drain. Nothing here
+ * ever ends, so only the frames themselves can end the turn.
+ */
+function residentStdout(values: readonly string[]): AsyncIterable<Uint8Array> {
+  return {
+    async *[Symbol.asyncIterator]() {
+      for (const value of values) {
+        yield Buffer.from(value, 'utf8');
+      }
+      await new Promise<never>(() => {});
+    },
+  };
+}
+
+/**
+ * Fails loudly instead of hanging the suite: a run that never settles is the
+ * defect under test, and jest's own timeout would report it as an unhelpful
+ * whole-test expiry rather than as this assertion.
+ */
+function settledWithin<T>(work: Promise<T>, ms: number): Promise<T> {
+  return Promise.race([
+    work,
+    new Promise<never>((_resolve, reject) => {
+      setTimeout(() => reject(new Error(`run did not settle within ${ms}ms`)), ms).unref?.();
+    }),
+  ]);
+}
+
+/** The liveness poll, driven by the test rather than by a clock. */
+class ManualPoll {
+  private callback: (() => void) | undefined;
+
+  readonly set = (callback: () => void): unknown => {
+    this.callback = callback;
+    return 'poll';
+  };
+
+  readonly clear = (): void => {
+    this.callback = undefined;
+  };
+
+  /** Runs one tick and lets the size read it awaits settle. */
+  async fire(): Promise<void> {
+    this.callback?.();
+    await flush();
+  }
+}
+
+/** Drains the microtask queue so awaited reads and frames land. */
+async function flush(): Promise<void> {
+  for (let index = 0; index < 10; index += 1) {
+    await Promise.resolve();
+  }
 }
 
 function deferred<T>() {

--- a/tests/unit/providers/antigravity/AntigravityPrintProcessRunner.test.ts
+++ b/tests/unit/providers/antigravity/AntigravityPrintProcessRunner.test.ts
@@ -240,6 +240,32 @@ describe('AntigravityPrintProcessRunner', () => {
     await expect(handle.completed).resolves.toMatchObject({ exitCode: 0 });
   });
 
+  it('ends a turn on the result frame even when the CLI never leaves', async () => {
+    // Observed live: `agy` answered and stayed resident. Treating process exit
+    // as the end of the turn leaves the tab spinning on an answer it already
+    // has. The turn is over when the last `result` frame arrives.
+    const child = new FakeManagedChild({
+      stdout: [
+        '{"event":"result","result":{"status":"ok","response":"done","error":null}}\n',
+      ],
+    });
+    // `exit` is never resolved: the process outlives its own answer.
+    const runner = new AntigravityPrintProcessRunner({
+      transport: new FakeTransport(child),
+      drainGraceMs: 1,
+      createLogPath: () => '/tmp/antigravity.log',
+      removeLog: async () => undefined,
+    });
+
+    const handle = runner.start({
+      ...INVOCATION,
+      cliCapabilities: { addDir: false, printTimeout: false, streamJson: true },
+    });
+
+    await expect(handle.completed).resolves.toMatchObject({ stdout: 'done' });
+    expect(child.terminationModes.length).toBeGreaterThan(0);
+  });
+
   it('recovers the Windows transcript only after a successful empty stdout', async () => {
     const child = new FakeManagedChild();
     const recoverTranscript = jest.fn().mockResolvedValue({


### PR DESCRIPTION
Fixes #139. Background and the shared cause behind all four commits: see the turn-lifecycle issue.

Four commits on one seam, in the order the defects were found — each became visible only once the one before it was fixed.

## 1. `stop killing a turn that says more than a parse buffer held`

`OUTPUT_BUFFER_LIMIT = 64_000` was the size of a *sliding* buffer in 1.3.2: keep the last 64 KB, discard the head. In 2.0 the same number became a cumulative budget for the turn, which turns "keep the last 64 KB" into "kill any turn that says more than 64 KB". A trivial `agy` probe already writes ~30 KB, so real turns died with `The response exceeded its size limit` and stored an empty answer.

Now a memory ceiling rather than a limit on what the agent may say.

## 2. `give the pipes a deadline once the process has gone`

1.3.2 gave the streams a grace period after exit and then forced them shut, because an orphaned grandchild holding the pipes would otherwise hold the run hostage. 2.0 waited on them with no deadline: answer in, process gone, tab spinning on a pipe nobody will close.

## 3. `end the turn on the result frame, not on the process leaving`

`agy` does not exit after answering — verified against a live run where the process stayed resident with a complete response. In stream-json the turn ends at the last `result` frame; the `text_delta` frames sum exactly to `result.response`, so the frame is both the terminal signal and the whole answer. A CLI that overstays its own answer is then asked to leave.

## 4. `stop a resident CLI's own log from re-arming the turn`

The one that survived the first three, and the direct cause of #139.

`agy` emits frames on step transitions, so a long tool call keeps both pipes quiet — one measured at about five minutes. To tell that apart from a hang, the runner polls the run's log file and reports growth as activity, re-arming the backend inactivity timeout.

But the log belongs to the CLI, not to the turn. A resident `agy` keeps appending after the answer is delivered, so unconditional reporting re-arms the timeout on every poll. A turn whose `result` frame never arrives then has no boundary left but the 30-minute absolute ceiling. Observed: turns active for five to eleven minutes with a complete visible answer, ending only on Escape. Every such run recorded `wasInterrupted: true` and `planCompleted: false` — none ended on its own.

`agy` brackets every tool call with an `ACTIVE`/`DONE` pair sharing one step id, so the set of calls started and not yet finished is exact evidence that the CLI still owes this turn work. Log growth counts while a call is out; after the last `DONE`, silence is silence.

Deliberately not done here: nothing ends a turn because text became visible, and cancellation and process ownership are untouched. A run with no frames to read keeps the unconditional watch it has always had, and the log size is still recorded when it is not reported, so growth during a quiet stretch cannot arrive later as one jump and read as the run waking up.

## Tests

Each commit carries a regression test that fails before it.

The fourth also carries the complementary case, so the behaviour it narrows cannot be removed by accident: while a tool call is open, log growth must still count as liveness.

One existing test was found to pass for the wrong reason and is now backed by a stricter sibling: its fake stdout *ended* after the result frame, so the drain resolved and the wait was released by the pipe rather than by the frame. The added case keeps the pipe open, which is what a resident CLI does.

## Verification

- focused Antigravity suites: 17 passed, 185 tests passed
- `npx tsc --noEmit`: exit 0
- `npx eslint "src/**/*.ts" "tests/**/*.ts" --max-warnings=0`: exit 0
- full unit run: 23 failed, 9001 passed — the same pre-existing Windows failures as the `65dc6775` baseline, no delta
- `npm run build:release`: exit 0, source, CSS and dependency review gates passed

Issue: #141 