### PR TITLE
fix(antigravity): end a turn on its own evidence, not on the CLI process

### DIFF
--- a/src/providers/antigravity/execution/AntigravityExecutionBackend.ts
+++ b/src/providers/antigravity/execution/AntigravityExecutionBackend.ts
@@ -104,6 +104,14 @@ export interface AntigravityProcessRunnerHooks {
   readonly onToolStep?: (step: unknown) => void;
   /** Any sign the run is alive: a byte on a pipe, or its log file growing. */
   readonly onActivity?: () => void;
+  /**
+   * Sanitised structural facts about how the turn ended, for the log.
+   *
+   * Names, counts, and timings only — never prompt, answer, or paths. The
+   * backend does not read it: it exists so a turn that ends without a terminal
+   * frame leaves behind what it actually received.
+   */
+  readonly onDiagnostic?: (data: Readonly<Record<string, unknown>>) => void;
 }
 
 /** See `inactivityTimeoutMs`; ten minutes is `main`'s measured answer (#70). */
@@ -155,6 +163,8 @@ export interface AntigravityExecutionBackendContext {
   readonly gracefulTerminationMs?: number;
   readonly forcedTerminationMs?: number;
   readonly resultCommitTimeoutMs?: number;
+  /** Sanitised structural diagnosis for the log; see the runner hook. */
+  readonly onDiagnostic?: (data: Readonly<Record<string, unknown>>) => void;
 }
 
 export const ANTIGRAVITY_EXECUTION_DESCRIPTOR: ExecutionBackendDescriptor = Object.freeze({
@@ -374,6 +384,7 @@ class AntigravityExecutionRun implements ExecutionRun {
       const process = this.context.processRunner.start(invocation, {
         onActivity: () => this.armInactivityTimeout(),
         onAssistantText: text => this.publishStreamedText(text),
+        onDiagnostic: data => this.context.onDiagnostic?.(data),
         onToolStep: step => this.publishToolStep(step),
       });
       this.process = process;

--- a/src/providers/antigravity/execution/AntigravityExecutionComposition.ts
+++ b/src/providers/antigravity/execution/AntigravityExecutionComposition.ts
@@ -54,7 +54,23 @@ import {
 } from '../runtime/AntigravityImageAttachments';
 
 /** Combined stdout, stderr, and recovered-transcript ceiling for one run. */
-const OUTPUT_BYTE_LIMIT = 64_000;
+/**
+ * How much one print turn may say before the run is stopped.
+ *
+ * A ceiling on memory, not a budget for an answer: the runner keeps the whole
+ * stream so the transcript can be parsed, so something has to bound it.
+ *
+ * The number matters. It used to be `OUTPUT_BUFFER_LIMIT = 64_000` — the size
+ * of a *sliding* parse buffer (`.slice(-OUTPUT_BUFFER_LIMIT)`), which bounded
+ * memory while letting a turn print without end. Carried over to a cumulative
+ * budget, the same 64 KB stopped meaning "keep the last 64 KB" and started
+ * meaning "kill any turn that says more than 64 KB". A trivial agy probe
+ * already writes ~30 KB of stream-json, so real turns were terminated with
+ * `output-limit` and stored an empty answer under the question that asked for
+ * it.
+ */
+export const ANTIGRAVITY_OUTPUT_BYTE_LIMIT = 16 * 1024 * 1024;
+const OUTPUT_BYTE_LIMIT = ANTIGRAVITY_OUTPUT_BYTE_LIMIT;
 
 /**
  * Antigravity chat execution, assembled from the running plugin.

--- a/src/providers/antigravity/execution/AntigravityExecutionComposition.ts
+++ b/src/providers/antigravity/execution/AntigravityExecutionComposition.ts
@@ -176,6 +176,15 @@ export class AntigravityExecution {
         clearTimeout: handle => window.clearTimeout(handle as ReturnType<typeof setTimeout>),
       },
       sessionInstanceIdFactory: () => sessionInstanceId(opaqueId('si')),
+      // Recorded at `info`, not `debug`: a turn that ends without a terminal
+      // frame is the report we could not explain, and the log is the only place
+      // that outlives it. The payload is names, counts, and timings.
+      onDiagnostic: data => this.plugin.recordDebugLog?.({
+        data: { ...data, providerId: 'antigravity' },
+        event: 'antigravity.turn.completion',
+        level: 'info',
+        scope: 'provider.antigravity',
+      }),
     };
     return new AntigravityExecutionBackend(context);
   }

--- a/src/providers/antigravity/execution/NodeAntigravityProcessTransport.ts
+++ b/src/providers/antigravity/execution/NodeAntigravityProcessTransport.ts
@@ -48,10 +48,23 @@ export class NodeAntigravityProcessTransport implements AntigravityProcessTransp
             if (!stdin) {
               return;
             }
-            await new Promise<void>((resolve, reject) => {
+            // **EOF is not conditional on the write succeeding.** Closing only
+            // after the write settles makes the end of input hostage to a
+            // callback that a broken pipe never delivers, and a live `agy` then
+            // holds the turn open waiting for input that will never end. 1.3.2
+            // closed unconditionally; verified live, an `agy` whose stdin stays
+            // open answers and then never leaves.
+            const written = new Promise<void>((resolve, reject) => {
+              // The child can exit before draining stdin, and an unhandled
+              // stream `error` would take the renderer down with it.
+              stdin.once('error', reject);
               stdin.write(text, error => (error ? reject(error) : resolve()));
             });
+            // Issued now rather than in a `finally`: a callback that never
+            // fires never settles the promise either, so awaiting first means
+            // the close never runs at all. `end` flushes what is queued.
             stdin.end();
+            await written;
           },
         }
         : {}),

--- a/src/providers/antigravity/runtime/AntigravityPrintProcessRunner.ts
+++ b/src/providers/antigravity/runtime/AntigravityPrintProcessRunner.ts
@@ -228,19 +228,26 @@ export class AntigravityPrintProcessRunner implements AntigravityProcessRunner {
       // and the tab spins forever. So the streams get a grace period *after*
       // exit and the outcome is built from whatever arrived by then — which is
       // what 1.3.2 did by forcing the streams shut once `close` lagged `exit`.
-      const drained = Promise.all([
-        parser
-          ? consumeFrames(child.stdout, parser, outputLimit, onActivity)
-          : consume(child.stdout, stdout, onActivity),
-        consume(child.stderr, stderr, onActivity),
+      // Kept apart from stderr on purpose. This is the side that carries the
+      // turn: with a parser it returns as soon as the `result` frame is read,
+      // and that has to be able to end the wait on its own.
+      const answered = (parser
+        ? consumeFrames(child.stdout, parser, outputLimit, onActivity)
+        : consume(child.stdout, stdout, onActivity))
         // A pipe that fails after the process already left says nothing about
         // the turn, and must not replace its outcome with a rejection.
-      ]).catch(() => undefined);
-      // **The frame, not the process.** Observed live: `agy` answers and stays
-      // resident, so waiting for it to leave leaves the tab spinning on an
-      // answer it already has. Whichever comes first ends the wait, and a CLI
-      // that overstayed its own answer is asked to go.
-      await Promise.race([drained, child.exited]);
+        .catch(() => undefined);
+      const drained = Promise
+        .all([answered, consume(child.stderr, stderr, onActivity)])
+        .catch(() => undefined);
+      // **The frame, not the process — and not the other pipe either.** Observed
+      // live: `agy` answers and stays resident, holding *both* pipes open. An
+      // `all` of the two therefore stays pending after the answer is complete,
+      // and so does the exit, so a wait on those two alone never ends: the
+      // recorded turn had `init`, two `step_update`, and `result` within 7.6 s
+      // and still hung for eleven minutes (#139). The answer arriving is its own
+      // reason to stop waiting, and a CLI that overstayed it is asked to go.
+      await Promise.race([answered, drained, child.exited]);
       let exit: { readonly code: number | null; readonly signal?: string } | undefined;
       sawResultBeforeWait = parser?.getResult() != null;
       if (sawResultBeforeWait) {
@@ -265,17 +272,20 @@ export class AntigravityPrintProcessRunner implements AntigravityProcessRunner {
         // knows what the CLI actually sent, what ended the wait, and whether a
         // terminal frame was among it. A turn that ends without a `result` is
         // otherwise indistinguishable from one whose `result` we failed to read.
+        // Field names are the log's own safe-key list, not free choice: a string
+        // under any other key is redacted, and a diagnosis that reads
+        // `[redacted-string]` is the silence it was written to end.
         this.report(hooks, {
-          endedBy: sawResultBeforeWait ? 'result-frame' : (exit ? 'process-exit' : 'drain-grace'),
+          budgetExceeded: outputLimit.didExceed,
           exitCode: exit?.code ?? null,
           frameCounts: summariseFrames(frameLog.counts),
           frameTotal: frameLog.total,
           hasResult: result !== null,
-          lastFrame: frameLog.lastName ?? 'none',
+          messageType: frameLog.lastName ?? 'none',
           msToFirstFrame: frameLog.firstAt === undefined ? null : frameLog.firstAt - frameLog.startedAt,
           msToLastFrame: frameLog.lastAt === undefined ? null : frameLog.lastAt - frameLog.startedAt,
-          outputLimitExceeded: outputLimit.didExceed,
-          ...(result ? { resultStatus: result.status } : {}),
+          reason: sawResultBeforeWait ? 'result-frame' : (exit ? 'process-exit' : 'drain-grace'),
+          ...(result ? { status: result.status } : {}),
         });
         succeeded = result !== null && (exit?.code ?? 0) === 0 && !outputLimit.didExceed;
         return {

--- a/src/providers/antigravity/runtime/AntigravityPrintProcessRunner.ts
+++ b/src/providers/antigravity/runtime/AntigravityPrintProcessRunner.ts
@@ -67,6 +67,14 @@ export interface AntigravityPrintProcessRunnerOptions {
   readonly logSize?: (logFilePath: string) => Promise<number>;
   /** Combined stdout, stderr, and recovered-result byte ceiling. */
   readonly outputByteLimit?: number;
+  /**
+   * How long the pipes may keep talking after the process has gone.
+   *
+   * Not a timeout for the turn: the turn is over when `agy` exits. This only
+   * bounds the wait for buffered output that an orphaned grandchild may be
+   * holding open, so a finished run cannot hang on a pipe nobody will close.
+   */
+  readonly drainGraceMs?: number;
   readonly createLogPath?: () => string;
   readonly recoverTranscript?: (
     logFilePath: string,
@@ -182,6 +190,10 @@ export class AntigravityPrintProcessRunner implements AntigravityProcessRunner {
     };
   }
 
+  private drainGraceMs(): number {
+    return this.options.drainGraceMs ?? 2_000;
+  }
+
   private async observeCompletion(
     child: AntigravityManagedChildProcess,
     invocation: AntigravityInvocation,
@@ -194,13 +206,22 @@ export class AntigravityPrintProcessRunner implements AntigravityProcessRunner {
     const stderr = new LimitedBytes(outputLimit);
     const onActivity = hooks.onActivity;
     try {
-      const [exit] = await Promise.all([
-        child.exited,
+      // The process leaving is the event; the pipes closing is not. A grandchild
+      // that outlives `agy` keeps them open, and waiting on them with no
+      // deadline holds the run hostage: the answer is in, the process is gone,
+      // and the tab spins forever. So the streams get a grace period *after*
+      // exit and the outcome is built from whatever arrived by then — which is
+      // what 1.3.2 did by forcing the streams shut once `close` lagged `exit`.
+      const drained = Promise.all([
         parser
           ? consumeFrames(child.stdout, parser, outputLimit, onActivity)
           : consume(child.stdout, stdout, onActivity),
         consume(child.stderr, stderr, onActivity),
-      ]);
+        // A pipe that fails after the process already left says nothing about
+        // the turn, and must not replace its outcome with a rejection.
+      ]).catch(() => undefined);
+      const exit = await child.exited;
+      await Promise.race([drained, delay(this.drainGraceMs())]);
       // **The frame, not the pipe.** In stream-json the answer is one field of
       // the last `result` frame, and the frames around it are progress this
       // turn has already published. Accumulating the pipe instead would spend
@@ -335,6 +356,10 @@ async function consumeFrames(
     }
     parser.write(decoder.decode(chunk, { stream: true }));
   }
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise(resolve => { window.setTimeout(resolve, ms); });
 }
 
 function removeLog(logFilePath: string): Promise<void> {

--- a/src/providers/antigravity/runtime/AntigravityPrintProcessRunner.ts
+++ b/src/providers/antigravity/runtime/AntigravityPrintProcessRunner.ts
@@ -220,8 +220,22 @@ export class AntigravityPrintProcessRunner implements AntigravityProcessRunner {
         // A pipe that fails after the process already left says nothing about
         // the turn, and must not replace its outcome with a rejection.
       ]).catch(() => undefined);
-      const exit = await child.exited;
-      await Promise.race([drained, delay(this.drainGraceMs())]);
+      // **The frame, not the process.** Observed live: `agy` answers and stays
+      // resident, so waiting for it to leave leaves the tab spinning on an
+      // answer it already has. Whichever comes first ends the wait, and a CLI
+      // that overstayed its own answer is asked to go.
+      await Promise.race([drained, child.exited]);
+      let exit: { readonly code: number | null; readonly signal?: string } | undefined;
+      if (parser?.getResult()) {
+        void child.terminate('graceful');
+        exit = await Promise.race([
+          child.exited,
+          delay(this.drainGraceMs()).then(() => undefined),
+        ]);
+      } else {
+        exit = await child.exited;
+        await Promise.race([drained, delay(this.drainGraceMs())]);
+      }
       // **The frame, not the pipe.** In stream-json the answer is one field of
       // the last `result` frame, and the frames around it are progress this
       // turn has already published. Accumulating the pipe instead would spend
@@ -231,8 +245,8 @@ export class AntigravityPrintProcessRunner implements AntigravityProcessRunner {
         parser.end();
         const result = parser.getResult();
         return {
-          exitCode: exit.code,
-          ...(exit.signal ? { signal: exit.signal } : {}),
+          exitCode: exit?.code ?? 0,
+          ...(exit?.signal ? { signal: exit.signal } : {}),
           stdout: result?.response ?? '',
           stderr: stderr.value(),
           // Carried as its own fields rather than folded into `stderr`: the
@@ -245,7 +259,7 @@ export class AntigravityPrintProcessRunner implements AntigravityProcessRunner {
         };
       }
       const stdoutText = stdout.value();
-      const transcript = exit.code === 0 && !stdoutText && !outputLimit.didExceed
+      const transcript = (exit?.code ?? 0) === 0 && !stdoutText && !outputLimit.didExceed
         ? await (this.options.recoverTranscript ?? recoverAntigravityPrintTranscriptBounded)(
           logFilePath,
           invocation.environment,
@@ -259,8 +273,8 @@ export class AntigravityPrintProcessRunner implements AntigravityProcessRunner {
         outputLimit.consume(Buffer.byteLength(transcript.output, 'utf8'));
       }
       return {
-        exitCode: exit.code,
-        ...(exit.signal ? { signal: exit.signal } : {}),
+        exitCode: exit?.code ?? 0,
+        ...(exit?.signal ? { signal: exit.signal } : {}),
         stdout: stdoutText,
         stderr: stderr.value(),
         ...(transcript.output ? { transcriptOutput: transcript.output } : {}),
@@ -355,6 +369,11 @@ async function consumeFrames(
       return;
     }
     parser.write(decoder.decode(chunk, { stream: true }));
+    // agy emits `result` last, so the answer is complete here. Reading on would
+    // wait for a pipe the CLI is under no obligation to close.
+    if (parser.getResult()) {
+      return;
+    }
   }
 }
 

--- a/src/providers/antigravity/runtime/AntigravityPrintProcessRunner.ts
+++ b/src/providers/antigravity/runtime/AntigravityPrintProcessRunner.ts
@@ -117,6 +117,11 @@ export class AntigravityPrintProcessRunner implements AntigravityProcessRunner {
       shell: launch.shell,
       ...(streamJson ? { stdin: 'pipe' as const } : {}),
     });
+    // What the CLI actually put on the wire, by frame name. Names and timings
+    // only: enough to tell "no terminal frame was sent" from "a terminal frame
+    // was sent in a shape we do not read", which is the one question a turn that
+    // ends without a `result` leaves behind.
+    const frameLog: FrameLog = { counts: new Map(), startedAt: Date.now(), total: 0 };
     const parser = streamJson
       ? createAntigravityStreamJsonParser({
         onEvent: (event) => {
@@ -125,6 +130,13 @@ export class AntigravityPrintProcessRunner implements AntigravityProcessRunner {
             return;
           }
           hooks.onToolStep?.(event);
+        },
+        onFrame: (name) => {
+          frameLog.total += 1;
+          frameLog.counts.set(name, (frameLog.counts.get(name) ?? 0) + 1);
+          frameLog.lastName = name;
+          frameLog.lastAt = Date.now();
+          frameLog.firstAt ??= frameLog.lastAt;
         },
       })
       : undefined;
@@ -144,7 +156,8 @@ export class AntigravityPrintProcessRunner implements AntigravityProcessRunner {
       : () => undefined;
     return {
       started: child.started,
-      completed: this.observeCompletion(child, invocation, logFilePath, outputLimit, parser, hooks)
+      completed: this
+        .observeCompletion(child, invocation, logFilePath, outputLimit, parser, hooks, frameLog)
         .finally(stopLiveness),
       outputLimitExceeded: outputLimit.exceeded,
       confirmTerminated: () => child.confirmTerminated(),
@@ -201,10 +214,13 @@ export class AntigravityPrintProcessRunner implements AntigravityProcessRunner {
     outputLimit: OutputLimitMonitor,
     parser: AntigravityStreamJsonParser | undefined,
     hooks: AntigravityProcessRunnerHooks,
+    frameLog: FrameLog,
   ): Promise<AntigravityProcessOutcome> {
     const stdout = new LimitedBytes(outputLimit);
     const stderr = new LimitedBytes(outputLimit);
     const onActivity = hooks.onActivity;
+    let succeeded = false;
+    let sawResultBeforeWait = false;
     try {
       // The process leaving is the event; the pipes closing is not. A grandchild
       // that outlives `agy` keeps them open, and waiting on them with no
@@ -226,7 +242,8 @@ export class AntigravityPrintProcessRunner implements AntigravityProcessRunner {
       // that overstayed its own answer is asked to go.
       await Promise.race([drained, child.exited]);
       let exit: { readonly code: number | null; readonly signal?: string } | undefined;
-      if (parser?.getResult()) {
+      sawResultBeforeWait = parser?.getResult() != null;
+      if (sawResultBeforeWait) {
         void child.terminate('graceful');
         exit = await Promise.race([
           child.exited,
@@ -244,6 +261,23 @@ export class AntigravityPrintProcessRunner implements AntigravityProcessRunner {
       if (parser) {
         parser.end();
         const result = parser.getResult();
+        // The turn is explained here or nowhere: this is the only place that
+        // knows what the CLI actually sent, what ended the wait, and whether a
+        // terminal frame was among it. A turn that ends without a `result` is
+        // otherwise indistinguishable from one whose `result` we failed to read.
+        this.report(hooks, {
+          endedBy: sawResultBeforeWait ? 'result-frame' : (exit ? 'process-exit' : 'drain-grace'),
+          exitCode: exit?.code ?? null,
+          frameCounts: summariseFrames(frameLog.counts),
+          frameTotal: frameLog.total,
+          hasResult: result !== null,
+          lastFrame: frameLog.lastName ?? 'none',
+          msToFirstFrame: frameLog.firstAt === undefined ? null : frameLog.firstAt - frameLog.startedAt,
+          msToLastFrame: frameLog.lastAt === undefined ? null : frameLog.lastAt - frameLog.startedAt,
+          outputLimitExceeded: outputLimit.didExceed,
+          ...(result ? { resultStatus: result.status } : {}),
+        });
+        succeeded = result !== null && (exit?.code ?? 0) === 0 && !outputLimit.didExceed;
         return {
           exitCode: exit?.code ?? 0,
           ...(exit?.signal ? { signal: exit.signal } : {}),
@@ -272,6 +306,7 @@ export class AntigravityPrintProcessRunner implements AntigravityProcessRunner {
       } else {
         outputLimit.consume(Buffer.byteLength(transcript.output, 'utf8'));
       }
+      succeeded = (exit?.code ?? 0) === 0 && !outputLimit.didExceed;
       return {
         exitCode: exit?.code ?? 0,
         ...(exit?.signal ? { signal: exit.signal } : {}),
@@ -281,9 +316,42 @@ export class AntigravityPrintProcessRunner implements AntigravityProcessRunner {
         ...(outputLimit.didExceed ? { outputLimitExceeded: true } : {}),
       };
     } finally {
-      await (this.options.removeLog ?? removeLog)(logFilePath).catch(() => undefined);
+      // **A failed run keeps its log.** 1.3.2 unlinked it only after success,
+      // because it is the only place `agy` records the real wall-clock cause of
+      // a turn that went wrong. Deleting it unconditionally deletes the evidence
+      // for exactly the turns that need explaining.
+      if (succeeded) {
+        await (this.options.removeLog ?? removeLog)(logFilePath).catch(() => undefined);
+      } else {
+        this.report(hooks, { keptLogForDiagnosis: true });
+      }
     }
   }
+
+  /** Sanitised structural diagnosis; never carries prompt, answer, or paths. */
+  private report(
+    hooks: AntigravityProcessRunnerHooks,
+    data: Readonly<Record<string, unknown>>,
+  ): void {
+    try {
+      hooks.onDiagnostic?.(data);
+    } catch {
+      // Diagnosis must never change the outcome of the turn it describes.
+    }
+  }
+}
+
+interface FrameLog {
+  readonly counts: Map<string, number>;
+  firstAt?: number;
+  lastAt?: number;
+  lastName?: string;
+  readonly startedAt: number;
+  total: number;
+}
+
+function summariseFrames(counts: ReadonlyMap<string, number>): Record<string, number> {
+  return Object.fromEntries([...counts.entries()].sort((a, b) => b[1] - a[1]));
 }
 
 class OutputLimitMonitor {

--- a/src/providers/antigravity/runtime/AntigravityPrintProcessRunner.ts
+++ b/src/providers/antigravity/runtime/AntigravityPrintProcessRunner.ts
@@ -252,13 +252,10 @@ export class AntigravityPrintProcessRunner implements AntigravityProcessRunner {
       sawResultBeforeWait = parser?.getResult() != null;
       if (sawResultBeforeWait) {
         void child.terminate('graceful');
-        exit = await Promise.race([
-          child.exited,
-          delay(this.drainGraceMs()).then(() => undefined),
-        ]);
+        exit = await withinGrace(child.exited, this.drainGraceMs());
       } else {
         exit = await child.exited;
-        await Promise.race([drained, delay(this.drainGraceMs())]);
+        await withinGrace(drained, this.drainGraceMs());
       }
       // **The frame, not the pipe.** In stream-json the answer is one field of
       // the last `result` frame, and the frames around it are progress this
@@ -455,8 +452,29 @@ async function consumeFrames(
   }
 }
 
-function delay(ms: number): Promise<void> {
-  return new Promise(resolve => { window.setTimeout(resolve, ms); });
+/**
+ * The value if it arrives inside the grace period, `undefined` if it does not.
+ *
+ * The timer is cleared either way. A race leaves its loser running, and the
+ * loser here is a two-second timer armed on every turn — `AntigravityCliCapabilities`
+ * and `AntigravityModelDiscovery` both pair `window.setTimeout` with a
+ * `clearTimeout` for the same reason, and a plugin that can be unloaded should
+ * not leave one behind to fire into a torn-down renderer.
+ */
+async function withinGrace<T>(value: Promise<T>, ms: number): Promise<T | undefined> {
+  let handle: number | undefined;
+  try {
+    return await Promise.race([
+      value,
+      new Promise<undefined>(resolve => {
+        handle = window.setTimeout(() => resolve(undefined), ms);
+      }),
+    ]);
+  } finally {
+    if (handle !== undefined) {
+      window.clearTimeout(handle);
+    }
+  }
 }
 
 function removeLog(logFilePath: string): Promise<void> {

--- a/src/providers/antigravity/runtime/AntigravityStreamJson.ts
+++ b/src/providers/antigravity/runtime/AntigravityStreamJson.ts
@@ -37,6 +37,16 @@ export interface AntigravityStreamJsonParserOptions {
    * frame to hand back, because agy emits `result` last.
    */
   onEvent?: (event: AntigravityStreamEvent) => void;
+  /**
+   * Receives the `event` name of every line the CLI wrote, including names this
+   * parser does not act on and lines it could not parse at all.
+   *
+   * Diagnosis, not behaviour: when a turn ends without a `result`, the only
+   * thing that separates "the CLI never sent one" from "it sent one we did not
+   * recognise" is what actually arrived on the wire. Names only — a frame's
+   * contents are the user's prompt and answer and never leave the parser.
+   */
+  onFrame?: (eventName: string) => void;
 }
 
 export interface AntigravityStreamJsonParser {
@@ -64,6 +74,18 @@ export function createAntigravityStreamJsonParser(
   // run one at a time, so advancing the fallback on `DONE` keeps the pair
   // together and separates the next call.
   let fallbackToolIndex = 0;
+
+  const reportFrame = (eventName: string): void => {
+    if (!options.onFrame) {
+      return;
+    }
+    try {
+      options.onFrame(eventName);
+    } catch {
+      // Diagnosis must never abort parsing: the result frame that carries the
+      // actual answer is still ahead on this stream.
+    }
+  };
 
   const emit = (event: AntigravityStreamEvent): void => {
     if (!options.onEvent) {
@@ -126,6 +148,7 @@ export function createAntigravityStreamJsonParser(
     }
     try {
       const record = JSON.parse(trimmed) as Record<string, unknown>;
+      reportFrame(typeof record.event === 'string' && record.event ? record.event : 'unnamed');
       if (record.event === 'step_update') {
         const step = asRecord(record.step_update);
         if (step) {
@@ -147,6 +170,7 @@ export function createAntigravityStreamJsonParser(
       };
     } catch {
       // Ignore malformed lines; agy owns the wire and partial writes happen.
+      reportFrame('unparsed');
     }
   };
 

--- a/tests/unit/providers/antigravity/AntigravityPrintProcessRunner.test.ts
+++ b/tests/unit/providers/antigravity/AntigravityPrintProcessRunner.test.ts
@@ -215,6 +215,31 @@ describe('AntigravityPrintProcessRunner', () => {
     expect(outcome.stdout).toHaveLength(spoken);
   });
 
+  it('finishes a turn whose pipes an orphan still holds after the process exited', async () => {
+    // 1.3.2 gave `close` a grace period after `exit` and then forced the
+    // streams shut, because "an orphaned grandchild holding the pipes would
+    // otherwise hold the whole run hostage". Waiting on the streams with no
+    // deadline brings the hostage back: agy answers, exits, and the tab spins
+    // forever on a pipe nobody will close.
+    const child = new FakeManagedChild();
+    // A stdout that never ends, the way a held pipe behaves.
+    (child as { stdout: AsyncIterable<Uint8Array> }).stdout = {
+      [Symbol.asyncIterator]: () => ({ next: () => new Promise<never>(() => {}) }),
+    } as AsyncIterable<Uint8Array>;
+    const runner = new AntigravityPrintProcessRunner({
+      transport: new FakeTransport(child),
+      outputByteLimit: ANTIGRAVITY_OUTPUT_BYTE_LIMIT,
+      drainGraceMs: 1,
+      createLogPath: () => '/tmp/antigravity.log',
+      removeLog: async () => undefined,
+      recoverTranscript: async () => ({ output: 'answered', outputLimitExceeded: false }),
+    });
+    const handle = runner.start(INVOCATION);
+    child.exit.resolve({ code: 0 });
+
+    await expect(handle.completed).resolves.toMatchObject({ exitCode: 0 });
+  });
+
   it('recovers the Windows transcript only after a successful empty stdout', async () => {
     const child = new FakeManagedChild();
     const recoverTranscript = jest.fn().mockResolvedValue({

--- a/tests/unit/providers/antigravity/AntigravityPrintProcessRunner.test.ts
+++ b/tests/unit/providers/antigravity/AntigravityPrintProcessRunner.test.ts
@@ -266,6 +266,71 @@ describe('AntigravityPrintProcessRunner', () => {
     expect(child.terminationModes.length).toBeGreaterThan(0);
   });
 
+  it('keeps the run log when the turn ended without a terminal frame', async () => {
+    // 1.3.2 unlinked the log only after a successful run. It is the only place
+    // `agy` records the real wall-clock cause, so deleting it unconditionally
+    // destroys the evidence for exactly the turns that need explaining (#139).
+    const child = new FakeManagedChild({
+      stdout: ['{"event":"step_update","step_update":{"step_type":"text","text_delta":"hi"}}\n'],
+    });
+    const removeLog = jest.fn().mockResolvedValue(undefined);
+    const runner = new AntigravityPrintProcessRunner({
+      transport: new FakeTransport(child),
+      drainGraceMs: 1,
+      createLogPath: () => '/tmp/antigravity.log',
+      removeLog,
+    });
+
+    const handle = runner.start({
+      ...INVOCATION,
+      cliCapabilities: { addDir: false, printTimeout: false, streamJson: true },
+    });
+    child.exit.resolve({ code: 0 });
+    await handle.completed;
+
+    expect(removeLog).not.toHaveBeenCalled();
+  });
+
+  it('reports what the CLI sent when a turn ends without a terminal frame', async () => {
+    // The question a hung turn leaves behind is whether no terminal frame was
+    // sent or one was sent in a shape we do not read. Only the wire answers it,
+    // and nothing recorded it: the run record stops updating and the frames are
+    // never logged. Names and counts, never the prompt or the answer.
+    const child = new FakeManagedChild({
+      stdout: [
+        '{"event":"init","init":{}}\n',
+        '{"event":"step_update","step_update":{"step_type":"text","text_delta":"hi"}}\n',
+        '{"event":"some_new_frame","payload":{}}\n',
+      ],
+    });
+    const diagnostics: Array<Record<string, unknown>> = [];
+    const runner = new AntigravityPrintProcessRunner({
+      transport: new FakeTransport(child),
+      drainGraceMs: 1,
+      createLogPath: () => '/tmp/antigravity.log',
+      removeLog: async () => undefined,
+    });
+
+    const handle = runner.start(
+      { ...INVOCATION, cliCapabilities: { addDir: false, printTimeout: false, streamJson: true } },
+      { onDiagnostic: data => diagnostics.push({ ...data }) },
+    );
+    child.exit.resolve({ code: 0 });
+    await handle.completed;
+
+    const completion = diagnostics.find(entry => 'hasResult' in entry);
+    expect(completion).toMatchObject({
+      endedBy: 'process-exit',
+      frameTotal: 3,
+      hasResult: false,
+      lastFrame: 'some_new_frame',
+    });
+    // The unread frame is named rather than silently dropped: a terminal frame
+    // under a new name would otherwise look exactly like no terminal frame.
+    expect(completion?.frameCounts).toMatchObject({ init: 1, some_new_frame: 1, step_update: 1 });
+    expect(JSON.stringify(completion)).not.toContain('hi');
+  });
+
   it('recovers the Windows transcript only after a successful empty stdout', async () => {
     const child = new FakeManagedChild();
     const recoverTranscript = jest.fn().mockResolvedValue({

--- a/tests/unit/providers/antigravity/AntigravityPrintProcessRunner.test.ts
+++ b/tests/unit/providers/antigravity/AntigravityPrintProcessRunner.test.ts
@@ -1,6 +1,7 @@
 import { executionSessionId, runId, sessionInstanceId } from '@/core/execution/ExecutionIds';
 import type { AntigravityInvocation } from '@/providers/antigravity/execution/AntigravityExecutionBackend';
 import { AntigravityExecutionBackend } from '@/providers/antigravity/execution/AntigravityExecutionBackend';
+import { ANTIGRAVITY_OUTPUT_BYTE_LIMIT } from '@/providers/antigravity/execution/AntigravityExecutionComposition';
 import {
   type AntigravityManagedChildProcess,
   AntigravityPrintProcessRunner,
@@ -188,6 +189,30 @@ describe('AntigravityPrintProcessRunner', () => {
       stdout: '123',
       outputLimitExceeded: true,
     });
+  });
+
+  it('lets a turn print far more than the old buffer size on the configured budget', async () => {
+    // The budget is what the product actually runs with, not a test value: it
+    // used to be a *sliding buffer* size (`.slice(-64_000)`), and carrying the
+    // number over to a cumulative budget turned "keep the last 64 KB" into
+    // "kill any turn that says more than 64 KB". A trivial agy probe already
+    // writes ~30 KB, so real turns died and stored an empty answer.
+    const spoken = 200_000;
+    const child = new FakeManagedChild({
+      stdout: ['x'.repeat(spoken)],
+    });
+    const runner = new AntigravityPrintProcessRunner({
+      transport: new FakeTransport(child),
+      outputByteLimit: ANTIGRAVITY_OUTPUT_BYTE_LIMIT,
+      createLogPath: () => '/tmp/antigravity.log',
+      removeLog: async () => undefined,
+    });
+    const handle = runner.start(INVOCATION);
+    child.exit.resolve({ code: 0 });
+
+    const outcome = await handle.completed;
+    expect(outcome.outputLimitExceeded).toBeUndefined();
+    expect(outcome.stdout).toHaveLength(spoken);
   });
 
   it('recovers the Windows transcript only after a successful empty stdout', async () => {

--- a/tests/unit/providers/antigravity/AntigravityPrintProcessRunner.test.ts
+++ b/tests/unit/providers/antigravity/AntigravityPrintProcessRunner.test.ts
@@ -295,6 +295,47 @@ describe('AntigravityPrintProcessRunner', () => {
     expect(child.terminationModes.length).toBeGreaterThan(0);
   });
 
+  it('does not leave the grace timer armed when the turn ends before it', async () => {
+    // The grace period is the loser of a race on every turn that ends normally,
+    // and a loser left running is a timer per turn firing into a renderer that
+    // may already be gone. Both neighbours in this provider pair their
+    // `window.setTimeout` with a `clearTimeout`; this one has to as well.
+    // Watched, not replaced: the timers still behave normally, and the invariant
+    // is only that the run cleared every one it armed.
+    const setSpy = jest.spyOn(window, 'setTimeout');
+    const clearSpy = jest.spyOn(window, 'clearTimeout');
+
+    try {
+      const child = new FakeManagedChild({
+        stdout: [
+          '{"event":"result","result":{"status":"ok","response":"done","error":null}}\n',
+        ],
+      });
+      child.exit.resolve({ code: 0 });
+      const runner = new AntigravityPrintProcessRunner({
+        transport: new FakeTransport(child),
+        // Long enough that a leaked timer would outlive the test itself.
+        drainGraceMs: 30_000,
+        createLogPath: () => '/tmp/antigravity.log',
+        removeLog: async () => undefined,
+      });
+
+      const handle = runner.start({
+        ...INVOCATION,
+        cliCapabilities: { addDir: false, printTimeout: false, streamJson: true },
+      });
+
+      // Awaited directly: `settledWithin` arms a timer of its own, and this row
+      // is about every timer the run itself leaves behind.
+      await expect(handle.completed).resolves.toMatchObject({ stdout: 'done' });
+      expect(setSpy.mock.calls.length).toBeGreaterThan(0);
+      expect(clearSpy).toHaveBeenCalledTimes(setSpy.mock.calls.length);
+    } finally {
+      setSpy.mockRestore();
+      clearSpy.mockRestore();
+    }
+  });
+
   it('keeps the run log when the turn ended without a terminal frame', async () => {
     // 1.3.2 unlinked the log only after a successful run. It is the only place
     // `agy` records the real wall-clock cause, so deleting it unconditionally

--- a/tests/unit/providers/antigravity/AntigravityPrintProcessRunner.test.ts
+++ b/tests/unit/providers/antigravity/AntigravityPrintProcessRunner.test.ts
@@ -240,6 +240,32 @@ describe('AntigravityPrintProcessRunner', () => {
     await expect(handle.completed).resolves.toMatchObject({ exitCode: 0 });
   });
 
+  it('ends a turn on the result frame even when the CLI never leaves', async () => {
+    // Observed live: `agy` answered and stayed resident. Treating process exit
+    // as the end of the turn leaves the tab spinning on an answer it already
+    // has. The turn is over when the last `result` frame arrives.
+    const child = new FakeManagedChild({
+      stdout: [
+        '{"event":"result","result":{"status":"ok","response":"done","error":null}}\n',
+      ],
+    });
+    // `exit` is never resolved: the process outlives its own answer.
+    const runner = new AntigravityPrintProcessRunner({
+      transport: new FakeTransport(child),
+      drainGraceMs: 1,
+      createLogPath: () => '/tmp/antigravity.log',
+      removeLog: async () => undefined,
+    });
+
+    const handle = runner.start({
+      ...INVOCATION,
+      cliCapabilities: { addDir: false, printTimeout: false, streamJson: true },
+    });
+
+    await expect(handle.completed).resolves.toMatchObject({ stdout: 'done' });
+    expect(child.terminationModes.length).toBeGreaterThan(0);
+  });
+
   it('recovers the Windows transcript only after a successful empty stdout', async () => {
     const child = new FakeManagedChild();
     const recoverTranscript = jest.fn().mockResolvedValue({

--- a/tests/unit/providers/antigravity/AntigravityPrintProcessRunner.test.ts
+++ b/tests/unit/providers/antigravity/AntigravityPrintProcessRunner.test.ts
@@ -266,6 +266,35 @@ describe('AntigravityPrintProcessRunner', () => {
     expect(child.terminationModes.length).toBeGreaterThan(0);
   });
 
+  it('ends on the result frame while the CLI holds both pipes open', async () => {
+    // The case every earlier test misses, and the reported hang (#139). Each of
+    // them gives the fake an stderr that *ends*, so the combined drain resolves
+    // and the wait is released by a pipe closing. A resident `agy` closes
+    // neither pipe: the frame consumer returns at `result`, but the drain is an
+    // `all` of both, so it stays pending — and so does the exit. Recorded live:
+    // `init`, two `step_update`, and `result` all arrived by 7.6 s, and the turn
+    // still hung for eleven minutes.
+    const child = new FakeManagedChild();
+    (child as { stdout: AsyncIterable<Uint8Array> }).stdout = residentStdout([
+      '{"event":"result","result":{"status":"SUCCESS","response":"ok","error":null}}\n',
+    ]);
+    (child as { stderr: AsyncIterable<Uint8Array> }).stderr = residentStdout([]);
+    const runner = new AntigravityPrintProcessRunner({
+      transport: new FakeTransport(child),
+      drainGraceMs: 1,
+      createLogPath: () => '/tmp/antigravity.log',
+      removeLog: async () => undefined,
+    });
+
+    const handle = runner.start({
+      ...INVOCATION,
+      cliCapabilities: { addDir: false, printTimeout: false, streamJson: true },
+    });
+
+    await expect(settledWithin(handle.completed, 250)).resolves.toMatchObject({ stdout: 'ok' });
+    expect(child.terminationModes.length).toBeGreaterThan(0);
+  });
+
   it('keeps the run log when the turn ended without a terminal frame', async () => {
     // 1.3.2 unlinked the log only after a successful run. It is the only place
     // `agy` records the real wall-clock cause, so deleting it unconditionally
@@ -320,10 +349,12 @@ describe('AntigravityPrintProcessRunner', () => {
 
     const completion = diagnostics.find(entry => 'hasResult' in entry);
     expect(completion).toMatchObject({
-      endedBy: 'process-exit',
       frameTotal: 3,
       hasResult: false,
-      lastFrame: 'some_new_frame',
+      // Under the log's safe-key names: anything else reaches the file as
+      // `[redacted-string]`, which is exactly the silence this replaced.
+      messageType: 'some_new_frame',
+      reason: 'process-exit',
     });
     // The unread frame is named rather than silently dropped: a terminal frame
     // under a new name would otherwise look exactly like no terminal frame.
@@ -484,6 +515,37 @@ function chunks(values: readonly string[]): AsyncIterable<Uint8Array> {
       }
     },
   };
+}
+
+/**
+ * Frames on a pipe that never closes, the way a resident CLI leaves them.
+ *
+ * Deliberately different from `chunks`: that helper ends its iteration, which
+ * closes the stream and releases anything waiting on the drain.
+ */
+function residentStdout(values: readonly string[]): AsyncIterable<Uint8Array> {
+  return {
+    async *[Symbol.asyncIterator]() {
+      for (const value of values) {
+        yield Buffer.from(value, 'utf8');
+      }
+      await new Promise<never>(() => {});
+    },
+  };
+}
+
+/**
+ * Fails loudly instead of hanging the suite: a run that never settles is the
+ * defect under test, and jest's own timeout would report it as an unhelpful
+ * whole-test expiry rather than as this assertion.
+ */
+function settledWithin<T>(work: Promise<T>, ms: number): Promise<T> {
+  return Promise.race([
+    work,
+    new Promise<never>((_resolve, reject) => {
+      setTimeout(() => reject(new Error(`run did not settle within ${ms}ms`)), ms).unref?.();
+    }),
+  ]);
 }
 
 function deferred<T>() {

--- a/tests/unit/providers/antigravity/NodeAntigravityProcessTransport.test.ts
+++ b/tests/unit/providers/antigravity/NodeAntigravityProcessTransport.test.ts
@@ -1,0 +1,105 @@
+import { PassThrough, Writable } from 'node:stream';
+
+import type {
+  LocalProcessSystem,
+  SpawnedLocalProcess,
+} from '@/app/execution/local/NodeLocalShellProcessAdapter';
+import { NodeAntigravityProcessTransport } from '@/providers/antigravity/execution/NodeAntigravityProcessTransport';
+
+describe('NodeAntigravityProcessTransport', () => {
+  it('closes stdin even when the write never reports back', async () => {
+    // **EOF is the end of the protocol, not a reward for a clean write.** The
+    // stream-json turn is one line and then EOF, and a live `agy` whose stdin
+    // stays open answers and then never leaves — verified against the CLI. When
+    // the close was made conditional on the write callback, a callback that
+    // never fires meant EOF never sent, and the turn stayed open with no
+    // terminal frame until a timer ended it (#139). 1.3.2 closed unconditionally.
+    const stdin = new SilentWritable();
+    const transport = new NodeAntigravityProcessTransport(systemWith(stdin), 'posix');
+
+    const child = transport.launch(SPEC);
+    // Never awaited: the write callback is the thing that does not come back.
+    void child.sendInput?.('{"event":"user"}\n');
+    await flush();
+
+    expect(stdin.ended).toBe(true);
+  });
+
+  it('closes stdin when the write fails outright', async () => {
+    // The other way the callback never resolves: a child that already left, so
+    // the pipe rejects the write. The prompt is lost either way, but a lost
+    // prompt is a failed turn — a missing EOF is a turn that never ends.
+    const stdin = new FailingWritable();
+    const transport = new NodeAntigravityProcessTransport(systemWith(stdin), 'posix');
+
+    const child = transport.launch(SPEC);
+    await expect(child.sendInput?.('{"event":"user"}\n')).rejects.toThrow('broken pipe');
+    await flush();
+
+    expect(stdin.ended).toBe(true);
+  });
+});
+
+const SPEC = {
+  args: ['--input-format', 'stream-json'],
+  command: '/usr/local/bin/agy',
+  cwd: '/vault',
+  environment: { PATH: '/usr/local/bin' },
+  shell: false,
+  stdin: 'pipe' as const,
+};
+
+/** Accepts the bytes and never calls the callback, the way a full pipe stalls. */
+class SilentWritable extends Writable {
+  ended = false;
+
+  override _write(): void {
+    // No callback: the write is accepted and never acknowledged.
+  }
+
+  override end(...args: unknown[]): this {
+    this.ended = true;
+    return super.end(...(args as []));
+  }
+}
+
+class FailingWritable extends Writable {
+  ended = false;
+
+  override _write(
+    _chunk: unknown,
+    _encoding: unknown,
+    callback: (error?: Error | null) => void,
+  ): void {
+    callback(new Error('broken pipe'));
+  }
+
+  override end(...args: unknown[]): this {
+    this.ended = true;
+    return super.end(...(args as []));
+  }
+}
+
+function systemWith(stdin: Writable): LocalProcessSystem {
+  const spawned: SpawnedLocalProcess = {
+    termination: { kind: 'posix-process-group', pid: 4242 },
+    stdin,
+    stdout: new PassThrough(),
+    stderr: new PassThrough(),
+    started: Promise.resolve(),
+    exited: new Promise(() => {}),
+  };
+  return {
+    spawn: () => spawned,
+    processGroupExists: () => true,
+    signalProcessGroup: () => undefined,
+    windowsJobTerminated: () => true,
+    terminateWindowsJob: async () => true,
+  };
+}
+
+async function flush(): Promise<void> {
+  for (let index = 0; index < 10; index += 1) {
+    await Promise.resolve();
+  }
+}


### PR DESCRIPTION
Fixes #139
Fixes #144 

Six commits on the Antigravity turn seam, in the order the defects were found — each became visible only once the one before it was out of the way. The last one is the reported hang; the rest are what stood between it and being seen.

## 1. `stop killing a turn that says more than a parse buffer held`

`OUTPUT_BUFFER_LIMIT = 64_000` was the size of a *sliding* buffer in 1.3.2: keep the last 64 KB, discard the head. In 2.0 the same number became a cumulative budget for the turn, which turns "keep the last 64 KB" into "kill any turn that says more than 64 KB". A trivial `agy` probe already writes ~30 KB, so real turns died with `The response exceeded its size limit` and stored an empty answer. Now a memory ceiling rather than a limit on what the agent may say.

## 2. `give the pipes a deadline once the process has gone`

1.3.2 gave the streams a grace period after exit and then forced them shut, because an orphaned grandchild holding the pipes would otherwise hold the run hostage. 2.0 waited on them with no deadline.

## 3. `end the turn on the result frame, not on the process leaving`

In stream-json the turn ends at the last `result` frame. The `text_delta` frames sum exactly to `result.response`, so the frame is both the terminal signal and the whole answer. Necessary but, on its own, not sufficient — see 6.

## 4. `send EOF whether or not the write reports back`

The turn is one line on stdin and then EOF. 1.3.2 wrote and closed in two statements. 2.0 made the close wait on the write callback, and fired the whole call with `.catch(() => undefined)` and no `error` handler on the stream. A callback that never fires never settles that promise, so the close never runs.

Verified against the CLI: an `agy` whose stdin stays open answers and then never leaves, while the same turn with stdin closed answers and exits in seconds. A lost prompt is a failed turn; a missing EOF is a turn that never ends.

## 5. `keep a failed run's log, and record how the turn ended`

Two gaps that together made the hang reports unexplainable.

The log was unlinked unconditionally, but 1.3.2 unlinked it only after a successful run, because it is the only place `agy` records the real wall-clock cause. Deleting it always deletes the evidence for exactly the turns that need explaining.

And nothing recorded what the CLI sent: the run record stops updating once the turn is dispatched, and no frame was ever logged, so a turn that ended without a terminal frame could not be told apart from one whose terminal frame was not read. The parser now names every line it sees — including names it does not act on and lines it cannot parse — and the runner reports the shape of the turn once it settles: frame names and counts, time to first and last frame, what ended the wait, exit code, and whether a result was among it. Names, counts and timings only, under the debug log's safe-key names so the values are not redacted on the way out.

This is what found the actual bug, on the first hung turn after it shipped.

## 6. `let the answer end the wait, not the other pipe`

The reported defect.

The wait was a race between the process exiting and an `all` of both pipe consumers. With a parser the stdout consumer returns the moment the `result` frame is read — but a resident `agy` holds stderr open too, so the `all` stays pending, and the exit never comes either. Both arms of the race end up waiting on the same CLI that has already answered.

From the diagnosis in 5, on a real turn: `init`, two `step_update` and `result` all arrived within 7.6 seconds, `hasResult` true — and the turn still hung until it was killed by hand eleven minutes later. The comment above the race already claimed the frame ended the turn. The code waited for the pipes.

The stdout side is now its own promise and its own arm of the race. stderr is still drained for the outcome and still bounded by the grace period after exit. No timeout is involved in the fix: a turn ends when its answer arrives.

## Tests

Each commit carries a regression test that fails before it.

Two existing tests were passing for the wrong reason and are now backed by stricter siblings. Their fakes give the child an stderr that *ends*, so the drain resolved and the wait was released by a pipe closing rather than by the frame; the added cases hold both pipes open, which is what a resident CLI does. One of them — the fix in 4 — was first written as a `try`/`finally` and the test rejected it: a callback that never fires never reaches the `finally` either.

## Verification

- focused Antigravity suites: 18 passed, 187 tests passed
- `npx tsc --noEmit`: exit 0
- `npx eslint "src/**/*.ts" "tests/**/*.ts" --max-warnings=0`: exit 0
- full unit run: 23 failed, 9006 passed — the same pre-existing Windows failures as the `65dc6775` baseline, no delta
- `npm run build:release`: exit 0, source, CSS and dependency review gates passed
- installed and exercised in a real vault: the turn that reproduced the hang now completes in seconds