### PR TITLE
fix(codex): give a restored native thread to the session that runs the turn

### DIFF
--- a/src/core/execution/testing/DeterministicFakeBackend.ts
+++ b/src/core/execution/testing/DeterministicFakeBackend.ts
@@ -318,11 +318,23 @@ export class DeterministicFakeSession implements ExecutionSession {
     };
   }
 
+  /**
+   * What the session can say about its provider-native counterpart.
+   *
+   * A reference appears when the session has one to report: restored from the
+   * config, or minted when this session first runs. A session that has neither
+   * reports none, which every real backend does and this double used not to —
+   * it invented a reference unconditionally, so no test could express the
+   * restarted conversation that holds one session with a native reference and
+   * one without.
+   */
   getSnapshot(): ExecutionSessionSnapshot {
+    const nativeSessionRef = this.config.nativeSessionRef
+      ?? (this.runs.size > 0 ? `fake-session-${this.executionSessionId}` : undefined);
     return {
       executionSessionId: this.executionSessionId,
       sessionInstanceId: this.sessionInstanceId,
-      nativeSessionRef: `fake-session-${this.executionSessionId}`,
+      ...(nativeSessionRef ? { nativeSessionRef } : {}),
     };
   }
 

--- a/src/features/chat/application/ChatExecutionCoordinator.ts
+++ b/src/features/chat/application/ChatExecutionCoordinator.ts
@@ -744,9 +744,19 @@ export class ChatExecutionCoordinator {
     const unfinished = this.lifecycle.getRunsForOwner(owner).filter(run => !run.terminal);
     const sessions = this.lifecycle.getSessionsForOwner(owner);
     const latest = unfinished.at(-1);
+    const idle = sessions.filter(candidate => candidate.status !== 'disposed');
     const session = latest
       ? sessions.find(candidate => candidate.executionSessionId === latest.executionSessionId)
-      : sessions.filter(candidate => candidate.status !== 'disposed').at(-1);
+      // The newest session is not automatically the authoritative one. A
+      // restart can leave a conversation with two: the restored session, which
+      // carries the provider-native reference the conversation continues from,
+      // and a replacement opened afterwards without one. Adopting by recency
+      // alone picked the replacement, and the next turn then asked the provider
+      // to resume a thread the restored session still owned — which Codex
+      // refuses as an active-writer conflict, leaving the conversation
+      // unusable until it was recreated. The reference is what makes a session
+      // this conversation's, so it wins; recency only breaks the tie.
+      : idle.filter(candidate => candidate.nativeSessionRef).at(-1) ?? idle.at(-1);
     if (!session) {
       return;
     }

--- a/src/providers/codex/execution/CodexExecutionBackend.ts
+++ b/src/providers/codex/execution/CodexExecutionBackend.ts
@@ -51,6 +51,7 @@ import type {
   CodexExecutionConnection,
   CodexExecutionServerRequestHandler,
 } from '../runtime/CodexExecutionConnection';
+import { CodexRpcResponseError } from '../runtime/CodexRpcTransport';
 
 export interface CodexExecutionConnectionFactory {
   create(): CodexExecutionConnection;
@@ -189,6 +190,36 @@ interface PendingInteraction {
   settled: boolean;
 }
 
+/**
+ * A refusal this backend issued itself, before saying anything to the daemon.
+ *
+ * Carried as its own type because the run has to classify it: a binding this
+ * backend declined is as definite as one the app-server declined, and neither
+ * can have changed a workspace. A bare `Error` here would be read as a failure
+ * of unknown consequence and reported as `effects-unknown`.
+ */
+export class CodexThreadOwnershipError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'CodexThreadOwnershipError';
+  }
+}
+
+/**
+ * Who owns which native thread, and which threads this daemon already holds.
+ *
+ * Load state is the backend's rather than the session's because the conflict it
+ * prevents is the daemon's: `thread/resume` is refused for a thread already
+ * open, no matter which execution session asks. A session that tracked only its
+ * own loads could not see the load another session — or the recovery path —
+ * had already performed, and would ask a second time.
+ */
+interface CodexThreadRegistry {
+  bind(threadId: string, session: CodexExecutionSession): void;
+  markLoaded(threadId: string): void;
+  isLoaded(threadId: string): boolean;
+}
+
 interface CodexExecutionServices {
   readonly connection: CodexExecutionConnection;
   readonly turnReconciler: CodexTurnReconciler;
@@ -203,6 +234,13 @@ ExecutionRecoveryPort {
   readonly descriptor = CODEX_EXECUTION_DESCRIPTOR;
   private readonly sessions = new Set<CodexExecutionSession>();
   private readonly sessionsByThread = new Map<string, CodexExecutionSession>();
+  /**
+   * The threads this app-server generation has open.
+   *
+   * Emptied whenever the connection behind them goes: a new daemon holds no
+   * thread, so every reference has to be resumed again.
+   */
+  private readonly loadedThreads = new Set<string>();
   private readonly interactions = new Map<InteractionId, PendingInteraction>();
   private readonly interactionsByNativeRequest = new Map<string, PendingInteraction>();
   private servicesTask: Promise<CodexExecutionServices> | undefined;
@@ -239,7 +277,7 @@ ExecutionRecoveryPort {
       config,
       this.context,
       () => this.ensureServices(),
-      (threadId, owner) => this.bindThread(threadId, owner),
+      this.threadRegistry,
       () => this.sessions.delete(session),
       run => this.handleRunTerminal(run),
     );
@@ -298,13 +336,15 @@ ExecutionRecoveryPort {
     }
     try {
       const services = await this.ensureServices();
-      const session = this.sessionsByThread.get(query.nativeSessionRef);
-      if (!session?.getThreadState().loaded) {
+      if (!this.loadedThreads.has(query.nativeSessionRef)) {
         await services.connection.request<ThreadResumeResult>('thread/resume', {
           ...this.context.defaultResumeParams,
           threadId: query.nativeSessionRef,
         });
-        session?.markLoaded();
+        // Recorded on the backend rather than on a session: recovery runs for
+        // threads no live session owns, and the load it performs is what a
+        // later run would otherwise repeat into an active-writer conflict.
+        this.loadedThreads.add(query.nativeSessionRef);
       }
       const evidence = await services.turnReconciler.reconcile({
         threadId: query.nativeSessionRef,
@@ -426,6 +466,8 @@ ExecutionRecoveryPort {
       this.activeServices = undefined;
       this.servicesTask = undefined;
     }
+    // Every thread this daemon held is gone with it.
+    this.loadedThreads.clear();
     if (!this.disposing) {
       for (const session of this.sessions) {
         session.handleConnectionLost(error);
@@ -588,6 +630,26 @@ ExecutionRecoveryPort {
     }
   }
 
+  private readonly threadRegistry: CodexThreadRegistry = {
+    bind: (threadId, session) => this.bindThread(threadId, session),
+    markLoaded: threadId => this.loadedThreads.add(threadId),
+    isLoaded: threadId => this.loadedThreads.has(threadId),
+  };
+
+  /**
+   * Moves a native thread to the session that is about to use it.
+   *
+   * A restart leaves one conversation holding two execution sessions: the
+   * restored one carries the native reference, and the replacement the kernel
+   * opens for the reopened tab carries none. Refusing the replacement outright
+   * left the conversation unusable, because the session that owned the thread
+   * was not the session the next turn was dispatched through.
+   *
+   * So an idle binding is handed over. A binding whose session still has a run
+   * in flight is not: that run is producing an answer through this thread, and
+   * moving it would leave the turn writing into a session nobody is watching.
+   * The refusal is definite, and typed so the run reports it as such.
+   */
   private bindThread(threadId: string, session: CodexExecutionSession): void {
     for (const [existingThreadId, owner] of this.sessionsByThread) {
       if (owner === session && existingThreadId !== threadId) {
@@ -596,7 +658,12 @@ ExecutionRecoveryPort {
     }
     const existing = this.sessionsByThread.get(threadId);
     if (existing && existing !== session) {
-      throw new Error('Codex native thread is already owned by another execution session.');
+      if (existing.activeExecutionRun) {
+        throw new CodexThreadOwnershipError(
+          'Codex native thread is in use by another execution session.',
+        );
+      }
+      existing.releaseThread();
     }
     this.sessionsByThread.set(threadId, session);
   }
@@ -630,14 +697,13 @@ class CodexExecutionSession implements ExecutionSession {
   private activeRun: CodexExecutionRun | undefined;
   private nativeThreadId: string | undefined;
   private lastNativeTurnId: string | undefined;
-  private loadedInConnection = false;
   private disposed = false;
 
   constructor(
     private readonly config: ExecutionSessionConfig,
     private readonly context: CodexExecutionBackendContext,
     private readonly servicesProvider: CodexExecutionServicesProvider,
-    private readonly onBindThread: (threadId: string, session: CodexExecutionSession) => void,
+    private readonly threads: CodexThreadRegistry,
     private readonly onDispose: () => void,
     private readonly onRunTerminal: (run: CodexExecutionRun) => void,
   ) {
@@ -712,11 +778,37 @@ class CodexExecutionSession implements ExecutionSession {
 
   handleConnectionLost(_error?: Error): void {
     this.activeRun?.handleConnectionLost();
-    this.loadedInConnection = false;
   }
 
   getThreadState(): { readonly threadId?: string; readonly loaded: boolean } {
-    return { threadId: this.nativeThreadId, loaded: this.loadedInConnection };
+    return {
+      threadId: this.nativeThreadId,
+      // Asked of the daemon's registry, not remembered here: another session
+      // may have loaded this same thread, and resuming it again is the
+      // active-writer conflict.
+      loaded: this.nativeThreadId ? this.threads.isLoaded(this.nativeThreadId) : false,
+    };
+  }
+
+  /**
+   * Takes a thread this daemon already holds open, without resuming it.
+   *
+   * Answers `false` when the thread is not loaded, which leaves the caller to
+   * resume it as before. Throws when a live run owns it.
+   */
+  adoptLoadedThread(threadId: string): boolean {
+    requireNativeId(threadId, 'Codex thread id');
+    if (!this.threads.isLoaded(threadId)) {
+      return false;
+    }
+    this.threads.bind(threadId, this);
+    this.nativeThreadId = threadId;
+    return true;
+  }
+
+  /** Gives up a binding another session is taking over. */
+  releaseThread(): void {
+    this.nativeThreadId = undefined;
   }
 
   getPreviousNativeTurnId(): string | undefined {
@@ -725,20 +817,21 @@ class CodexExecutionSession implements ExecutionSession {
 
   bindThread(threadId: string): void {
     requireNativeId(threadId, 'Codex thread id');
-    this.onBindThread(threadId, this);
+    this.threads.bind(threadId, this);
     this.nativeThreadId = threadId;
-    this.loadedInConnection = true;
+    this.threads.markLoaded(threadId);
   }
 
   restoreThreadRef(threadId: string): void {
     requireNativeId(threadId, 'Codex restored thread id');
-    this.onBindThread(threadId, this);
+    this.threads.bind(threadId, this);
     this.nativeThreadId = threadId;
-    this.loadedInConnection = false;
   }
 
   markLoaded(): void {
-    this.loadedInConnection = true;
+    if (this.nativeThreadId) {
+      this.threads.markLoaded(this.nativeThreadId);
+    }
   }
 
   async dispose(): Promise<void> {
@@ -1006,18 +1099,47 @@ class CodexExecutionRun implements ExecutionRun {
       if (this.cancellation && !this.terminal) {
         void this.cancel(this.cancellation);
       }
-    } catch {
+    } catch (error) {
       if (!this.terminal) {
-        const effectsPossible = this.turnDispatchStarted || this.nativePreparationStarted;
-        this.finish(
-          effectsPossible ? 'indeterminate' : 'invalidated',
-          effectsPossible
-            ? (this.turnDispatchStarted ? 'dispatch-unknown' : 'effects-unknown')
-            : 'pre-dispatch-rejected',
-          !effectsPossible,
-        );
+        this.finishFailedDispatch(error);
       }
     }
+  }
+
+  /**
+   * Says what a failed dispatch is allowed to claim about the workspace.
+   *
+   * The old rule read one flag — had any native preparation been *started* —
+   * and answered `effects-unknown` for everything after it. The flag is set
+   * before the request is awaited, so a `thread/resume` the app-server refused
+   * outright was reported as a run whose effects could not be established. That
+   * is the harshest verdict the kernel has, and it was being given to the one
+   * case that is certain: the daemon answered, and answered no.
+   *
+   * What matters is not whether a request was sent but whether an answer came
+   * back. A structured error response is an answer. A transport failure, a
+   * timeout or a process exit are not, and those keep the old verdict, because
+   * a `thread/start` whose acknowledgement was lost may well have created a
+   * thread.
+   *
+   * Anything after `turn/start` was reached stays `dispatch-unknown` regardless:
+   * a definite refusal of the turn itself is not worth distinguishing from a
+   * lost one while the turn may already be running.
+   */
+  private finishFailedDispatch(error: unknown): void {
+    if (this.turnDispatchStarted) {
+      this.finish('indeterminate', 'dispatch-unknown');
+      return;
+    }
+    if (isDefiniteRejection(error)) {
+      this.finish('invalidated', 'side-effect-free-rejection', true);
+      return;
+    }
+    if (this.nativePreparationStarted) {
+      this.finish('indeterminate', 'effects-unknown');
+      return;
+    }
+    this.finish('invalidated', 'pre-dispatch-rejected', true);
   }
 
   private async ensureThread(intent: CodexThreadIntent): Promise<string> {
@@ -1041,6 +1163,13 @@ class CodexExecutionRun implements ExecutionRun {
       return result.thread.id;
     }
     if (intent.kind === 'resume') {
+      // The thread may already be open in this daemon — loaded by the session
+      // this one replaces, or by startup recovery. Resuming it a second time is
+      // what the app-server answers with an active-writer conflict, so the
+      // binding moves and the existing load stands.
+      if (this.session.adoptLoadedThread(intent.threadId)) {
+        return intent.threadId;
+      }
       const result = await this.requestNativePreparation<ThreadResumeResult>('thread/resume', {
         ...intent.params,
         threadId: intent.threadId,
@@ -1685,6 +1814,16 @@ function validatePreparedInteraction(prepared: CodexPreparedInteraction): void {
   if (!prepared.responseIds.includes(prepared.providerResolvedResponseId)) {
     throw new Error('Codex interaction must include its provider-resolved response.');
   }
+}
+
+/**
+ * Whether the failure is an answer rather than a silence.
+ *
+ * Both cases are decisions taken and reported: one by the app-server, one by
+ * this backend. Neither can have left work running.
+ */
+function isDefiniteRejection(error: unknown): boolean {
+  return error instanceof CodexRpcResponseError || error instanceof CodexThreadOwnershipError;
 }
 
 function resumeParams(intent: CodexThreadIntent): Omit<ThreadResumeParams, 'threadId'> {

--- a/src/providers/codex/execution/CodexExecutionBackend.ts
+++ b/src/providers/codex/execution/CodexExecutionBackend.ts
@@ -84,6 +84,16 @@ export interface CodexExecutionInvocation {
 export interface CodexExecutionRequestResolver {
   resolve(requestRef: string): Promise<CodexExecutionInvocation>;
   resolveSteer(requestRef: string): Promise<readonly UserInput[]>;
+  /**
+   * Keeps what a definite rejection said, for the terminal that follows it.
+   *
+   * The kernel's terminal names a category — the turn was rejected before it
+   * could act — and the sentence a user can do something about lives only in
+   * the refusal itself: a thread already open elsewhere, a model the account
+   * cannot reach. The store this reaches is the one a refused turn already
+   * reads from, so both kinds of rejection are described the same way.
+   */
+  recordRefusal(requestRef: string, message: string): void;
 }
 
 export interface CodexExecutionResultSink {
@@ -663,7 +673,11 @@ ExecutionRecoveryPort {
           'Codex native thread is in use by another execution session.',
         );
       }
-      existing.releaseThread();
+      // The turn the thread ended on travels with it. `turn/started` for a turn
+      // that already finished is recognised by comparing against that id, and a
+      // session that inherited the thread but not the id has nothing to compare
+      // against — it would take the previous turn for its own.
+      session.inheritThreadHistory(existing.releaseThread());
     }
     this.sessionsByThread.set(threadId, session);
   }
@@ -806,9 +820,23 @@ class CodexExecutionSession implements ExecutionSession {
     return true;
   }
 
-  /** Gives up a binding another session is taking over. */
-  releaseThread(): void {
+  /**
+   * Gives up a binding another session is taking over, naming the turn it
+   * ended on so the session taking over can keep telling that turn from its own.
+   */
+  releaseThread(): string | undefined {
     this.nativeThreadId = undefined;
+    return this.lastNativeTurnId;
+  }
+
+  /**
+   * Takes on the turn the session that held this thread ended on.
+   *
+   * Never overwrites a turn this session ran itself: what it knows first-hand
+   * is later than anything it is being told.
+   */
+  inheritThreadHistory(lastNativeTurnId: string | undefined): void {
+    this.lastNativeTurnId ??= lastNativeTurnId;
   }
 
   getPreviousNativeTurnId(): string | undefined {
@@ -828,9 +856,17 @@ class CodexExecutionSession implements ExecutionSession {
     this.nativeThreadId = threadId;
   }
 
-  markLoaded(): void {
-    if (this.nativeThreadId) {
-      this.threads.markLoaded(this.nativeThreadId);
+  /**
+   * Records a load with the daemon's registry.
+   *
+   * Takes a thread id for the fork path, which resumes a thread before it is
+   * bound to anything: the binding is the last step there, and a failure
+   * between the two would otherwise leave a thread this daemon holds open with
+   * nothing remembering it — which the next run resumes into a writer conflict.
+   */
+  markLoaded(threadId: string | undefined = this.nativeThreadId): void {
+    if (threadId) {
+      this.threads.markLoaded(threadId);
     }
   }
 
@@ -1132,6 +1168,12 @@ class CodexExecutionRun implements ExecutionRun {
       return;
     }
     if (isDefiniteRejection(error)) {
+      // The provider's own words, and only its words: a structured `data`
+      // payload is untrusted and is never rendered.
+      const message = error.message.trim();
+      if (message) {
+        this.context.requestResolver.recordRefusal(this.request.requestRef, message);
+      }
       this.finish('invalidated', 'side-effect-free-rejection', true);
       return;
     }
@@ -1189,6 +1231,7 @@ class CodexExecutionRun implements ExecutionRun {
       ...intent.resumeParams,
       threadId,
     });
+    this.session.markLoaded(threadId);
     const rollback = fork.thread.turns.length - checkpoint - 1;
     if (rollback > 0) {
       await this.requestNativePreparation('thread/rollback', { threadId, numTurns: rollback });
@@ -1822,7 +1865,9 @@ function validatePreparedInteraction(prepared: CodexPreparedInteraction): void {
  * Both cases are decisions taken and reported: one by the app-server, one by
  * this backend. Neither can have left work running.
  */
-function isDefiniteRejection(error: unknown): boolean {
+function isDefiniteRejection(
+  error: unknown,
+): error is CodexRpcResponseError | CodexThreadOwnershipError {
   return error instanceof CodexRpcResponseError || error instanceof CodexThreadOwnershipError;
 }
 

--- a/src/providers/codex/execution/CodexExecutionComposition.ts
+++ b/src/providers/codex/execution/CodexExecutionComposition.ts
@@ -362,7 +362,10 @@ export class CodexExecution {
         if (reason === 'provider-failure') {
           return content.lastFailure();
         }
-        return reason === 'pre-dispatch-rejected'
+        // Both rejections read the same store: one refused by the resolver
+        // before anything was sent, one refused by the daemon before the turn
+        // was. Neither ran, and neither is explained by the kernel's wording.
+        return reason === 'pre-dispatch-rejected' || reason === 'side-effect-free-rejection'
           ? this.requests.refusalFor(lastRequestRef)
           : undefined;
       },

--- a/src/providers/codex/execution/CodexExecutionRequests.ts
+++ b/src/providers/codex/execution/CodexExecutionRequests.ts
@@ -401,7 +401,14 @@ export class CodexExecutionRequests implements CodexExecutionRequestResolver {
     return refusal;
   }
 
-  private refuse(requestRef: string, message: string): Error {
+  /**
+   * Keeps a refusal this store did not itself issue.
+   *
+   * The backend records what the daemon answered a native preparation with, so
+   * a `thread/resume` refused before any turn was dispatched is described in
+   * the words that explain it rather than by the kernel's neutral sentence.
+   */
+  recordRefusal(requestRef: string, message: string): void {
     while (this.refusals.size >= REFUSAL_LIMIT) {
       const oldest = this.refusals.keys().next();
       if (oldest.done) {
@@ -410,6 +417,10 @@ export class CodexExecutionRequests implements CodexExecutionRequestResolver {
       this.refusals.delete(oldest.value);
     }
     this.refusals.set(requestRef, message);
+  }
+
+  private refuse(requestRef: string, message: string): Error {
+    this.recordRefusal(requestRef, message);
     return new Error(message);
   }
 

--- a/src/providers/codex/runtime/CodexRpcTransport.ts
+++ b/src/providers/codex/runtime/CodexRpcTransport.ts
@@ -3,6 +3,29 @@ import type { Readable, Writable } from 'stream';
 
 import type { JsonRpcError } from './codexAppServerTypes';
 
+/**
+ * An error the peer answered with, as opposed to one that befell the request.
+ *
+ * The distinction is the whole point of the class. A JSON-RPC error response is
+ * proof that the app-server received the request, decided against it and said
+ * so; a transport failure, a timeout or a process exit prove nothing about
+ * whether the request was acted on. Callers that must classify side effects —
+ * the execution run does — cannot tell those apart from a message string, and
+ * flattening the response into `new Error(err.message)` is what forced the run
+ * to assume the worst for every failed native preparation.
+ */
+export class CodexRpcResponseError extends Error {
+  readonly code: number;
+  readonly data: unknown;
+
+  constructor(error: JsonRpcError) {
+    super(error.message);
+    this.name = 'CodexRpcResponseError';
+    this.code = error.code;
+    this.data = error.data;
+  }
+}
+
 const DEFAULT_TIMEOUT_MS = 30_000;
 
 interface PendingRequest {
@@ -197,8 +220,7 @@ export class CodexRpcTransport {
     if (pending.timer) window.clearTimeout(pending.timer);
 
     if (msg.error) {
-      const err = msg.error as JsonRpcError;
-      pending.reject(new Error(err.message));
+      pending.reject(new CodexRpcResponseError(msg.error as JsonRpcError));
     } else {
       pending.resolve(msg.result);
     }

--- a/tests/unit/features/chat/application/ChatExecutionCoordinator.test.ts
+++ b/tests/unit/features/chat/application/ChatExecutionCoordinator.test.ts
@@ -950,6 +950,34 @@ describe('chat execution coordinator', () => {
       ]);
       reopened.dispose();
     });
+
+    it('adopts the session that holds the native provider thread, not the newest one', async () => {
+      const harness = await createHarness();
+      const owner = { kind: 'conversation' as const, ownerId: CONVERSATION_ID };
+      // What a restart leaves behind: the restored session carries the
+      // conversation's provider-native thread.
+      const restored = executionSessionId(opaque('es', 41));
+      await harness.registry.createSession({
+        backendId: FAKE_BACKEND_ID,
+        executionSessionId: restored,
+        owner,
+        nativeSessionRef: 'native-thread-1',
+      });
+      // And a second one for the same conversation, opened without it.
+      await harness.registry.createSession({
+        backendId: FAKE_BACKEND_ID,
+        executionSessionId: executionSessionId(opaque('es', 42)),
+        owner,
+      });
+
+      const reopened = harness.createCoordinator();
+      await reopened.loadConversation(CONVERSATION_ID);
+
+      // Dispatching through the session without the reference would resume a
+      // thread another session already owns, which the provider refuses.
+      expect(reopened.executionSessionFor(CONVERSATION_ID)).toBe(restored);
+      reopened.dispose();
+    });
   });
 
   it('detaches from a durable turn on dispose and refuses what never started', async () => {

--- a/tests/unit/providers/codex/CodexExecutionBackend.test.ts
+++ b/tests/unit/providers/codex/CodexExecutionBackend.test.ts
@@ -34,6 +34,7 @@ import type {
   CodexExecutionNotificationListener,
   CodexExecutionServerRequestHandler,
 } from '@/providers/codex/runtime/CodexExecutionConnection';
+import { CodexRpcResponseError } from '@/providers/codex/runtime/CodexRpcTransport';
 
 const RUN_1 = runId(`run-${'1'.repeat(32)}`);
 const RUN_2 = runId(`run-${'2'.repeat(32)}`);
@@ -51,6 +52,18 @@ const TURN_PARAMS: Omit<TurnStartParams, 'threadId'> = {
   model: 'gpt-5.6-codex',
   summary: 'detailed',
 };
+const RESTORED_THREAD = 'thread-restored';
+const RESUME_PARAMS = {
+  experimentalRawEvents: true,
+  persistExtendedHistory: true,
+};
+/**
+ * What the app-server answers a second `thread/resume` with.
+ *
+ * A structured JSON-RPC error rather than a bare `Error`: the run has to tell
+ * a definite refusal from a lost answer, and only the shape carries that.
+ */
+const ACTIVE_WRITER_CODE = -32603;
 
 describe('CodexExecutionBackend', () => {
   it('multiplexes sessions through one initialized connection and preserves early notifications', async () => {
@@ -1035,6 +1048,99 @@ describe('CodexExecutionBackend', () => {
     expect(fixture.connection.calls.filter(call => call.method === 'turn/interrupt'))
       .toHaveLength(1);
   });
+
+  it('reuses a restored native thread when a replacement session takes it over', async () => {
+    // One conversation, two execution sessions after a restart: the restored
+    // one carries the native thread, the replacement one the kernel opened
+    // carries no reference at all. The replacement must not resume a thread
+    // this app-server generation has already loaded.
+    const fixture = createFixture({
+      invocations: {
+        first: resumeInvocation(),
+        second: resumeInvocation(),
+      },
+    });
+    const restored = await fixture.backend.createSession({
+      executionSessionId: executionSessionId(`es-${'1'.repeat(32)}`),
+      owner: OWNER,
+      backendGeneration: 1,
+      nativeSessionRef: RESTORED_THREAD,
+    });
+    const firstEvents = collectEvents(restored.createRun(request(RUN_1, 'first')));
+    await fixture.connection.waitForCalls('turn/start', 1);
+    fixture.connection.complete(RESTORED_THREAD, 'turn-1', 'first answer');
+    expectTerminal(await firstEvents, 'succeeded', 'completed');
+
+    const replacement = await createSession(fixture.backend, 2);
+    const secondEvents = collectEvents(replacement.createRun(request(RUN_2, 'second')));
+    await fixture.connection.waitForCalls('turn/start', 2);
+    fixture.connection.complete(RESTORED_THREAD, 'turn-2', 'second answer');
+
+    expectTerminal(await secondEvents, 'succeeded', 'completed');
+    expect(fixture.connection.calls.filter(call => call.method === 'thread/resume'))
+      .toHaveLength(1);
+    expect(replacement.getSnapshot()).toMatchObject({ nativeSessionRef: RESTORED_THREAD });
+  });
+
+  it('refuses to take a native thread away from a session with a live run', async () => {
+    const fixture = createFixture({
+      invocations: {
+        first: resumeInvocation(),
+        second: resumeInvocation(),
+      },
+    });
+    const restored = await fixture.backend.createSession({
+      executionSessionId: executionSessionId(`es-${'1'.repeat(32)}`),
+      owner: OWNER,
+      backendGeneration: 1,
+      nativeSessionRef: RESTORED_THREAD,
+    });
+    const firstEvents = collectEvents(restored.createRun(request(RUN_1, 'first')));
+    await fixture.connection.waitForCalls('turn/start', 1);
+
+    const replacement = await createSession(fixture.backend, 2);
+    const secondEvents = collectEvents(replacement.createRun(request(RUN_2, 'second')));
+
+    // The live turn keeps its thread; the intruder is rejected before dispatch
+    // rather than silently displacing the run that is still producing an answer.
+    expectTerminal(await secondEvents, 'invalidated', 'side-effect-free-rejection');
+    expect(fixture.connection.calls.filter(call => call.method === 'turn/start'))
+      .toHaveLength(1);
+
+    fixture.connection.complete(RESTORED_THREAD, 'turn-1', 'first answer');
+    expectTerminal(await firstEvents, 'succeeded', 'completed');
+  });
+
+  it('classifies a definite native preparation rejection as side-effect-free', async () => {
+    const fixture = createFixture({ invocations: { first: resumeInvocation() } });
+    fixture.connection.beforeRequest = method => (method === 'thread/resume'
+      ? Promise.reject(new CodexRpcResponseError({
+        code: ACTIVE_WRITER_CODE,
+        message: 'thread already has an active writer',
+      }))
+      : undefined);
+    const session = await createSession(fixture.backend, 1);
+
+    const events = collectEvents(session.createRun(request(RUN_1, 'first')));
+
+    // The provider answered. Nothing was dispatched, so nothing can have run.
+    expectTerminal(await events, 'invalidated', 'side-effect-free-rejection');
+    expect(fixture.connection.calls.some(call => call.method === 'turn/start')).toBe(false);
+  });
+
+  it('keeps an ambiguous native preparation failure indeterminate', async () => {
+    const fixture = createFixture({ invocations: { first: resumeInvocation() } });
+    fixture.connection.beforeRequest = method => (method === 'thread/resume'
+      ? Promise.reject(new Error('Transport disposed'))
+      : undefined);
+    const session = await createSession(fixture.backend, 1);
+
+    const events = collectEvents(session.createRun(request(RUN_1, 'first')));
+
+    // No answer came back. The request may have been acted on.
+    expectTerminal(await events, 'indeterminate', 'effects-unknown');
+    expect(fixture.connection.calls.some(call => call.method === 'turn/start')).toBe(false);
+  });
 });
 
 interface FixtureOptions {
@@ -1148,6 +1254,7 @@ class FakeCodexConnection implements CodexExecutionConnection {
   private readonly notifications = new Set<CodexExecutionNotificationListener>();
   private readonly serverRequests = new Set<CodexExecutionServerRequestHandler>();
   private readonly connectionLosses = new Set<(error?: Error) => void>();
+  private readonly loadedThreads = new Set<string>();
   private threadSequence = 0;
   private turnSequence = 0;
 
@@ -1169,10 +1276,22 @@ class FakeCodexConnection implements CodexExecutionConnection {
     }
     const record = params as Record<string, unknown>;
     if (method === 'thread/start') {
-      return startResult(thread(`thread-${++this.threadSequence}`)) as T;
+      const started = thread(`thread-${++this.threadSequence}`);
+      this.loadedThreads.add(started.id);
+      return startResult(started) as T;
     }
     if (method === 'thread/resume') {
-      return startResult(thread(String(record.threadId))) as T;
+      const threadId = String(record.threadId);
+      // The app-server refuses to load a thread it already holds open, which
+      // is the conflict this suite exists to keep out.
+      if (this.loadedThreads.has(threadId)) {
+        throw new CodexRpcResponseError({
+          code: ACTIVE_WRITER_CODE,
+          message: 'thread already has an active writer',
+        });
+      }
+      this.loadedThreads.add(threadId);
+      return startResult(thread(threadId)) as T;
     }
     if (method === 'thread/fork') {
       return startResult(thread(`thread-${++this.threadSequence}`)) as T;
@@ -1245,6 +1364,10 @@ class FakeCodexConnection implements CodexExecutionConnection {
   waitForCall(method: string): Promise<void> {
     return waitFor(() => this.calls.some(call => call.method === method));
   }
+
+  waitForCalls(method: string, count: number): Promise<void> {
+    return waitFor(() => this.calls.filter(call => call.method === method).length >= count);
+  }
 }
 
 class ManualScheduler implements CodexExecutionScheduler {
@@ -1278,6 +1401,13 @@ function request(id: typeof RUN_1, requestRef: string): ExecutionRequest {
     owner: OWNER,
     resultExpectation: 'required',
     requestRef,
+  };
+}
+
+function resumeInvocation(threadId = RESTORED_THREAD): CodexExecutionInvocation {
+  return {
+    thread: { kind: 'resume', threadId, params: RESUME_PARAMS },
+    turn: { kind: 'start', params: TURN_PARAMS },
   };
 }
 

--- a/tests/unit/providers/codex/CodexExecutionBackend.test.ts
+++ b/tests/unit/providers/codex/CodexExecutionBackend.test.ts
@@ -1106,6 +1106,10 @@ describe('CodexExecutionBackend', () => {
     expectTerminal(await secondEvents, 'invalidated', 'side-effect-free-rejection');
     expect(fixture.connection.calls.filter(call => call.method === 'turn/start'))
       .toHaveLength(1);
+    // The tab renders this instead of the kernel's neutral sentence, which
+    // cannot name what is holding the thread.
+    expect(fixture.refusals.get('second'))
+      .toBe('Codex native thread is in use by another execution session.');
 
     fixture.connection.complete(RESTORED_THREAD, 'turn-1', 'first answer');
     expectTerminal(await firstEvents, 'succeeded', 'completed');
@@ -1126,6 +1130,99 @@ describe('CodexExecutionBackend', () => {
     // The provider answered. Nothing was dispatched, so nothing can have run.
     expectTerminal(await events, 'invalidated', 'side-effect-free-rejection');
     expect(fixture.connection.calls.some(call => call.method === 'turn/start')).toBe(false);
+    // The daemon's own words, kept for the terminal that follows them. Only the
+    // message: the structured `data` of a provider error is never rendered.
+    expect(fixture.refusals.get('first')).toBe('thread already has an active writer');
+  });
+
+  it('fences the previous turn after a replacement session takes the thread over', async () => {
+    const fixture = createFixture({
+      invocations: {
+        first: resumeInvocation(),
+        compact: {
+          thread: { kind: 'resume', threadId: RESTORED_THREAD, params: RESUME_PARAMS },
+          turn: { kind: 'compact' },
+        },
+      },
+    });
+    const restored = await fixture.backend.createSession({
+      executionSessionId: executionSessionId(`es-${'1'.repeat(32)}`),
+      owner: OWNER,
+      backendGeneration: 1,
+      nativeSessionRef: RESTORED_THREAD,
+    });
+    const firstEvents = collectEvents(restored.createRun(request(RUN_1, 'first')));
+    await fixture.connection.waitForCalls('turn/start', 1);
+    fixture.connection.complete(RESTORED_THREAD, 'turn-1', 'first answer');
+    await firstEvents;
+
+    const replacement = await createSession(fixture.backend, 2);
+    const compactEvents = collectEvents(replacement.createRun(request(RUN_2, 'compact')));
+    await fixture.connection.waitForCall('thread/compact/start');
+    // The turn the session it replaced ended on. A compaction learns its turn
+    // id from this notification alone, so the replacement has to know which one
+    // is already over — which it can only do if the id travelled with the
+    // thread it took over.
+    fixture.connection.notifyExecution('turn/started', {
+      threadId: RESTORED_THREAD,
+      turn: turn('turn-1', 'inProgress'),
+    });
+    fixture.connection.notifyExecution('turn/started', {
+      threadId: RESTORED_THREAD,
+      turn: turn('turn-compact', 'inProgress'),
+    });
+    fixture.connection.complete(RESTORED_THREAD, 'turn-compact', 'compacted');
+
+    const settled = await compactEvents;
+    expectTerminal(settled, 'succeeded', 'completed');
+    expect(settled.filter(event => event.event.kind === 'run-started')).toEqual([
+      expect.objectContaining({ scope: expect.objectContaining({ nativeRunRef: 'turn-compact' }) }),
+    ]);
+  });
+
+  it('remembers a forked thread the daemon loaded when the rollback fails', async () => {
+    const fixture = createFixture({
+      invocations: {
+        first: {
+          thread: {
+            kind: 'fork',
+            sourceThreadId: 'thread-source',
+            resumeAtTurnId: 'source-turn-1',
+            resumeParams: RESUME_PARAMS,
+          },
+          turn: { kind: 'start', params: TURN_PARAMS },
+        },
+        second: resumeInvocation('thread-fork'),
+      },
+    });
+    fixture.connection.beforeRequest = method => {
+      if (method === 'thread/fork') {
+        return startResult(thread('thread-fork', [
+          turn('source-turn-1', 'completed'),
+          turn('source-turn-2', 'completed'),
+        ]));
+      }
+      return method === 'thread/rollback'
+        ? Promise.reject(new Error('Transport disposed'))
+        : undefined;
+    };
+    const forking = await createSession(fixture.backend, 1);
+    const forkEvents = collectEvents(forking.createRun(request(RUN_1, 'first')));
+    expectTerminal(await forkEvents, 'indeterminate', 'effects-unknown');
+
+    // The fork is resumed before it is bound to anything, and the binding is
+    // what used to record the load. A failure in between left a thread this
+    // daemon holds open with nothing remembering it, and the next run resumed
+    // it again — into the writer conflict.
+    const resuming = await createSession(fixture.backend, 2);
+    const secondEvents = collectEvents(resuming.createRun(request(RUN_2, 'second')));
+    await fixture.connection.waitForCall('turn/start');
+    fixture.connection.complete('thread-fork', 'turn-1', 'second answer');
+
+    expectTerminal(await secondEvents, 'succeeded', 'completed');
+    expect(fixture.connection.calls.filter(call => call.method === 'thread/resume'
+      && (call.params as { readonly threadId?: string }).threadId === 'thread-fork'))
+      .toHaveLength(1);
   });
 
   it('keeps an ambiguous native preparation failure indeterminate', async () => {
@@ -1161,6 +1258,8 @@ function createFixture(options: FixtureOptions = {}) {
     readonly output: string;
     readonly source: 'assistant' | 'native-agent';
   }> = [];
+  /** What a definite rejection told the store the tab reads its wording from. */
+  const refusals = new Map<string, string>();
   let connectionFactoryCalls = 0;
   let sessionInstances = 0;
   let interactionIdsCreated = 0;
@@ -1184,6 +1283,7 @@ function createFixture(options: FixtureOptions = {}) {
     requestResolver: {
       resolve: async requestRef => options.invocations?.[requestRef] ?? defaultInvocation,
       resolveSteer: async () => [{ type: 'text', text: 'Continue with the correction' }],
+      recordRefusal: (requestRef, message) => { refusals.set(requestRef, message); },
     },
     resultSink: {
       storeResult: async input => {
@@ -1240,6 +1340,7 @@ function createFixture(options: FixtureOptions = {}) {
     scheduler,
     interactionIds,
     resultSinkInputs,
+    refusals,
     get connectionFactoryCalls() {
       return connectionFactoryCalls;
     },

--- a/tests/unit/providers/codex/CodexExecutionConformance.test.ts
+++ b/tests/unit/providers/codex/CodexExecutionConformance.test.ts
@@ -58,6 +58,7 @@ function createDriver(
     requestResolver: {
       resolve: () => requestResolution.promise,
       resolveSteer: async () => [],
+      recordRefusal: () => {},
     },
     resultSink: {
       storeResult: async () => ({


### PR DESCRIPTION
Fixes #137.

## What was wrong

Three defects, one visible symptom: after an Obsidian restart, sending a message
in an existing Codex conversation failed in about 0.3 s with "Grimoire could not
establish what this run changed."

### 1. Adoption preferred recency over authority

A restart can leave one conversation with two execution sessions: the restored
one, carrying the provider-native thread the conversation continues from, and a
replacement opened afterwards without one. `ChatExecutionCoordinator.adoptOwnedWork`
took the newest non-disposed session, so the turn was dispatched through the
replacement — which then asked the daemon to resume a thread the restored session
still owned.

### 2. Thread load state was tracked per session, not per daemon

The conflict `thread/resume` raises is the daemon's: it refuses to load a thread
it already holds open, whichever execution session asks. `loadedInConnection`
lived on the session, so a session could not see a load performed by another
session — or by `CodexExecutionBackend.reconcile()`, which resumed a thread and
then recorded the load through `session?.markLoaded()`. When no session owned the
thread, the optional chaining silently dropped the fact, and the next run resumed
it again.

### 3. Every failed native preparation claimed unknown workspace effects

`CodexRpcTransport.handleResponse` flattened every JSON-RPC error response into
`new Error(err.message)`, discarding `code` and `data`. With the shape gone, the
run could not tell an answer from a silence, so `execute()` fell back to one flag —
`nativePreparationStarted`, set *before* the request is awaited — and reported a
`thread/resume` the daemon had refused outright as `indeterminate / effects-unknown`.
That is the harshest verdict the kernel has, given to the one case that is certain:
the provider answered, and answered no. `turn/start` was never sent.

## What changed

**Ownership.** Thread load state moves from the session to the backend, where the
constraint actually lives. An idle binding is handed to the session about to use
it; a binding whose session still has a run in flight is refused, so a live turn
cannot be silently displaced. A thread this daemon generation already holds is
adopted without a second `thread/resume`. The set is emptied when the connection
goes, because a new daemon holds no thread.

**Recovery.** `reconcile()` records its load on the backend rather than through a
session that may not exist.

**Classification.** `CodexRpcResponseError` carries the structured `code` and
`data`; `CodexThreadOwnershipError` marks a refusal this backend issued itself.
Both are definite: the decision was taken and reported, so nothing can have run.
A definite rejection before `turn/start` is now `invalidated / side-effect-free-rejection`.
A lost or ambiguous acknowledgement keeps `effects-unknown`, because a `thread/start`
whose answer never arrived may well have created a thread. Anything after
`turn/start` was reached stays `dispatch-unknown` regardless.

**Adoption.** The native reference decides which session a conversation adopts;
recency only breaks the tie between sessions that both have one. An unfinished run
still pins the choice — a live turn names its own session.

## Tests

Five focused tests, each of which fails on `main`:

- a replacement session takes over a restored thread and runs, with exactly one
  `thread/resume` on the wire;
- a session with a live run does not lose its thread to a replacement;
- a definite `thread/resume` rejection before `turn/start` is terminal and
  side-effect-free, and no `turn/start` is sent;
- an ambiguous native preparation failure stays indeterminate;
- adoption picks the session holding the native reference, not the newest.

The fake connection now answers a second `thread/resume` for a loaded thread with
a structured error, the way the app-server does, so a duplicate resume cannot pass
this suite again. `DeterministicFakeSession` reported a native reference
unconditionally, which no real backend does and which is why the restarted-conversation
state could not be expressed in a test at all; it now reports one when it has one.

## Verification

`tsc --noEmit`, `eslint --max-warnings=0`, `review:source`, `review:css` and
`review:deps` all pass. Full suite on Windows: 9155 passed, 30 failed — the failing
set is byte-identical to the same suite on `65dc6775` (guardian DLL EPERM, CLI PATH
detection and platform-coverage checks, all pre-existing and unrelated). Verified by
diffing the sorted failing-test names between the branch and the base commit; the
difference is empty in both directions.

## Notes for review

No permission behaviour changes. The separation between saved authorization,
effective session state, native thread ownership, execution-session ownership and
run dispatch evidence is preserved. Provider errors stay untrusted input: the new
error type carries the provider's `code` and `data` without interpreting either,
and nothing new is logged.

Manually verified against a live Codex daemon, on a build carrying these two
commits on top of the reporter's existing fix stack; the change set in that build
is identical to this branch's.

- An existing conversation that had already taken turns before the restart
  continued without error across several consecutive Obsidian restarts.
- A second, older conversation branch reopened from history and continued without
  error — a resume intent for a different thread, exercising two conversations
  holding their own threads in one app-server generation.

Not covered manually: the guard that refuses to move a thread away from a session
with a run still in flight. That is a race, and it is covered by unit test only.