### PR TITLE
fix(chat): stop disabling auto-rename during the first turn

### DIFF
--- a/src/features/chat/controllers/ConversationController.ts
+++ b/src/features/chat/controllers/ConversationController.ts
@@ -1314,7 +1314,32 @@ export class ConversationController {
    */
   canSuggestTitle(conversationId: string | null): boolean {
     if (!conversationId) return false;
-    return this.resolveTitleSource(this.deps.plugin.getConversationSync(conversationId)).ok;
+    return this.resolveTitleSource(this.deps.plugin.getConversationSync(conversationId), conversationId).ok;
+  }
+
+  /**
+   * The first user message, from the record or from the tab that is on it.
+   *
+   * A conversation is created when its first message is sent and saved when the
+   * turn that answers it ends, so for the whole of that first turn the record
+   * holds no messages while the tab plainly shows one. Gating on the record
+   * alone disabled auto-rename there and explained it with «needs a message» to
+   * a user looking at their own — and it came back by itself when the answer
+   * landed, which is what made it read as a broken control rather than a wait.
+   *
+   * Only this tab's own conversation is answered from the live state: another
+   * tab's messages are not this controller's to read.
+   */
+  private firstUserMessage(
+    conversation: Conversation | null | undefined,
+    conversationId?: string,
+  ): ChatMessage | undefined {
+    const stored = conversation?.messages.find(m => m.role === 'user');
+    if (stored) return stored;
+    const { state } = this.deps;
+    const id = conversationId ?? conversation?.id;
+    if (!id || state.currentConversationId !== id) return undefined;
+    return state.messages.find(m => m.role === 'user');
   }
 
   /**
@@ -1331,7 +1356,7 @@ export class ConversationController {
    */
   async suggestTitle(conversationId: string): Promise<TitleSuggestion> {
     const conversation = await this.deps.plugin.getConversationById(conversationId);
-    const source = this.resolveTitleSource(conversation);
+    const source = this.resolveTitleSource(conversation, conversationId);
     if (!source.ok) return source;
 
     return new Promise<TitleSuggestion>((resolve) => {
@@ -1358,10 +1383,13 @@ export class ConversationController {
   }
 
   /** Shared gates for both the synchronous check and the actual generation. */
-  private resolveTitleSource(conversation: Conversation | null): TitleSuggestionSource {
+  private resolveTitleSource(
+    conversation: Conversation | null,
+    conversationId?: string,
+  ): TitleSuggestionSource {
     if (!this.isAutoTitleEnabled()) return { ok: false, reason: 'disabled' };
 
-    const firstUserMsg = conversation?.messages.find(m => m.role === 'user');
+    const firstUserMsg = this.firstUserMessage(conversation, conversationId);
     if (!conversation || !firstUserMsg) return { ok: false, reason: 'no-messages' };
 
     const service = this.deps.getTitleGenerationService();
@@ -1381,7 +1409,7 @@ export class ConversationController {
     if (!conversation) return;
     // Gate on the conversation we just loaded rather than the sync accessor: same object in
     // production, and it keeps this path independent of which accessor a caller warmed up.
-    if (!this.resolveTitleSource(conversation).ok) return;
+    if (!this.resolveTitleSource(conversation, conversationId).ok) return;
 
     // Remember the title so a manual rename during generation wins over the model.
     const expectedTitle = conversation.title;

--- a/src/features/chat/controllers/ConversationController.ts
+++ b/src/features/chat/controllers/ConversationController.ts
@@ -1332,13 +1332,12 @@ export class ConversationController {
    */
   private firstUserMessage(
     conversation: Conversation | null | undefined,
-    conversationId?: string,
+    conversationId: string,
   ): ChatMessage | undefined {
     const stored = conversation?.messages.find(m => m.role === 'user');
     if (stored) return stored;
     const { state } = this.deps;
-    const id = conversationId ?? conversation?.id;
-    if (!id || state.currentConversationId !== id) return undefined;
+    if (state.currentConversationId !== conversationId) return undefined;
     return state.messages.find(m => m.role === 'user');
   }
 
@@ -1385,7 +1384,7 @@ export class ConversationController {
   /** Shared gates for both the synchronous check and the actual generation. */
   private resolveTitleSource(
     conversation: Conversation | null,
-    conversationId?: string,
+    conversationId: string,
   ): TitleSuggestionSource {
     if (!this.isAutoTitleEnabled()) return { ok: false, reason: 'disabled' };
 

--- a/tests/unit/features/chat/controllers/ConversationController.test.ts
+++ b/tests/unit/features/chat/controllers/ConversationController.test.ts
@@ -2807,6 +2807,39 @@ describe('ConversationController title suggestion', () => {
     ).toBe(false);
   });
 
+  it('can suggest while the first turn is still running, before the record is saved', () => {
+    // The record for a conversation whose first turn has not ended yet: created
+    // on send, saved when the answer lands.
+    const { controller, deps } = createTitleHarness({
+      conversation: conversationWithUserMessage({ messages: [] }),
+    });
+    deps.state.currentConversationId = 'conv-1';
+    deps.state.messages = [{ id: 'm1', role: 'user', content: 'how do I dry PETG?', timestamp: 1 } as any];
+
+    expect(controller.canSuggestTitle('conv-1')).toBe(true);
+  });
+
+  it('does not read the live messages of another tab', () => {
+    const { controller, deps } = createTitleHarness({
+      conversation: conversationWithUserMessage({ messages: [] }),
+    });
+    deps.state.currentConversationId = 'conv-2';
+    deps.state.messages = [{ id: 'm1', role: 'user', content: 'not this conversation', timestamp: 1 } as any];
+
+    expect(controller.canSuggestTitle('conv-1')).toBe(false);
+  });
+
+  it('generates from the live message when the record has not caught up', async () => {
+    const { controller, deps, service } = createTitleHarness({
+      conversation: conversationWithUserMessage({ messages: [] }),
+    });
+    deps.state.currentConversationId = 'conv-1';
+    deps.state.messages = [{ id: 'm1', role: 'user', content: 'how do I dry PETG?', timestamp: 1 } as any];
+
+    await expect(controller.suggestTitle('conv-1')).resolves.toEqual({ ok: true, title: 'Drying PETG' });
+    expect(service.generateTitle).toHaveBeenCalledWith('conv-1', 'how do I dry PETG?', expect.any(Function));
+  });
+
   it('returns the generated title without touching the conversation', async () => {
     const { controller, deps, service } = createTitleHarness();
 


### PR DESCRIPTION
### Problem

Auto-rename is disabled for the whole of a conversation's first turn, and enables
itself when the answer lands. The sparkle button in the rename dialog and the
"Auto rename" item in the tab context menu are both greyed, and the tooltip
explains it with `chat.ui.tabs.autoRenameNeedsMessage` — a conversation needs a
message — to a user looking at the message they just sent.

`canSuggestTitle` resolves its source from `plugin.getConversationSync(id)`, and
that record is empty exactly then. A conversation is created on send with
`messages: []` and its messages are written when the turn that answers them ends.
So for the length of the first turn the control was reporting the save, not the
conversation. Nothing is broken afterwards, which is what makes it read as an
unreliable control rather than as a wait: the same tab answers differently to the
same question a minute apart.

Reported on a live vault, where it looked provider-specific — it is not; it is
the first turn on any provider.

### What changed

`firstUserMessage` looks in the record and, when the record has not caught up,
in this tab's live state. `resolveTitleSource` takes the conversation id so the
fallback can be scoped, and `suggestTitle` and `regenerateTitle` resolve their
source the same way — an enabled control is one that can actually generate,
rather than one that enables and then does nothing.

Only the tab's own conversation is answered from live state: another tab's
messages are not this controller's to read, and the state it holds is one tab's.

Follow-up to #123, which added the control and this gate.

### Tests

Three added: the gate opens while the first turn is still running and the record
is empty; it stays shut for a conversation that is not this tab's, even with live
messages present; and `suggestTitle` generates from the live message when the
record has not caught up. The existing negative cases — no user message, service
absent, setting disabled, null id — are untouched and still pass.

### Verification

`typecheck`, `lint`, `review:source`, `review:css`, `review:deps`,
`build:release` — all pass.

`npx jest --selectProjects unit` — the Windows baseline of 22 failing test names
is unchanged. Compared by name against `origin/main` with `comm`, not by count:
the delta is empty in both directions.

Fixes #157 