### PR TITLE
fix(tests): refuse to record a CLI that never started

### DIFF
--- a/tests/helpers/recordAcpWire.ts
+++ b/tests/helpers/recordAcpWire.ts
@@ -153,6 +153,18 @@ export async function recordAcpWire(
     stdio: ['pipe', 'pipe', 'pipe'],
   });
 
+  // A command that does not exist emits `error` and never `exit`. Unhandled it
+  // takes the run down; unread it is worse — the recorder wrote a fixture
+  // saying the CLI had refused a session, which is a fact about a CLI that
+  // never ran, in the file someone reads later as evidence.
+  let startupFailure: Error | undefined;
+  child.once('error', error => {
+    startupFailure = error;
+  });
+  // The other half of the same failure: writes to the stdin of a process that
+  // never started fail on their own.
+  child.stdin.on('error', () => {});
+
   let buffered = '';
   child.stdout.on('data', chunk => {
     buffered += String(chunk);
@@ -191,6 +203,10 @@ export async function recordAcpWire(
     },
   });
   await settle(timings.handshakeMs);
+  if (startupFailure) {
+    rmSync(vault, { force: true, recursive: true });
+    throw new Error(`\`${options.command}\` could not be started: ${startupFailure.message}`);
+  }
   send({ jsonrpc: '2.0', id: 2, method: 'session/new', params: { cwd: vault, mcpServers: [] } });
   await settle(timings.sessionMs);
 

--- a/tests/integration/providers/wire/AcpWireRecorder.integration.test.ts
+++ b/tests/integration/providers/wire/AcpWireRecorder.integration.test.ts
@@ -174,6 +174,23 @@ describe('the ACP wire recorder', () => {
     expect(vaults()).toEqual(before);
   });
 
+  it('says which CLI it could not start, and leaves no vault behind', async () => {
+    const vaults = (): string[] => readdirSync(tmpdir())
+      .filter(entry => entry.startsWith('grimoire-fake-wire-'));
+    const before = vaults();
+
+    await expect(recordAcpWire({
+      providerId: 'fake',
+      command: join(workspace, 'no-such-cli'),
+      args: [],
+      transport: 'stdio JSON-RPC 2.0 (fake)',
+      fixturePath,
+      timings,
+    })).rejects.toThrow(/no-such-cli/);
+
+    expect(vaults()).toEqual(before);
+  });
+
   it('writes the recording where it was told to', async () => {
     await record('answers');
 


### PR DESCRIPTION
### Problem

Follow-up to #136, found while reviewing it.

`recordAcpWire` spawns the CLI and listens for neither `error` nor a failed
`stdin` write. `spawn` of a command that does not exist emits `error` and never
`exit`, so two things happen at once.

The first is loud: an unhandled `'error'` event takes the run down.

The second is the one that matters. The run *completes anyway* and writes a
fixture, and the fixture says:

```
"limitations": [
  "The CLI refused to open a session: \"no reason given\". That is a real shape a flip meets.",
  "The handshake is evidence; the prompt traffic still needs an account that generates."
],
"recordedAgainst": "/…/no-such-cli unknown",
"coverage": "partial"
```

No CLI refused anything. None ran. The frames went into a stdin nobody was
reading. That is a recording of nothing wearing the shape of a thin one — and
`AcpWireRecorder.integration.test.ts` exists because the recorder once stated,
in the file it writes, a fact it could not observe. This is the same defect one
step earlier, on the path none of those rows covered.

Reachable from `AcpWireRecording.integration.test.ts` whenever `GRIMOIRE_WIRE_RECORD=1`
runs on a machine without the provider's CLI installed.

### Fix

Read the error, remove the vault, throw with the command named. The `stdin`
handler is the other half of the same failure: writes to a process that never
started fail on their own.

### Verification

The new row was written first and fails on `main`: the promise resolves instead
of rejecting, and the resolved value is the fabricated recording quoted above.

- `--selectProjects integration --testPathPatterns AcpWireRecorder` → 7 passed.
- `tsc --noEmit` and `eslint` clean.