### PR TITLE
fix(tests): budget the Windows guardian start for the compile it always pays

### DIFF
--- a/tests/integration/app/execution/local/LocalShellProcessOwnership.integration.test.ts
+++ b/tests/integration/app/execution/local/LocalShellProcessOwnership.integration.test.ts
@@ -13,7 +13,16 @@ import type {
 } from '@/core/execution/local/LocalShellBackend';
 
 describe('local shell process ownership on the host OS', () => {
-  jest.setTimeout(20_000);
+  // The Windows row's start is a cold C# compile every time it runs in CI: the
+  // POSIX row returns immediately there, the step runs `--runInBand`, and the
+  // guardian assembly is cached per machine — so the one launch in the job
+  // always pays `Add-Type`, which this repository measured at two to three
+  // seconds before the cache existed. Green runs of that row have taken 8.6s,
+  // 8.6s, 8.9s, 9.6s and 12.2s end to end; the one that failed reached the old
+  // 10s start budget at 10034ms. The row asserts ownership, not latency, so
+  // the budget is a hang detector and belongs far from where a loaded runner
+  // lands.
+  jest.setTimeout(120_000);
 
   it('owns and terminates a POSIX descendant after the root shell exits', async () => {
     if (localShellPlatformForNode(process.platform) !== 'posix') {
@@ -26,8 +35,9 @@ describe('local shell process ownership on the host OS', () => {
       terminationKind: 'posix-process-group',
     });
     try {
-      await within(child.started, 5_000);
-      await expect(within(child.exited, 5_000)).resolves.toEqual({ code: 0 });
+      await within(child.started, 5_000, 'the POSIX shell to start');
+      await expect(within(child.exited, 5_000, 'the POSIX shell to exit'))
+        .resolves.toEqual({ code: 0 });
       await expect(adapter.confirmTerminated(child.termination)).resolves.toBe(false);
 
       await adapter.terminate(child.termination, 'forced');
@@ -65,10 +75,15 @@ describe('local shell process ownership on the host OS', () => {
     const child = adapter.launch(windowsSpec(command));
     let descendantPid: number | undefined;
     try {
-      await within(child.started, 10_000);
-      descendantPid = await waitForPidFile(pidPath, 5_000);
+      await within(child.started, 60_000, 'the Windows job guardian to start');
+      // The pid comes from a second cold `powershell.exe`, started by the
+      // shell under test. Its sibling in CodexPersistentProcessOwnership
+      // budgets that same wait at 15s on Windows and says why; this one was
+      // left at the POSIX figure.
+      descendantPid = await waitForPidFile(pidPath, 15_000);
       expect(isProcessRunning(descendantPid)).toBe(true);
-      await expect(within(child.exited, 10_000)).resolves.toEqual({ code: 0 });
+      await expect(within(child.exited, 10_000, 'the Windows job root to exit'))
+        .resolves.toEqual({ code: 0 });
       expect(readFileSync(outputPath, 'utf8').replaceAll('\r\n', '\n'))
         .toBe('"hello world"\nnested\n');
       await expect(waitForPidTermination(descendantPid)).resolves.toBeUndefined();
@@ -146,9 +161,15 @@ function isProcessRunning(pid: number): boolean {
   }
 }
 
-function within<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
+function within<T>(promise: Promise<T>, timeoutMs: number, waitingFor: string): Promise<T> {
   return new Promise((resolve, reject) => {
-    const timeout = setTimeout(() => reject(new Error('Timed out.')), timeoutMs);
+    // Named, because the phase is the whole diagnosis: three waits in this
+    // file share one helper, and a bare "Timed out." left the last Windows
+    // failure to be attributed by arithmetic on the suite's own duration.
+    const timeout = setTimeout(
+      () => reject(new Error(`Timed out after ${timeoutMs}ms waiting for ${waitingFor}.`)),
+      timeoutMs,
+    );
     void promise.then(
       value => {
         clearTimeout(timeout);


### PR DESCRIPTION
### What happened

`LocalShellProcessOwnership.integration.test.ts` › *uses a Job Object guardian to
kill Windows descendants when the root exits* failed on #166 at **10034 ms**, and
passed on a rerun of the same commit. Nothing in that PR touches this path — it
edits the ACP wire recorder, which is not even in the suite that step runs.

### Why it fails

Not a race. The budget sits inside the spread of the row's own green runs:

| run | duration (passed) |
|---|---|
| 34215244937 | 8629 ms |
| 34245838575 | 8843 ms |
| 34239465004 | 8895 ms |
| 34211607433 | 9602 ms |
| 34243707243 | **12164 ms** |

Against a `within(child.started, 10_000)`. Which colour CI reports is decided by
how loaded the runner is.

The time goes to a cold compile, and in CI the compile is never warm. The
guardian is C# that PowerShell puts in the session with `Add-Type`, cached per
machine as a DLL keyed by a fingerprint of its source. In this job:

- the POSIX row returns immediately on Windows,
- the step runs `--runInBand`,
- so the Windows row is the **only** guardian launch in the job.

Every CI run therefore pays the full compile — measured in this repository at two
to three seconds, per `windowsJobGuardianTypeLoad`'s own comment — plus two cold
`powershell.exe` starts, before ownership is under test at all.

None of this is new. `CodexPersistentProcessOwnership.integration.test.ts`
already budgets its Windows waits at 15s and its comment explains exactly this
cost. That lesson never reached this file, whose Windows row kept the POSIX
figures.

### Fix

- 60s to see the guardian start; 15s for the pid file its child writes from a
  second cold PowerShell. The row asserts ownership, not latency — the budget is
  a hang detector and belongs nowhere near where a loaded runner lands.
- `within` now names the phase it gave up on. Three waits here share one helper
  and it raised a bare `Timed out.`, so attributing the failure above took
  arithmetic on the suite's reported duration.

### Verification

Honest limits: on macOS the Windows row is a no-op, so the local run
(2 passed, 0.18s) only shows nothing broke. `tsc --noEmit` and `eslint` clean.
The evidence for the diagnosis is the CI durations above, read from the job logs
of five green runs plus the failed one.

Deliberately not touched: `CodexPersistentProcessOwnership`, whose Windows budget
is already widened and for which I have no failure in hand — only the report in
 #136 that it flakes under a parallel run.