### PR TITLE
fix(claude): read plan quota percentages from unifiedWindows

### DIFF
--- a/src/providers/claude/app/ClaudePlanUsageStore.ts
+++ b/src/providers/claude/app/ClaudePlanUsageStore.ts
@@ -14,6 +14,18 @@ import { loadClaudeStatusLineUsageSnapshot } from './ClaudeStatusLineUsageSnapsh
 
 type ClaudeRateLimitType = 'five_hour' | 'seven_day' | 'seven_day_opus' | 'seven_day_sonnet' | 'overage';
 
+interface ClaudeRateLimitWindowEntry {
+  key: string;
+  window: ProviderPlanUsageWindow;
+}
+
+/**
+ * Windows resolved from `rate_limit_info.unifiedWindows`. The SDK also reports
+ * `seven_day_overage_included` there, which carries separate product meaning and
+ * stays out until the readout defines how to present it.
+ */
+const UNIFIED_RATE_LIMIT_KEYS: readonly ClaudeRateLimitType[] = ['five_hour', 'seven_day'];
+
 export class ClaudePlanUsageStore extends ProviderSpendUsageStore {
   private windows = new Map<string, ProviderPlanUsageWindow>();
 
@@ -26,12 +38,24 @@ export class ClaudePlanUsageStore extends ProviderSpendUsageStore {
   }
 
   recordSdkMessage(message: SDKMessage | Record<string, unknown>): boolean {
-    const rateLimitWindow = parseClaudeRateLimitWindow(message);
-    if (rateLimitWindow) {
-      const current = this.windows.get(rateLimitWindow.key);
-      const changed = JSON.stringify(current) !== JSON.stringify(rateLimitWindow.window);
-      this.windows.set(rateLimitWindow.key, rateLimitWindow.window);
-      return changed;
+    const rateLimitWindows = parseUnifiedRateLimitWindows(message);
+    const eventWindow = parseClaudeRateLimitWindow(message);
+    // The event-level window is frequently reset-only, so it must not replace a
+    // key already resolved from `unifiedWindows`, which reports the percentage.
+    if (eventWindow && !rateLimitWindows.some(entry => entry.key === eventWindow.key)) {
+      rateLimitWindows.push(eventWindow);
+    }
+
+    if (rateLimitWindows.length > 0) {
+      let quotaChanged = false;
+      for (const { key, window } of rateLimitWindows) {
+        const current = this.windows.get(key);
+        if (JSON.stringify(current) !== JSON.stringify(window)) {
+          quotaChanged = true;
+        }
+        this.windows.set(key, window);
+      }
+      return quotaChanged;
     }
 
     if (!isRecord(message) || message.type !== 'result' || !isRecord(message.modelUsage)) {
@@ -87,7 +111,7 @@ export class ClaudePlanUsageStore extends ProviderSpendUsageStore {
 
 export const claudePlanUsageStore = new ClaudePlanUsageStore();
 
-function parseClaudeRateLimitWindow(message: SDKMessage | Record<string, unknown>): { key: string; window: ProviderPlanUsageWindow } | null {
+function parseClaudeRateLimitWindow(message: SDKMessage | Record<string, unknown>): ClaudeRateLimitWindowEntry | null {
   if (!isRecord(message) || message.type !== 'rate_limit_event' || !isRecord(message.rate_limit_info)) {
     return null;
   }
@@ -114,6 +138,48 @@ function parseClaudeRateLimitWindow(message: SDKMessage | Record<string, unknown
       reset,
     },
   };
+}
+
+/**
+ * Recent Claude CLI builds report the consumed percentage per window in
+ * `rate_limit_info.unifiedWindows` and leave the top-level `utilization`
+ * undefined on most events. Reading only the top-level field leaves the window
+ * at `pctKnown: false`, which renders as an em dash and, while it is the only
+ * known window, suppresses the quota readout entirely.
+ *
+ * The field is absent from the published SDK types, so it is read defensively:
+ * anything unexpected falls back to the event-level window parsed above.
+ */
+function parseUnifiedRateLimitWindows(
+  message: SDKMessage | Record<string, unknown>,
+): ClaudeRateLimitWindowEntry[] {
+  if (!isRecord(message) || message.type !== 'rate_limit_event' || !isRecord(message.rate_limit_info)) {
+    return [];
+  }
+
+  const unifiedWindows = message.rate_limit_info.unifiedWindows;
+  if (!isRecord(unifiedWindows)) {
+    return [];
+  }
+
+  const entries: ClaudeRateLimitWindowEntry[] = [];
+  for (const key of UNIFIED_RATE_LIMIT_KEYS) {
+    const unifiedWindow = unifiedWindows[key];
+    if (!isRecord(unifiedWindow)) {
+      continue;
+    }
+
+    const pct = readUtilizationPct(unifiedWindow);
+    const reset = formatResetValue(unifiedWindow.resetsAt);
+    const label = formatRateLimitLabel(key);
+    if (pct === null || !reset || !label) {
+      continue;
+    }
+
+    entries.push({ key, window: { label, pct, reset } });
+  }
+
+  return entries;
 }
 
 function readRateLimitType(value: unknown): ClaudeRateLimitType | null {

--- a/src/providers/claude/app/ClaudePlanUsageStore.ts
+++ b/src/providers/claude/app/ClaudePlanUsageStore.ts
@@ -38,14 +38,7 @@ export class ClaudePlanUsageStore extends ProviderSpendUsageStore {
   }
 
   recordSdkMessage(message: SDKMessage | Record<string, unknown>): boolean {
-    const rateLimitWindows = parseUnifiedRateLimitWindows(message);
-    const eventWindow = parseClaudeRateLimitWindow(message);
-    // The event-level window is frequently reset-only, so it must not replace a
-    // key already resolved from `unifiedWindows`, which reports the percentage.
-    if (eventWindow && !rateLimitWindows.some(entry => entry.key === eventWindow.key)) {
-      rateLimitWindows.push(eventWindow);
-    }
-
+    const rateLimitWindows = parseClaudeRateLimitWindows(message);
     if (rateLimitWindows.length > 0) {
       let quotaChanged = false;
       for (const { key, window } of rateLimitWindows) {
@@ -111,12 +104,28 @@ export class ClaudePlanUsageStore extends ProviderSpendUsageStore {
 
 export const claudePlanUsageStore = new ClaudePlanUsageStore();
 
-function parseClaudeRateLimitWindow(message: SDKMessage | Record<string, unknown>): ClaudeRateLimitWindowEntry | null {
+/**
+ * Every window one `rate_limit_event` reports: the per-window percentages in
+ * `unifiedWindows` first, then the event-level window for a key they did not
+ * report. The event-level record is frequently reset-only, so it must never
+ * replace a key already resolved from `unifiedWindows`.
+ */
+function parseClaudeRateLimitWindows(message: SDKMessage | Record<string, unknown>): ClaudeRateLimitWindowEntry[] {
   if (!isRecord(message) || message.type !== 'rate_limit_event' || !isRecord(message.rate_limit_info)) {
-    return null;
+    return [];
   }
 
   const info = message.rate_limit_info;
+  const entries = parseUnifiedRateLimitWindows(info);
+  const eventWindow = parseEventRateLimitWindow(info);
+  if (eventWindow && !entries.some(entry => entry.key === eventWindow.key)) {
+    entries.push(eventWindow);
+  }
+
+  return entries;
+}
+
+function parseEventRateLimitWindow(info: Record<string, unknown>): ClaudeRateLimitWindowEntry | null {
   const rateLimitType = readRateLimitType(info.rateLimitType);
   if (!rateLimitType) {
     return null;
@@ -148,16 +157,10 @@ function parseClaudeRateLimitWindow(message: SDKMessage | Record<string, unknown
  * known window, suppresses the quota readout entirely.
  *
  * The field is absent from the published SDK types, so it is read defensively:
- * anything unexpected falls back to the event-level window parsed above.
+ * anything unexpected falls back to the event-level window.
  */
-function parseUnifiedRateLimitWindows(
-  message: SDKMessage | Record<string, unknown>,
-): ClaudeRateLimitWindowEntry[] {
-  if (!isRecord(message) || message.type !== 'rate_limit_event' || !isRecord(message.rate_limit_info)) {
-    return [];
-  }
-
-  const unifiedWindows = message.rate_limit_info.unifiedWindows;
+function parseUnifiedRateLimitWindows(info: Record<string, unknown>): ClaudeRateLimitWindowEntry[] {
+  const unifiedWindows = info.unifiedWindows;
   if (!isRecord(unifiedWindows)) {
     return [];
   }

--- a/tests/unit/providers/claude/app/ClaudePlanUsageStore.test.ts
+++ b/tests/unit/providers/claude/app/ClaudePlanUsageStore.test.ts
@@ -318,6 +318,32 @@ describe('ClaudePlanUsageStore', () => {
     });
   });
 
+  it('prefers the unifiedWindows percentage over the event-level one for the same key', () => {
+    const store = new ClaudePlanUsageStore();
+
+    store.recordSdkMessage({
+      type: 'rate_limit_event',
+      rate_limit_info: {
+        status: 'allowed',
+        rateLimitType: 'five_hour',
+        resetsAt: '5:00 PM',
+        utilization: 0.12,
+        unifiedWindows: {
+          five_hour: { utilization: 0.63, resetsAt: '5:00 PM' },
+        },
+      },
+    });
+
+    expect(store.getCachedUsage({
+      plugin: {} as any,
+      providerId: 'claude',
+      settings: {},
+    })).toEqual({
+      plan: 'Claude Code',
+      windows: [{ label: '5-hr', pct: 63, reset: '5:00 PM' }],
+    });
+  });
+
   it('falls back to the event window when unifiedWindows is unusable', () => {
     const store = new ClaudePlanUsageStore();
 

--- a/tests/unit/providers/claude/app/ClaudePlanUsageStore.test.ts
+++ b/tests/unit/providers/claude/app/ClaudePlanUsageStore.test.ts
@@ -223,4 +223,127 @@ describe('ClaudePlanUsageStore', () => {
       note: 'SDK token cost reported for completed turns.',
     });
   });
+
+  it('reads Claude quota percentages from unifiedWindows when the event omits utilization', () => {
+    jest.useFakeTimers().setSystemTime(new Date(2026, 5, 7, 13, 9).getTime());
+    try {
+      const store = new ClaudePlanUsageStore();
+      const fiveHourReset = new Date(2026, 5, 7, 17, 0);
+      const weeklyReset = new Date(2026, 5, 11, 3, 0);
+
+      const changed = store.recordSdkMessage({
+        type: 'rate_limit_event',
+        rate_limit_info: {
+          status: 'allowed',
+          rateLimitType: 'five_hour',
+          resetsAt: Math.floor(fiveHourReset.getTime() / 1000),
+          overageStatus: 'rejected',
+          overageDisabledReason: 'org_level_disabled',
+          isUsingOverage: false,
+          unifiedWindows: {
+            five_hour: {
+              utilization: 0.47,
+              resetsAt: Math.floor(fiveHourReset.getTime() / 1000),
+            },
+            seven_day: {
+              utilization: 0.31,
+              resetsAt: Math.floor(weeklyReset.getTime() / 1000),
+            },
+          },
+        },
+      });
+
+      expect(changed).toBe(true);
+      expect(store.getCachedUsage({
+        plugin: {} as any,
+        providerId: 'claude',
+        settings: {},
+      })).toEqual({
+        plan: 'Claude Code',
+        windows: [
+          {
+            label: '5-hr',
+            pct: 47,
+            reset: new Intl.DateTimeFormat(undefined, {
+              hour: 'numeric',
+              minute: '2-digit',
+            }).format(fiveHourReset),
+          },
+          {
+            label: 'Weekly',
+            pct: 31,
+            reset: new Intl.DateTimeFormat(undefined, { weekday: 'short' }).format(weeklyReset),
+          },
+        ],
+      });
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('keeps event-level Claude windows that unifiedWindows does not report', () => {
+    const store = new ClaudePlanUsageStore();
+
+    store.recordSdkMessage({
+      type: 'rate_limit_event',
+      rate_limit_info: {
+        status: 'allowed',
+        rateLimitType: 'five_hour',
+        resetsAt: '5:00 PM',
+        unifiedWindows: {
+          five_hour: { utilization: 0.09, resetsAt: '5:00 PM' },
+        },
+      },
+    });
+    store.recordSdkMessage({
+      type: 'rate_limit_event',
+      rate_limit_info: {
+        status: 'allowed',
+        rateLimitType: 'seven_day_opus',
+        resetsAt: 'Mon',
+        utilization: 71,
+      },
+    });
+
+    expect(store.getCachedUsage({
+      plugin: {} as any,
+      providerId: 'claude',
+      settings: {},
+    })).toEqual({
+      plan: 'Claude Code',
+      windows: [
+        { label: '5-hr', pct: 9, reset: '5:00 PM' },
+        { label: 'Weekly Opus', pct: 71, reset: 'Mon' },
+      ],
+    });
+  });
+
+  it('falls back to the event window when unifiedWindows is unusable', () => {
+    const store = new ClaudePlanUsageStore();
+
+    const changed = store.recordSdkMessage({
+      type: 'rate_limit_event',
+      rate_limit_info: {
+        status: 'allowed',
+        rateLimitType: 'five_hour',
+        resetsAt: '5:50 PM',
+        unifiedWindows: {
+          five_hour: 'not-a-window',
+          seven_day: { utilization: 0.5 },
+        },
+      },
+    });
+
+    expect(changed).toBe(true);
+    expect(store.getCachedUsage({
+      plugin: {} as any,
+      providerId: 'claude',
+      settings: {},
+    })).toEqual({
+      plan: 'Claude Code',
+      windows: [
+        { label: '5-hr', pct: 0, pctKnown: false, reset: '5:50 PM' },
+      ],
+    });
+  });
 });


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><!-- obsidian --><h2 data-heading="Problem">Problem</h2>
<p>Claude subscribers see only the monthly spend line in the model selector plan<br>
readout. The 5-hour window renders its percentage as an em dash, and while no<br>
window with a known percentage has arrived, the quota block is not rendered at<br>
all — so the readout offers a dollar estimate that a subscription is never<br>
billed for, instead of the plan limits the user actually spends.</p>
<p>Fixes #173</p>
<h2 data-heading="Root Cause">Root Cause</h2>
<p><code>ClaudePlanUsageStore.parseClaudeRateLimitWindow</code> reads the consumed percentage<br>
only from the top-level <code>rate_limit_info.utilization</code>. Current Claude CLI builds<br>
leave that field undefined on most <code>rate_limit_event</code> messages and report the<br>
percentage per window in <code>rate_limit_info.unifiedWindows</code> instead.</p>
<p>When <code>utilization</code> is absent, <code>readUtilizationPct</code> returns <code>null</code> and the window<br>
is stored as <code>pct: 0, pctKnown: false</code>. <code>InputToolbar.renderPlanUsageReadout</code><br>
then requires at least one window with a known percentage before it renders the<br>
quota block. <code>five_hour</code> is the most frequent event type, so its reset-only<br>
record repeatedly overwrites any window that did carry a percentage, and early in<br>
a session no known-percentage window exists at all. The condition is false and<br>
only the spend readout survives.</p>
<h3 data-heading="Protocol evidence">Protocol evidence</h3>
<p>Field shapes observed in a local Grimoire debug log (<code>usage</code> scope), 1,264<br>
<code>rate_limit_event</code> records between 2026-08-24 and 2026-09-06:</p>

rateLimitType | top-level utilization | unifiedWindows | events
-- | -- | -- | --
five_hour | absent | present | 853
seven_day | present | present | 233
five_hour | present | present | 117
five_hour | present | absent | 33
other combinations | — | — | 28


<p>67% of events carry the percentage only in <code>unifiedWindows</code>.</p>
<p>Per-window shape, from the CLI payload schema:</p>
<pre><code>unifiedWindows: {
  five_hour:                  { utilization, resetsAt },
  seven_day:                  { utilization, resetsAt },
  seven_day_overage_included: { utilization, resetsAt },
}
</code></pre>
<p><code>utilization</code> is a 0–1 fraction and <code>resetsAt</code> is unix seconds, both already<br>
handled by the existing <code>readUtilizationPct</code> and <code>formatResetValue</code> helpers.</p>
<p>Why this was not caught earlier: the recorded wire fixture<br>
<code>tests/fixtures/provider-traces/wire/claude-wire.json</code> was captured 2026-08-16,<br>
before the field existed. Its <code>rate_limit_info</code> genuinely carries no percentage,<br>
so the reset-only path was correct when it was written. The wire format moved and<br>
the parser did not.</p>
<h2 data-heading="Approach">Approach</h2>
<p>Parse <code>unifiedWindows</code> into <code>five_hour</code> and <code>seven_day</code> windows, reusing the<br>
existing percentage, reset and label helpers rather than adding parallel<br>
formatting. Merge the resulting windows ahead of the event-level window and skip<br>
the event-level entry when it repeats a key already resolved from<br>
<code>unifiedWindows</code>; otherwise a reset-only record would overwrite a resolved<br>
percentage within the same message.</p>
<p><code>unifiedWindows</code> is absent from the published <code>SDKRateLimitInfo</code> type in<br>
<code>@anthropic-ai/claude-agent-sdk</code> 0.3.251, so it is read defensively through<br>
<code>isRecord</code> — the same style the surrounding code already applies to<br>
<code>rate_limit_info</code>. Any missing, malformed or unusable entry falls through to the<br>
previous behaviour, which makes the worst case equal to today's output.</p>
<p><code>seven_day_overage_included</code> is reported in the same object but carries separate<br>
product meaning, so it stays out of the readout until the readout defines how to<br>
present it.</p>
<p>Alternatives considered:</p>
<ul>
<li><strong>Rely on <code>.grimoire/claude/statusline-usage.json</code>.</strong> That snapshot is written<br>
by a Claude Code status line command, which is rendered by the CLI TUI. The<br>
queries Grimoire spawns are headless, so the file never refreshes for plugin<br>
sessions and the readout would show stale or absent windows.</li>
<li><strong>Hide the spend readout when quota windows exist.</strong> Rejected:<br>
<code>src/providers/claude/AGENTS.md</code> requires quota windows and spend to remain<br>
separate readouts when both exist.</li>
<li><strong>Wait for the field to be published in the SDK types.</strong> Rejected: subscribers<br>
lose percentages for as long as that takes, and the defensive read already<br>
degrades to current behaviour if the field disappears.</li>
</ul>
<h2 data-heading="Architecture">Architecture</h2>
<ul class="contains-task-list">
<li class="task-list-item is-checked" data-task="x"><input class="task-list-item-checkbox" type="checkbox" checked>Provider-native behavior remains inside <code>src/providers/&#x3C;provider>/</code>.</li>
<li class="task-list-item is-checked" data-task="x"><input class="task-list-item-checkbox" type="checkbox" checked>Shared code is provider-neutral and used by at least two providers, or the PR explains why it belongs there.</li>
<li class="task-list-item is-checked" data-task="x"><input class="task-list-item-checkbox" type="checkbox" checked>I checked sibling providers when changing a shared ACP or provider contract.</li>
</ul>
<p>Architecture notes:</p>
<p>The change is confined to <code>src/providers/claude/app/ClaudePlanUsageStore.ts</code>.<br>
<code>unifiedWindows</code> is Claude-specific wire vocabulary and is normalized into the<br>
existing provider-neutral <code>ProviderPlanUsageWindow</code> before it leaves the provider<br>
layer. No shared contract, no renderer and no sibling provider store is touched;<br>
<code>ProviderPlanUsageWindow</code> is unchanged.</p>
<h2 data-heading="Security And Privacy">Security And Privacy</h2>
<ul class="contains-task-list">
<li class="task-list-item is-checked" data-task="x"><input class="task-list-item-checkbox" type="checkbox" checked>Provider/session/model data is treated as untrusted input.</li>
<li class="task-list-item is-checked" data-task="x"><input class="task-list-item-checkbox" type="checkbox" checked>Permission changes cannot silently widen persistent authorization.</li>
<li class="task-list-item is-checked" data-task="x"><input class="task-list-item-checkbox" type="checkbox" checked>Filesystem, process, credential, MCP, and external-path boundaries are unchanged or explained below.</li>
<li class="task-list-item is-checked" data-task="x"><input class="task-list-item-checkbox" type="checkbox" checked>Logs and fixtures contain no secrets, prompts, note contents, local paths, or unsanitized provider payloads.</li>
</ul>
<p>Security notes:</p>
<p>No security boundary change. The new parser treats <code>rate_limit_info</code> and<br>
<code>unifiedWindows</code> as untrusted: container and per-window records are validated<br>
with <code>isRecord</code>, the percentage is clamped to 0–100 by the existing <code>clampPct</code>,<br>
and the reset value is accepted only as a non-empty string or a positive finite<br>
number. An unexpected shape yields no window rather than a partial or coerced<br>
one. No new logging, filesystem, process, credential or network path.</p>
<h2 data-heading="Verification">Verification</h2>
<p>Automated commands run:</p>
<pre><code class="language-text">npx npm@12.0.2 ci
npx npm@12.0.2 run test -- --selectProjects unit -t "ClaudePlanUsageStore"
npx npm@12.0.2 run test -- --selectProjects unit
npx npm@12.0.2 run typecheck
npx npm@12.0.2 run lint
npx npm@12.0.2 run build:release
</code></pre>
<p>Results:</p>
<ul>
<li>Targeted suite: 9/9 pass (6 existing, 3 added).</li>
<li><code>typecheck</code>, <code>lint</code>, <code>build:release</code>: pass, including <code>review:source</code>,<br>
<code>review:css</code>, <code>review:deps</code> and the release bundle load check.</li>
<li>Full unit run: 22 failures across 16 suites. These are pre-existing and<br>
unrelated. Verified by stashing this change and re-running on the clean<br>
branch: the same 16 suites and the same 22 failures appear, with 9,141<br>
passing before and 9,144 passing after — the difference is exactly the 3<br>
added tests, and no new failure is introduced. The failures are environment<br>
assumptions rather than product defects: POSIX path separators<br>
(<code>/home/tester/.grok</code> vs a Windows-separator result) and en-US digit grouping<br>
(<code>"256,500"</code> vs <code>"256 500"</code>) on a Windows checkout with a non-en-US locale.</li>
<li>Regression value confirmed: reverting only<br>
<code>src/providers/claude/app/ClaudePlanUsageStore.ts</code> and re-running the targeted<br>
suite fails 2 of the 3 added tests. The third asserts the unchanged fallback<br>
path and passes either way by design.</li>
</ul>
<p>Environment limitation: the machine's global npm is 11.17.0, below the<br>
<code>>=12.0.2 &#x3C;13</code> engine requirement, so every command above was run through<br>
<code>npx npm@12.0.2</code>. Node 24.19.0.</p>
<p>Manual verification: <strong>Not run.</strong> Verifying the readout requires an Obsidian<br>
session on a Claude subscription; screenshots of the quota rows are not included<br>
yet.</p>
<h2 data-heading="Generated Artifacts">Generated Artifacts</h2>
<ul class="contains-task-list">
<li class="task-list-item is-checked" data-task="x"><input class="task-list-item-checkbox" type="checkbox" checked><code>npm run build:release</code> recreates <code>dist/grimoire/main.js</code>, <code>manifest.json</code>, and <code>styles.css</code> from the submitted source.</li>
<li class="task-list-item is-checked" data-task="x"><input class="task-list-item-checkbox" type="checkbox" checked><code>package-lock.json</code> matches <code>package.json</code> when dependencies change.</li>
<li class="task-list-item is-checked" data-task="x"><input class="task-list-item-checkbox" type="checkbox" checked>Generated root bundles, <code>dist/grimoire</code>, and local-only artifacts are not included.</li>
</ul>
<p>No dependency change; <code>package-lock.json</code> is untouched. After <code>build:release</code>,<br>
<code>git status</code> lists only the two source files in this PR.</p>
<h2 data-heading="Review Checklist">Review Checklist</h2>
<ul class="contains-task-list">
<li class="task-list-item is-checked" data-task="x"><input class="task-list-item-checkbox" type="checkbox" checked>The PR is focused on one coherent problem.</li>
<li class="task-list-item is-checked" data-task="x"><input class="task-list-item-checkbox" type="checkbox" checked>Behavior changes have focused regression tests.</li>
<li class="task-list-item is-checked" data-task="x"><input class="task-list-item-checkbox" type="checkbox" checked>Protocol tests use real structured payloads and error codes.</li>
<li class="task-list-item is-checked" data-task="x"><input class="task-list-item-checkbox" type="checkbox" checked>Documentation and user-facing copy are in English.</li>
<li class="task-list-item is-checked" data-task="x"><input class="task-list-item-checkbox" type="checkbox" checked>The PR description accurately distinguishes automated tests from manual verification.</li>
</ul>
<h2 data-heading="Related observation, not addressed here">Related observation, not addressed here</h2>
<p><code>SDKRateLimitInfo</code> in SDK 0.3.251 also allows<br>
<code>rateLimitType: 'seven_day_overage_included'</code>, which <code>readRateLimitType</code> does not<br>
accept, so such an event is dropped entirely. Presenting it is a product decision<br>
about labels and overage semantics, so it is left out of this PR rather than<br>
guessed at.</p><!--EndFragment-->
</body>
</html>