### PR TITLE
fix(chat): preserve drafts, attachments, and native checkpoints

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1808,9 +1808,9 @@
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "3.15.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
-      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
+      "version": "3.15.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.2.tgz",
+      "integrity": "sha512-6EuL879VkRA+1Cz578mKMiKvjPNEuk6+r1JaFzoSWejZmtf7xWbIyw1e3KkxlkzTIt9Taw6JBhEppG7utc1P+w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7545,9 +7545,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.13.0",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.0.tgz",
-      "integrity": "sha512-jhunvfHWxd7J5EFfSgH4xsYJzSe/lfqbUCxiyyeaQasUsXeEHXtzVid+7EOGByc5JnFa23SSFL3Y2RV/z1T+eQ==",
+      "version": "4.13.5",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.5.tgz",
+      "integrity": "sha512-O6+/eCYRkzzzy0rPWwKLiGBR1nFuUPZynnwjxN1MBA62NNqbT0wQEzQyK2gSO5yDIDB336sXQleAhOHrzlYyKw==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -9182,9 +9182,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
-      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
       "dev": true,
       "funding": [
         {

--- a/src/app/chat/ChatExecutionComposition.ts
+++ b/src/app/chat/ChatExecutionComposition.ts
@@ -8,13 +8,14 @@ import {
   runId,
 } from '@/core/execution/ExecutionIds';
 import type { ChatTurnEncoder } from '@/core/runtime/execution/ExecutionChatRuntimeAdapter';
-import type { ChatRuntimeQueryOptions, ChatTurnRequest } from '@/core/runtime/types';
+import type { ChatRuntimeQueryOptions, ChatTurnMetadata, ChatTurnRequest } from '@/core/runtime/types';
 import type { ChatMessage } from '@/core/types';
 import {
   type ChatConversationPort,
   ChatExecutionCoordinator,
   type ChatExecutionLifecyclePort,
   type ChatSessionBinding,
+  ChatTurnCancelledError,
   type ChatTurnTicket,
 } from '@/features/chat/application/ChatExecutionCoordinator';
 import {
@@ -119,6 +120,7 @@ export class ChatExecutionComposition {
     // built from an earlier read has none of it. Encoding the history from the
     // stale one sends the provider a poorer transcript than the one on screen.
     const conversation = await this.coordinator.reloadConversation(command.conversationId);
+    if (command.isCancelled?.()) throw new ChatTurnCancelledError();
     const prepared = command.encoder.prepareTurn(command.request);
     const requestRef = command.encoder.encodeRequestRef(
       prepared,
@@ -144,6 +146,8 @@ export class ChatExecutionComposition {
       ...(command.nativeSessionRef ? { nativeSessionRef: command.nativeSessionRef } : {}),
       ...(command.resumeCheckpoint ? { resumeCheckpoint: command.resumeCheckpoint } : {}),
       ...(command.sessionBinding ? { sessionBinding: command.sessionBinding } : {}),
+      ...(command.turnMetadata ? { turnMetadata: command.turnMetadata } : {}),
+      ...(command.isCancelled ? { isCancelled: command.isCancelled } : {}),
     });
     // Handed back because the surface has already drawn its own copy: the
     // legacy path overwrites the message it rendered with what the provider
@@ -182,6 +186,8 @@ export interface SubmitChatMessageCommand {
   readonly resumeCheckpoint?: string;
   /** What the conversation's provider binding is once the turn has ended. */
   readonly sessionBinding?: () => ChatSessionBinding | null;
+  readonly turnMetadata?: () => Promise<ChatTurnMetadata | null> | ChatTurnMetadata | null;
+  readonly isCancelled?: () => boolean;
 }
 
 function opaqueId(prefix: string): string {

--- a/src/app/chat/ChatTabExecution.ts
+++ b/src/app/chat/ChatTabExecution.ts
@@ -12,9 +12,9 @@ import type {
 } from '@/core/runtime/types';
 import type { ChatMessage } from '@/core/types';
 import type { ProviderId } from '@/core/types/provider';
-import type {
-  ChatSessionBinding,
-  CompletedChatTurn,
+import {
+  type ChatSessionBinding,
+  ChatTurnCancelledError,
 } from '@/features/chat/application/ChatExecutionCoordinator';
 import type { ChatProjectionAttachment } from '@/features/chat/application/ChatProjectionAttachment';
 
@@ -68,17 +68,10 @@ export interface ChatTabExecutionOptions {
   /**
    * What the provider itself made of the turn that just ended.
    *
-   * Read once, after the turn, and merged into the completion — because one
-   * fact on it is the provider's alone. **A plan is the case**: Grimoire's own
-   * plan approval appears when a turn reports one, the coordinator derives that
-   * from a resolved interaction whose response id names a plan, and no provider
-   * produces such an id. Codex reads its own plan mode and its own plan deltas
-   * instead, and said so to nobody: a live plan turn ended with the provider
-   * holding `planCompleted: true` and the completion holding `undefined`, so the
-   * approval never appeared. The provider's own per-turn reading also carries
-   * side effects the legacy path performed once a turn — OpenCode backfills the
-   * session cost the vendor did not report on the wire — and with nothing
-   * reading it, those stopped happening too.
+   * Consumed once after received content has been presented, before the answer
+   * is persisted. Native message UUIDs and plan completion belong to the
+   * provider; neither can be inferred from Grimoire's display or result ids.
+   * The coordinator retains this reading across persistence retries.
    *
    * Absent for a surface with no runtime, like the encoder.
    */
@@ -91,6 +84,7 @@ export interface ChatTabExecutionOptions {
 export class ChatTabExecution {
   private readonly attachment: ChatProjectionAttachment;
   private bound: string | null = null;
+  private cancellationVersion = 0;
   private releasePresenter: (() => void) | null = null;
 
   constructor(private readonly options: ChatTabExecutionOptions) {
@@ -144,6 +138,8 @@ export class ChatTabExecution {
       readonly sessionBinding?: () => ChatSessionBinding | null;
     } = {},
   ): Promise<SubmittedChatTurn> {
+    const cancellationVersion = this.cancellationVersion;
+    const isCancelled = () => cancellationVersion !== this.cancellationVersion;
     const encoder = this.options.turnEncoder();
     if (!encoder) {
       // Refused rather than defaulted: without the provider's own encoding
@@ -153,7 +149,9 @@ export class ChatTabExecution {
       throw new Error('This tab has no provider runtime to encode a turn with.');
     }
     const conversationId = this.bound ?? await this.openCreated();
-    const submitted = await this.options.composition.submitTurn({
+    if (isCancelled()) throw new ChatTurnCancelledError();
+    return this.options.composition.submitTurn({
+      isCancelled,
       commandId: this.options.nextCommandId(),
       conversationId,
       backendId: this.options.backendId,
@@ -164,42 +162,13 @@ export class ChatTabExecution {
       ...(options.nativeSessionRef ? { nativeSessionRef: options.nativeSessionRef } : {}),
       ...(options.resumeCheckpoint ? { resumeCheckpoint: options.resumeCheckpoint } : {}),
       ...(options.sessionBinding ? { sessionBinding: options.sessionBinding } : {}),
+      turnMetadata: async () => {
+        // Provider content carries native message UUIDs. Finish presenting the
+        // received events before consuming those identities for persistence.
+        await this.attachment.settled();
+        return this.options.turnMetadata?.() ?? null;
+      },
     });
-    const completion = submitted.ticket.completion.then(completed => ({
-      ...completed,
-      ...this.providerReading(completed),
-    }));
-    // **Marked handled, because a caller may ignore it.** A turn whose
-    // coordinator is detached mid-flight rejects its completion, and deriving a
-    // second promise from it means a second rejection nobody is waiting on —
-    // which node reports as an unhandled rejection and, in a test process, ends
-    // the run. Awaiting this still throws; only the copy nobody took is quiet.
-    completion.catch(() => undefined);
-    return { ...submitted, ticket: { ...submitted.ticket, completion } };
-  }
-
-  /**
-   * The half of a finished turn only the provider knows.
-   *
-   * **Only the plan**, deliberately. The native identities are on the completion
-   * already, taken from what the kernel recorded, and letting a provider's
-   * copy overwrite them would put two answers to the same question back into
-   * the path the migration removed one from. Read here rather than by the
-   * surface because it is destructive — once per turn, at the moment the turn
-   * ends, which is the moment the legacy path read it too.
-   */
-  private providerReading(completed: CompletedChatTurn): { planCompleted?: true } {
-    if (completed.planCompleted === true) {
-      return {};
-    }
-    try {
-      return this.options.turnMetadata?.()?.planCompleted === true
-        ? { planCompleted: true }
-        : {};
-    } catch {
-      // A provider that cannot say is a turn with no plan, not a failed turn.
-      return {};
-    }
   }
 
   /**
@@ -266,6 +235,7 @@ export class ChatTabExecution {
   }
 
   async cancel(reason?: CancellationReason): Promise<void> {
+    this.cancellationVersion++;
     if (!this.bound) {
       return;
     }

--- a/src/core/attachments/hydrateImages.ts
+++ b/src/core/attachments/hydrateImages.ts
@@ -37,22 +37,3 @@ export async function hydrateImages(
     }
   }
 }
-
-/** Every attachment hash the given conversations still reference. */
-export function collectReferencedHashes(
-  conversations: readonly { messages?: ChatMessage[] }[],
-): Set<string> {
-  const hashes = new Set<string>();
-
-  for (const conversation of conversations) {
-    for (const message of conversation.messages ?? []) {
-      for (const image of message.images ?? []) {
-        if (image.hash) {
-          hashes.add(image.hash);
-        }
-      }
-    }
-  }
-
-  return hashes;
-}

--- a/src/core/runtime/execution/ExecutionChatRuntimeAdapter.ts
+++ b/src/core/runtime/execution/ExecutionChatRuntimeAdapter.ts
@@ -152,7 +152,6 @@ export class ExecutionRunStream {
   private cancelRequested = false;
   private metadataConsumed = false;
   private nativeRunRef: string | undefined;
-  private assistantMessageId: string | undefined;
   private planCompleted = false;
   private wake: (() => void) | null = null;
 
@@ -179,9 +178,6 @@ export class ExecutionRunStream {
       // Carried on every run-scoped envelope, so the identity survives even if
       // the turn ends on a path that emits nothing else.
       this.nativeRunRef = envelope.scope.nativeRunRef;
-    }
-    if (event.kind === 'result') {
-      this.assistantMessageId = event.result.resultId;
     }
     if (event.kind === 'interaction-resolved') {
       this.planCompleted = this.planCompleted || event.responseId.includes('plan');
@@ -294,7 +290,6 @@ export class ExecutionRunStream {
       // user one — so omitting them degrades rewind and resume silently, which
       // is worse than failing, because the turn still looks complete.
       ...(this.nativeRunRef ? { userMessageId: this.nativeRunRef } : {}),
-      ...(this.assistantMessageId ? { assistantMessageId: this.assistantMessageId } : {}),
       ...(this.planCompleted ? { planCompleted: true } : {}),
     };
   }

--- a/src/features/chat/application/ChatExecutionCoordinator.ts
+++ b/src/features/chat/application/ChatExecutionCoordinator.ts
@@ -40,7 +40,7 @@ import {
   ExecutionInteractionBridge,
   type ExecutionInteractionPresenter,
 } from '../../../core/runtime/execution/ExecutionChatRuntimeAdapter';
-import type { ChatRuntimeConversationState } from '../../../core/runtime/types';
+import type { ChatRuntimeConversationState, ChatTurnMetadata } from '../../../core/runtime/types';
 import type { ChatMessage, Conversation, UsageInfo } from '../../../core/types';
 import {
   type ChatProjection,
@@ -168,6 +168,16 @@ export interface SubmitChatTurnCommand {
    * no provider adapter here to ask.
    */
   readonly sessionBinding?: () => ChatSessionBinding | null;
+  /** Native message identities, consumed once before the persistence barrier. */
+  readonly turnMetadata?: () => Promise<ChatTurnMetadata | null> | ChatTurnMetadata | null;
+  readonly isCancelled?: () => boolean;
+}
+
+export class ChatTurnCancelledError extends Error {
+  constructor() {
+    super('Chat turn was cancelled before dispatch.');
+    this.name = 'ChatTurnCancelledError';
+  }
 }
 
 /**
@@ -190,7 +200,10 @@ export interface StartedChatTurn {
 export interface CompletedChatTurn extends StartedChatTurn {
   readonly terminal: RunTerminal;
   readonly result?: MaterializedChatResult;
+  /** The message id in Grimoire's projection. */
   readonly assistantMessageId?: string;
+  /** The provider's checkpoint, independent of display and result ids. */
+  readonly nativeAssistantMessageId?: string;
   /**
    * Whether a plan decision was answered during this turn.
    *
@@ -227,14 +240,7 @@ export interface ChatExecutionCoordinatorOptions {
   readonly nextExecutionSessionId: () => ExecutionSessionId;
   readonly nextRunId: () => RunId;
   readonly nextLeaseId: () => LifecycleLeaseId;
-  /**
-   * The message id for a run that committed no result of its own.
-   *
-   * A run that did commit one is identified by the provider's own result id,
-   * which is what the presentation adapter reports today and what rewind and
-   * fork address a checkpoint by. Preserving that is the point of the fallback
-   * being a fallback.
-   */
+  /** Stable display identity, including for runs adopted after a reload. */
   readonly assistantMessageIdForRun: (runId: RunId) => string;
   readonly now?: () => number;
 }
@@ -276,6 +282,8 @@ interface ActiveTurn {
    * turns on.
    */
   binding?: { readonly value: ChatSessionBinding | null };
+  metadata?: ChatTurnMetadata;
+  cancellationReason?: CancellationReason;
   executionSessionId?: ExecutionSessionId;
   runId?: RunId;
   dispatched: boolean;
@@ -421,6 +429,7 @@ export class ChatExecutionCoordinator {
     validateTurnCommand(command);
     const entry = await this.requireEntry(command.conversationId);
     this.requireOpen();
+    if (command.isCancelled?.()) throw new ChatTurnCancelledError();
     const admission = entry.active || entry.queue.length > 0 ? 'queued' : 'started';
     const pending: PendingTurn = {
       command,
@@ -443,11 +452,16 @@ export class ChatExecutionCoordinator {
     conversationId: string,
     reason: CancellationReason = { code: 'user' },
   ): Promise<void> {
-    const activeRunId = this.entries.get(conversationId)?.active?.runId;
-    if (!activeRunId) {
+    const active = this.entries.get(conversationId)?.active;
+    if (!active) {
       return;
     }
-    await this.lifecycle.cancelRun(activeRunId, reason);
+    active.cancellationReason = reason;
+    // Before admission returns, the kernel may not have registered the id yet.
+    // startActive checks the intent at each boundary and forwards it afterwards.
+    if (active.dispatched && active.runId) {
+      await this.lifecycle.cancelRun(active.runId, reason);
+    }
   }
 
   /**
@@ -844,6 +858,10 @@ export class ChatExecutionCoordinator {
     command: SubmitChatTurnCommand,
   ): Promise<void> {
     try {
+      const requireNotCancelled = () => {
+        if (active.cancellationReason || command.isCancelled?.()) throw new ChatTurnCancelledError();
+      };
+      requireNotCancelled();
       if (entry.backendId && entry.backendId !== command.backendId) {
         // One conversation, one backend. A second backend over the same
         // conversation would own runs the first one's session does not know
@@ -861,10 +879,12 @@ export class ChatExecutionCoordinator {
         conversation: withUser.conversation,
         revision: withUser.revision,
       });
+      requireNotCancelled();
 
       const owner: ExecutionOwner = { kind: 'conversation', ownerId: command.conversationId };
       const sessionId = entry.sessionId ?? await this.openSession(entry, command, owner);
       this.requireOpen();
+      requireNotCancelled();
       const nextRunId = this.nextRunId();
       active.executionSessionId = sessionId;
       active.runId = nextRunId;
@@ -876,6 +896,9 @@ export class ChatExecutionCoordinator {
         ...(command.resumeCheckpoint ? { resumeCheckpoint: command.resumeCheckpoint } : {}),
       });
       this.establishStartedTurn(entry, active, sessionId, nextRunId);
+      if (active.cancellationReason || command.isCancelled?.()) {
+        await this.lifecycle.cancelRun(nextRunId, active.cancellationReason ?? { code: 'user' });
+      }
     } catch (error) {
       this.abandonTurn(entry, active, error);
     }
@@ -1098,13 +1121,22 @@ export class ChatExecutionCoordinator {
         });
       }
       const completedAt = this.now();
+      if (!active.metadata) {
+        try {
+          active.metadata = await active.submitted?.turnMetadata?.() ?? {};
+        } catch {
+          // A missing native identity must not turn into a fabricated checkpoint.
+          active.metadata = {};
+        }
+      }
+      const metadata = active.metadata;
       const assistantMessage = createAssistantMessage(
         // The identity the turn was given when it started, not one minted here:
         // a surface has been drawing this answer under that id since the first
         // token, and a second identity at the barrier makes the drawn answer
         // and the stored answer two different messages.
         turn?.assistantMessageId ?? this.assistantMessageIdForRun(activeRunId),
-        resultRef,
+        metadata.assistantMessageId,
         streamed,
         completedAt,
       );
@@ -1128,6 +1160,12 @@ export class ChatExecutionCoordinator {
           const completed = completeConversation(
             current, assistantMessage, active.usage, completedAt,
           );
+          const nativeUserId = metadata.userMessageId ?? active.nativeRunRef;
+          if (nativeUserId && active.submitted) {
+            completed.messages = completed.messages.map(message => message.id === active.submitted?.userMessage.id
+              ? { ...message, userMessageId: nativeUserId }
+              : message);
+          }
           // Spread whole rather than field by field: `sessionId: undefined` is
           // how an invalidated binding is cleared, and skipping undefined keys
           // would leave the dead session id behind.
@@ -1152,8 +1190,10 @@ export class ChatExecutionCoordinator {
         terminal,
         ...(materialized ? { result: materialized } : {}),
         ...(assistantMessage ? { assistantMessageId: assistantMessage.id } : {}),
-        ...(answeredAPlan(entry.projection, activeRunId) ? { planCompleted: true } : {}),
-        ...(active.nativeRunRef ? { userMessageId: active.nativeRunRef } : {}),
+        ...(metadata.assistantMessageId ? { nativeAssistantMessageId: metadata.assistantMessageId } : {}),
+        ...(metadata.planCompleted || answeredAPlan(entry.projection, activeRunId) ? { planCompleted: true } : {}),
+        ...(metadata.userMessageId ?? active.nativeRunRef
+          ? { userMessageId: metadata.userMessageId ?? active.nativeRunRef } : {}),
       });
       this.startNext(entry);
     } catch (error) {
@@ -1279,7 +1319,7 @@ function materializeResult(
 
 function createAssistantMessage(
   messageId: string,
-  resultRef: ResultRef | undefined,
+  nativeAssistantMessageId: string | undefined,
   streamed: string | undefined,
   completedAt: number,
 ): ChatMessage | undefined {
@@ -1299,7 +1339,7 @@ function createAssistantMessage(
     // this conversation, and this names the answer in the provider's own terms
     // — which is what a rewind or a fork asks it to resume at. Conflating them
     // was what made the drawn message and the stored one differ.
-    ...(resultRef ? { assistantMessageId: resultRef.resultId } : {}),
+    ...(nativeAssistantMessageId ? { assistantMessageId: nativeAssistantMessageId } : {}),
   };
 }
 

--- a/src/features/chat/controllers/InputController.ts
+++ b/src/features/chat/controllers/InputController.ts
@@ -47,6 +47,7 @@ import type { CanvasSelectionContext } from '../../../utils/canvas';
 import type { EditorSelectionContext } from '../../../utils/editor';
 import { splitContextPaths } from '../../../utils/externalContext';
 import { appendMarkdownSnippet } from '../../../utils/markdown';
+import { ChatTurnCancelledError } from '../application/ChatExecutionCoordinator';
 import { buildImageGenerationPrompt } from '../imageGeneration';
 import type { QueuePauseReason } from '../queue/MessageQueue';
 import { InlineAskUserQuestion } from '../rendering/InlineAskUserQuestion';
@@ -309,7 +310,8 @@ export class InputController {
 
     const contentOverride = options?.content;
     const shouldUseInput = contentOverride === undefined;
-    const content = (contentOverride ?? inputEl.value).trim();
+    const originalInput = inputEl.value;
+    const content = (contentOverride ?? originalInput).trim();
     const displayContentOverride = options?.displayContentOverride?.trim();
     const imageOverride = options?.images;
     const hasImages = imageOverride !== undefined
@@ -424,12 +426,6 @@ export class InputController {
     // SDK handles expansion, $ARGUMENTS, @file references, and frontmatter options
     const images = imageOverride ?? imageContextManager?.getAttachedImages() ?? [];
     const imagesForMessage = images.length > 0 ? [...images] : undefined;
-    // A resend or a queued turn carries attachments straight off an existing
-    // message, whose bytes are left out of session metadata. The provider is
-    // about to write them to a file for the CLI, so refill them first.
-    if (plugin.storage?.attachments) {
-      await hydrateImages(imagesForMessage, plugin.storage.attachments);
-    }
     const isCompact = /^\/compact(\s|$)/i.test(content);
     plugin.recordDebugLog?.({
       data: {
@@ -447,9 +443,40 @@ export class InputController {
       imageContextManager?.clearImages();
     }
 
-    let turnSubmission: TurnSubmission;
+    let turnSubmission: TurnSubmission | undefined;
+    const restoreUnsent = () => {
+      if (state.streamGeneration !== streamGeneration) return;
+      const cancelled = state.cancelRequested;
+      state.isStreaming = false;
+      state.cancelRequested = false;
+      streamController.hideThinkingIndicator();
+      streamController.stopTurnSilenceIndicator();
+      this.activeStreamingAssistantMessage = null;
+      if (shouldUseInput && !inputEl.value && !imageContextManager?.hasImages()) {
+        inputEl.value = originalInput;
+        this.deps.resetInputHeight();
+        imageContextManager?.setImages(imagesForMessage ?? []);
+      } else {
+        // Preserve a newer draft and return a drained message to its queue slot.
+        state.queue.insertAt(0, this.createQueuedMessage(
+          turnSubmission?.displayContent ?? displayContentOverride ?? content,
+          turnSubmission?.turnRequest ?? options?.turnRequestOverride ?? {
+            text: content, images: imagesForMessage,
+            editorSelection: options?.editorContextOverride,
+            browserSelection: options?.browserContextOverride,
+            canvasSelection: options?.canvasContextOverride,
+          },
+        ));
+      }
+      this.pauseQueue(cancelled ? 'cancelled' : 'failed');
+      this.updateQueueIndicator();
+    };
+    const preparationCancelled = () => state.cancelRequested || state.streamGeneration !== streamGeneration;
     let queryOptions: ChatRuntimeQueryOptions | undefined;
     try {
+      if (plugin.storage?.attachments) {
+        await hydrateImages(imagesForMessage, plugin.storage.attachments);
+      }
       const turnSubmissionResult = options?.turnRequestOverride
         ? {
           displayContent: content,
@@ -476,12 +503,7 @@ export class InputController {
         model: workspaceQueryOptions?.model ?? (typeof activeModel === 'string' ? activeModel : undefined),
       };
     } catch (error) {
-      state.isStreaming = false;
-      if (shouldUseInput) {
-        inputEl.value = content;
-        this.deps.resetInputHeight();
-        imageContextManager?.setImages(imagesForMessage ?? []);
-      }
+      restoreUnsent();
       if (error instanceof ProjectWorkspaceRoutingError) {
         new Notice(error.message);
         return;
@@ -489,8 +511,7 @@ export class InputController {
       throw error;
     }
     const { displayContent, turnRequest } = turnSubmission;
-
-    fileContextManager?.markCurrentNoteSent();
+    if (preparationCancelled()) { restoreUnsent(); return; }
 
     const userCompletedAt = Date.now();
     // Reassigned on the projection path once the turn is durable, so the block
@@ -506,37 +527,25 @@ export class InputController {
       images: imagesForMessage,
       vaultSearchContext: turnRequest.vaultSearchContext,
     };
-    // **Every provider is on this path**, so a tab without one cannot send. The
-    // only way to be here is a tab whose provider left the catalog or one built
-    // before the kernel did — and the second resolves on the next attempt,
-    // because the tab asks again every time.
-    //
-    // **So the message has to survive the refusal.** The composer was cleared
-    // and the images detached on the way here; a refusal that kept them cleared
-    // would destroy what the person typed at the one moment they are told to
-    // try again. Restored the way the `catch` below restores them, which is the
-    // shape this was missing.
     const projection = this.deps.getProjectionExecution?.() ?? null;
     if (!projection) {
       new Notice(t('chat.ui.errors.agentUnavailable'));
-      streamController.hideThinkingIndicator();
-      streamController.stopTurnSilenceIndicator();
-      state.isStreaming = false;
-      if (shouldUseInput) {
-        inputEl.value = content;
-        this.deps.resetInputHeight();
-        imageContextManager?.setImages(imagesForMessage ?? []);
-      }
+      restoreUnsent();
       return;
     }
-    state.hasPendingConversationSave = true;
 
     // Both messages arrive from the projection: the question when the
     // coordinator has made it durable, and the answer as a turn the target
     // opens. Adding either here would draw it twice — and the question would be
     // drawn before it was recorded, which is the one thing the barrier exists
     // to stop being possible.
-    await this.triggerTitleGeneration(userMsg);
+    try {
+      await this.triggerTitleGeneration(userMsg);
+    } catch (error) {
+      restoreUnsent();
+      new Notice(error instanceof Error ? error.message : t('chat.ui.errors.initializeAgentFailed'));
+      return;
+    }
 
     let assistantMsg = this.createAssistantMessage(queryOptions);
 
@@ -551,31 +560,30 @@ export class InputController {
     // read by the legacy generator branch, and the generation is the whole of
     // it now — see the comment further down that says so.
     let turnFailed = false;
+    let preparationAborted = false;
     let didEnqueueToSdk = false;
     let planCompleted = false;
     /** What the provider addressed this turn by, as the completion reports it. */
     let turnIdentities: { userMessageId?: string; assistantMessageId?: string } = {};
 
-    // Lazy initialization: ensure service is ready before first query
-    if (this.deps.ensureServiceInitialized) {
-      const ready = await this.deps.ensureServiceInitialized();
-      if (!ready) {
+    // Initialization can suspend while Stop is pressed or the tab changes.
+    if (preparationCancelled()) { restoreUnsent(); return; }
+    try {
+      if (this.deps.ensureServiceInitialized && !await this.deps.ensureServiceInitialized()) {
         new Notice(t('chat.ui.errors.initializeAgentFailed'));
-        streamController.hideThinkingIndicator();
-        streamController.stopTurnSilenceIndicator();
-        state.isStreaming = false;
-        this.activeStreamingAssistantMessage = null;
+        restoreUnsent();
         return;
       }
+    } catch (error) {
+      restoreUnsent();
+      new Notice(error instanceof Error ? error.message : t('chat.ui.errors.initializeAgentFailed'));
+      return;
     }
-
+    if (preparationCancelled()) { restoreUnsent(); return; }
     const agentService = this.getAgentService();
     if (!agentService) {
       new Notice(t('chat.ui.errors.agentUnavailable'));
-      streamController.hideThinkingIndicator();
-      streamController.stopTurnSilenceIndicator();
-      state.isStreaming = false;
-      this.activeStreamingAssistantMessage = null;
+      restoreUnsent();
       return;
     }
 
@@ -610,6 +618,7 @@ export class InputController {
       }
     }
 
+    if (preparationCancelled()) { restoreUnsent(); return; }
     streamController.startTurnSilenceIndicator(this.getActiveProviderId());
 
     try {
@@ -644,6 +653,9 @@ export class InputController {
           sessionInvalidated: agentService.consumeSessionInvalidation?.() ?? false,
         }),
       });
+      await submitted.ticket.started;
+      state.hasPendingConversationSave = true;
+      fileContextManager?.markCurrentNoteSent();
       userMsg.content = submitted.userMessage.content;
       userMsg.currentNote = submitted.userMessage.currentNote;
       const completed = await submitted.ticket.completion;
@@ -652,7 +664,8 @@ export class InputController {
       // interleaves.
       await projection.settled();
       didEnqueueToSdk = completed.terminal.kind !== 'invalidated';
-      wasInterrupted = completed.terminal.kind === 'cancelled';
+      wasInterrupted = completed.terminal.kind === 'cancelled' || completed.terminal.kind === 'interrupted';
+      turnFailed = completed.terminal.kind !== 'succeeded' && !wasInterrupted;
       planCompleted = completed.planCompleted === true;
       // The messages the projection drew and the barrier stored are the ones
       // everything after a turn writes to: the native identities a rewind
@@ -663,9 +676,19 @@ export class InputController {
       this.activeStreamingAssistantMessage = assistantMsg;
       turnIdentities = {
         ...(completed.userMessageId ? { userMessageId: completed.userMessageId } : {}),
-        ...(completed.assistantMessageId ? { assistantMessageId: completed.assistantMessageId } : {}),
+        ...(completed.nativeAssistantMessageId ? { assistantMessageId: completed.nativeAssistantMessageId } : {}),
       };
     } catch (error) {
+      if (error instanceof ChatTurnCancelledError) {
+        await projection.settled();
+        if (!findMessage(state.messages, userMsg.id)) {
+          restoreUnsent();
+          preparationAborted = true;
+        } else {
+          wasInterrupted = true;
+        }
+        return;
+      }
       plugin.recordDebugLog?.({
         data: {
           providerId: this.getActiveProviderId(),
@@ -704,7 +727,7 @@ export class InputController {
       // moved on mid-turn; with that loop gone it was never set, which left the
       // recovery at the end of this block unreachable and a steer that raced a
       // conversation switch stuck on "Steering…" for the life of the tab.
-      const invalidated = state.streamGeneration !== streamGeneration;
+      const invalidated = preparationAborted || state.streamGeneration !== streamGeneration;
       const finalAssistantMsg = this.activeStreamingAssistantMessage ?? assistantMsg;
       // **From the completion, not from the runtime.** The turn-metadata member
       // this replaces read the same three facts off the same envelopes, one
@@ -820,7 +843,7 @@ export class InputController {
         let planAutoSendContent: string | null = null;
         let planApprovalInvalidated = false;
         let shouldProcessQueuedMessage = true;
-        if (planCompleted && !didCancelThisTurn) {
+        if (planCompleted && !didCancelThisTurn && !turnFailed) {
           const { decision, invalidated } = await this.showPlanApproval();
 
           // Re-check invalidation after async approval prompt

--- a/src/features/inline-edit/ui/InlineEditModal.ts
+++ b/src/features/inline-edit/ui/InlineEditModal.ts
@@ -53,6 +53,31 @@ const showInsertion = StateEffect.define<{
 }>();
 const hideInlineEdit = StateEffect.define<null>();
 
+const inlineEditRangeField = StateField.define<{ from: number; to: number; valid: boolean } | null>({
+  create: () => null,
+  update: (range, tr) => {
+    if (range && tr.docChanged) {
+      const { from, to } = range;
+      let valid = range.valid;
+      tr.changes.iterChangedRanges((start, end) => {
+        if (from === to ? start <= from && end >= from : start < to && end > from) {
+          valid = false;
+        }
+      });
+      const mappedFrom = tr.changes.mapPos(from, 1);
+      range = { from: mappedFrom, to: Math.max(mappedFrom, tr.changes.mapPos(to, -1)), valid };
+    }
+    for (const effect of tr.effects) {
+      if (effect.is(showInlineEdit)) {
+        range = { from: effect.value.selFrom, to: effect.value.selTo, valid: true };
+      } else if (effect.is(hideInlineEdit)) {
+        range = null;
+      }
+    }
+    return range;
+  },
+});
+
 let activeController: InlineEditController | null = null;
 
 class DiffWidget extends WidgetType {
@@ -282,6 +307,7 @@ export class InlineEditModal {
 }
 
 class InlineEditController {
+  private disposed = false;
   private inputEl: HTMLInputElement | null = null;
   private spinnerEl: HTMLElement | null = null;
   private agentReplyEl: HTMLElement | null = null;
@@ -379,7 +405,7 @@ class InlineEditController {
   show() {
     if (!installedEditors.has(this.editorView)) {
       this.editorView.dispatch({
-        effects: StateEffect.appendConfig.of(inlineEditField),
+        effects: StateEffect.appendConfig.of([inlineEditField, inlineEditRangeField]),
       });
       installedEditors.add(this.editorView);
     }
@@ -509,6 +535,7 @@ class InlineEditController {
   }
 
   private async generate() {
+    if (this.disposed) return;
     if (!this.inputEl || !this.spinnerEl) return;
     const userMessage = this.inputEl.value.trim();
     if (!userMessage) return;
@@ -548,6 +575,7 @@ class InlineEditController {
       }
     }
 
+    if (this.disposed) return;
     this.spinnerEl.addClass('grimoire-hidden');
 
     if (result.success) {
@@ -591,6 +619,7 @@ class InlineEditController {
 
   private showDiffInPlace() {
     if (this.editedText === null) return;
+    if (!this.syncRange()) { this.reject(); return; }
 
     hideSelectionHighlight(this.editorView);
 
@@ -610,6 +639,7 @@ class InlineEditController {
 
   private showInsertionInPlace() {
     if (this.insertedText === null) return;
+    if (!this.syncRange()) { this.reject(); return; }
 
     hideSelectionHighlight(this.editorView);
 
@@ -643,7 +673,17 @@ class InlineEditController {
     this.getOwnerDocument().addEventListener('keydown', this.escHandler);
   }
 
+  private syncRange(): boolean {
+    const range = this.editorView.state.field(inlineEditRangeField, false);
+    if (!range) return true;
+    this.selFrom = range.from;
+    this.selTo = range.to;
+    return range.valid;
+  }
+
   accept() {
+    if (this.disposed) return;
+    if (!this.syncRange()) { this.reject(); return; }
     const textToInsert = this.editedText ?? this.insertedText;
     if (textToInsert !== null) {
       // Convert CM6 positions back to Obsidian Editor positions
@@ -663,6 +703,8 @@ class InlineEditController {
   }
 
   reject() {
+    if (this.disposed) return;
+    this.syncRange();
     this.cleanup({ keepSelectionHighlight: true });
     this.restoreSelectionHighlight();
     this.resolve({ decision: 'reject' });
@@ -677,6 +719,7 @@ class InlineEditController {
   }
 
   private cleanup(options?: { keepSelectionHighlight?: boolean }) {
+    this.disposed = true;
     this.inlineEditService.cancel();
     this.inlineEditService.resetConversation();
     this.isConversing = false;

--- a/src/main.ts
+++ b/src/main.ts
@@ -31,7 +31,7 @@ import {
 } from './app/execution/local/LocalShellExecution';
 import { DEFAULT_GRIMOIRE_SETTINGS } from './app/settings/defaultSettings';
 import { SharedStorageService } from './app/storage/SharedStorageService';
-import { collectReferencedHashes, hydrateImageAttachments } from './core/attachments/hydrateImages';
+import { hydrateImageAttachments } from './core/attachments/hydrateImages';
 import type { UnreadableConversation } from './core/bootstrap/SessionStorage';
 import {
   applyAssistantResponseMetadataToMessages,
@@ -1264,7 +1264,9 @@ export default class GrimoirePlugin extends Plugin {
 
     await this.storage.sessions.deleteMetadata(id);
     this.historyHydration.delete(id);
-    await this.collectAttachmentGarbage();
+    // Shared attachment bytes may still belong to a draft, a queued turn, or a
+    // conversation this build cannot read. Deletion has no complete root set
+    // for garbage collection, so retain the bytes rather than risk data loss.
 
     for (const view of this.getAllViews()) {
       const tabManager = view.getTabManager();
@@ -1375,23 +1377,6 @@ export default class GrimoirePlugin extends Plugin {
       conversation,
       conversationMetadataFields(safeUpdates),
     );
-  }
-
-  /**
-   * Drops stored attachment files nothing references any more.
-   *
-   * The reachable set is read from metadata rather than from the in-memory
-   * conversations: transcript hydration replaces a conversation's messages with
-   * provider-derived ones that carry no hash, so memory is not a complete
-   * record of what is still referenced.
-   */
-  private async collectAttachmentGarbage(): Promise<void> {
-    try {
-      const metadata = await this.storage.sessions.listMetadata();
-      await this.storage.attachments.collectGarbage(collectReferencedHashes(metadata));
-    } catch {
-      // Reclaiming disk is never worth failing a delete over.
-    }
   }
 
   /**

--- a/src/providers/claude/execution/ClaudeExecutionBackend.ts
+++ b/src/providers/claude/execution/ClaudeExecutionBackend.ts
@@ -821,6 +821,7 @@ class ClaudeExecutionSession implements ExecutionSession {
   async prepareRun(
     invocation: ClaudeExecutionInvocation,
     run: ClaudeExecutionRun,
+    resumeCheckpoint?: string,
   ): Promise<void> {
     if (this.preparingRun && this.preparingRun !== run) {
       throw new ExecutionDispatchError('Claude execution preparation is already active.', true);
@@ -828,7 +829,7 @@ class ClaudeExecutionSession implements ExecutionSession {
     this.preparingRun = run;
     try {
       const restartRequired = this.query !== undefined
-        && this.restartFingerprint !== invocation.restartFingerprint;
+        && (this.restartFingerprint !== invocation.restartFingerprint || resumeCheckpoint !== undefined);
       if ((!this.query || restartRequired) && this.hasLiveNativeTasks()) {
         throw new ExecutionDispatchError(
           'Claude query ownership cannot change while native tasks are active.',
@@ -836,7 +837,7 @@ class ClaudeExecutionSession implements ExecutionSession {
         );
       }
       if (!this.query || restartRequired) {
-        await this.startQuery(invocation, run);
+        await this.startQuery(invocation, run, resumeCheckpoint);
       }
       await this.applyDynamicUpdates(invocation.dynamic ?? {}, run);
     } finally {
@@ -1081,11 +1082,18 @@ class ClaudeExecutionSession implements ExecutionSession {
   private async startQuery(
     invocation: ClaudeExecutionInvocation,
     run: ClaudeExecutionRun,
+    resumeCheckpoint?: string,
   ): Promise<void> {
+    let intent = this.resolveSessionIntent(invocation.session);
+    if (resumeCheckpoint !== undefined) {
+      if (intent.kind === 'new') {
+        throw new ExecutionDispatchError('Claude checkpoint requires a native session.', true);
+      }
+      intent = { ...intent, resumeAt: resumeCheckpoint };
+    }
     await this.closeQuery();
     this.completedTaskIds.clear();
     const channel = new ClaudeExecutionMessageChannel();
-    const intent = this.resolveSessionIntent(invocation.session);
     const sessionRef = intent.kind === 'new'
       ? undefined
       : intent.kind === 'resume'
@@ -2005,7 +2013,7 @@ class ClaudeExecutionRun implements ExecutionRun {
       return;
     }
     try {
-      await this.session.prepareRun(invocation, this);
+      await this.session.prepareRun(invocation, this, this.request.resumeCheckpoint);
       if (this.terminal || this.cancellation) {
         if (!this.terminal) {
           this.finish('cancelled', 'cancellation-confirmed', true);

--- a/tests/integration/app/chat/ClaudeChatProjectionLiveSmoke.integration.test.ts
+++ b/tests/integration/app/chat/ClaudeChatProjectionLiveSmoke.integration.test.ts
@@ -164,6 +164,7 @@ live('Claude chat projection live smoke', () => {
       // The vault the CLI is working in, so the column normalizes a written
       // file's path against the same root the product would.
       vaultPath: vault,
+      ...(vaultAdapter ? { vaultAdapter } : {}),
       // What `ConversationController` does when a conversation is opened. The
       // presenter's session belongs to the conversation it was told about.
       syncConversation: true,
@@ -240,6 +241,9 @@ live('Claude chat projection live smoke', () => {
     const storedAnswer = messages.find(message => message.role === 'assistant');
     expect(storedAnswer?.id).toBe(assistants[0]?.id);
     expect(storedAnswer?.content.trim()).not.toBe('');
+    expect(storedAnswer?.assistantMessageId).toMatch(/^[0-9a-f]{8}(?:-[0-9a-f]{4}){3}-[0-9a-f]{12}$/i);
+    expect(completed.nativeAssistantMessageId).toBe(storedAnswer?.assistantMessageId);
+    expect(storedAnswer?.assistantMessageId).not.toBe(storedAnswer?.id);
   });
 
   it('row B: asks once before it writes, and the answer continues the turn', async () => {
@@ -266,10 +270,11 @@ live('Claude chat projection live smoke', () => {
     // answer nobody was there to give — and a suite timeout reports that as
     // "the test took too long" rather than as what it is. Failing here says
     // what was asked and what came back.
+    let timeout: ReturnType<typeof setTimeout> | undefined;
     const ended = await Promise.race([
       submitted.ticket.completion.then(() => 'ended' as const),
-      new Promise<'waiting'>(resolve => { setTimeout(() => resolve('waiting'), 120_000); }),
-    ]);
+      new Promise<'waiting'>(resolve => { timeout = setTimeout(() => resolve('waiting'), 120_000); }),
+    ]).finally(() => clearTimeout(timeout));
     await tab.settled();
 
     report('ROW B', ended, JSON.stringify(asked), JSON.stringify(column.chunks.map(c => c.type)));
@@ -334,6 +339,44 @@ live('Claude chat projection live smoke', () => {
     report('ROW C', completed.terminal.kind, JSON.stringify(column.drawn.join('').slice(0, 160)));
     expect(completed.terminal.kind).toBe('succeeded');
     expect(column.drawn.join('').toLowerCase()).toContain('tomato');
+  });
+
+  it('row D: resumes the native checkpoint stored before a later turn', async () => {
+    const vaultAdapter = createDurableInMemoryVaultAdapter();
+    const first = await createHarness({}, vaultAdapter);
+    const remember = 'Remember the word "tomato". Reply with exactly: ok';
+    const checkpointTurn = await first.harness.tab.send({ text: remember }, userMessage(remember));
+    const completed = await checkpointTurn.ticket.completion;
+    await first.harness.tab.settled();
+    await first.harness.saveAfterTurn();
+    const checkpoint = completed.nativeAssistantMessageId;
+    expect(checkpoint).toBeTruthy();
+
+    const replace = 'Replace the word to remember with "potato". Reply with exactly: ok';
+    await (await first.harness.tab.send({ text: replace }, userMessage(replace))).ticket.completion;
+    await first.harness.tab.settled();
+    await first.harness.saveAfterTurn();
+    await first.harness.sessions.records.apply(CONVERSATION_ID, current => ({
+      ...current,
+      messages: [],
+      resumeAtMessageId: checkpoint,
+    }));
+    await first.release();
+
+    const second = await createHarness({}, vaultAdapter);
+    const stored = await second.harness.sessions.records.read(CONVERSATION_ID);
+    if (stored.kind !== 'present' || !stored.metadata.sessionId) throw new Error('Missing native session');
+    const ask = 'What word did I ask you to remember? Reply with just that word.';
+    const resumed = await second.harness.tab.send({ text: ask }, userMessage(ask), {
+      nativeSessionRef: stored.metadata.sessionId,
+      resumeCheckpoint: checkpoint,
+    });
+    expect((await resumed.ticket.completion).terminal.kind).toBe('succeeded');
+    await second.harness.tab.settled();
+    const answer = second.harness.column.drawn.join('').toLowerCase();
+    expect(answer).toContain('tomato');
+    expect(answer).not.toContain('potato');
+    report('ROW D restored native checkpoint');
   });
 
   // Matrix rows 11, 12 and 13, driven rather than watched: a turn that outlives

--- a/tests/unit/app/chat/ChatTabExecution.test.ts
+++ b/tests/unit/app/chat/ChatTabExecution.test.ts
@@ -1,4 +1,5 @@
 import { createMockEl } from '@test/helpers/mockElement';
+import { buildSDKMessage } from '@test/helpers/sdkMessages';
 import { TestDurableStorage } from '@test/unit/core/persistence/TestDurableStorage';
 
 import { ChatExecutionComposition } from '@/app/chat/ChatExecutionComposition';
@@ -19,7 +20,10 @@ import type {
   ChatMessageOperations,
   ChatStreamingCursor,
   ChatStreamOperations,
+  ChatSurfaceRenderTargetDeps,
 } from '@/features/chat/rendering/ChatSurfaceRenderTarget';
+import { ClaudeContentPresenter } from '@/providers/claude/execution/ClaudeContentPresenter';
+import { ClaudeProjectionResultSink } from '@/providers/claude/execution/ClaudeProjectionResultSink';
 
 /**
  * One tab's end of the path, over the real kernel and the real vault.
@@ -128,6 +132,7 @@ async function createTab(options: {
   readonly encoder?: ChatTurnEncoder | null;
   /** What the provider says about the turn that just ended, when it says anything. */
   readonly turnMetadata?: () => ChatTurnMetadata | null;
+  readonly presentProviderContent?: ChatSurfaceRenderTargetDeps['presentProviderContent'];
 } = {}) {
   const storage = new TestDurableStorage();
   const now = () => 1_000;
@@ -164,7 +169,7 @@ async function createTab(options: {
     composition,
     providerId: 'claude',
     backendId: BACKEND_ID,
-    surface: drawn.binding,
+    surface: { ...drawn.binding, ...(options.presentProviderContent ? { presentProviderContent: options.presentProviderContent } : {}) },
     turnEncoder: () => (options.encoder === undefined ? encoder : options.encoder),
     ...(options.turnMetadata ? { turnMetadata: options.turnMetadata } : {}),
     createConversation: async () => {
@@ -345,10 +350,9 @@ describe('chat tab execution', () => {
     const completed = await submitted.ticket.completion;
 
     expect(completed.planCompleted).toBe(true);
-    // **Only the plan.** The identities are the kernel's, and a provider's copy
-    // overwriting them would put a second answer to one question back into the
-    // path the migration took one out of.
+    // Native checkpoints never replace the projection's display identity.
     expect(completed.assistantMessageId).not.toBe('provider-answer');
+    expect(completed.nativeAssistantMessageId).toBe('provider-answer');
     // Once per turn: the read is destructive, and it carries the provider's own
     // per-turn side effects with it.
     expect(reads).toHaveLength(1);
@@ -387,4 +391,58 @@ describe('chat tab execution', () => {
     expect(completed.planCompleted).toBeUndefined();
     app.composition.dispose();
   });
+});
+
+test('the persisted Claude checkpoint must remain a native message UUID', async () => {
+  const nativeId = '8baecb38-3c01-4bc9-8447-2ec235a2057c';
+  const presenter = new ClaudeContentPresenter({ settings: () => ({}) });
+  const app = await createTab({
+    presentProviderContent: payload => presenter.present(payload).filter(chunk => chunk.type !== 'error'),
+    turnMetadata: () => ({ ...presenter.consumeTurnMetadata(), userMessageId: 'native-question' }),
+  });
+  try {
+    const { ticket } = await app.tab.send({ text: 'Hello' }, userMessage('msg-1', 'Hello'));
+    const started = await ticket.started;
+    const outcome = await new ClaudeProjectionResultSink().storeResult({
+      runId: started.runId, output: 'Answer', source: 'assistant', signal: new AbortController().signal,
+    });
+    if (outcome.kind !== 'committed') throw new Error('Unexpected result outcome');
+    app.backend.emit(started.runId, { kind: 'output-delta', channel: 'assistant', text: 'Answer' });
+    app.backend.emit(started.runId, { kind: 'provider-content', payload: buildSDKMessage({
+      type: 'assistant', uuid: nativeId,
+      message: { content: [{ type: 'text', text: 'Answer' }] },
+    }) });
+    app.backend.emit(started.runId, { kind: 'result', result: outcome.result });
+    app.backend.emit(started.runId, { kind: 'terminal', terminal: 'succeeded', reason: 'completed' });
+    await ticket.completion;
+    const record = await app.repository.read('conv-1');
+    if (record.kind !== 'present') throw new Error('Conversation missing');
+    expect(record.metadata.messages?.at(-1)?.assistantMessageId).toBe(nativeId);
+    expect(record.metadata.messages?.[0]?.userMessageId).toBe('native-question');
+  } finally {
+    app.composition.dispose();
+  }
+});
+
+test('Stop during conversation loading prevents dispatch', async () => {
+  const app = await createTab();
+  let release!: () => void;
+  let entered!: () => void;
+  const gate = new Promise<void>(resolve => { release = resolve; });
+  const loading = new Promise<void>(resolve => { entered = resolve; });
+  const reload = app.composition.coordinator.reloadConversation.bind(app.composition.coordinator);
+  jest.spyOn(app.composition.coordinator, 'reloadConversation').mockImplementation(async id => {
+    entered();
+    await gate;
+    return reload(id);
+  });
+  const start = jest.spyOn(app.registry, 'startRun');
+  const sending = app.tab.send({ text: 'Do work' }, userMessage('msg-1', 'Do work'));
+  const rejected = sending.catch(error => error as Error);
+  await loading;
+  await app.tab.cancel();
+  release();
+  expect(await rejected).toEqual(expect.objectContaining({ message: 'Chat turn was cancelled before dispatch.' }));
+  expect(start).not.toHaveBeenCalled();
+  app.composition.dispose();
 });

--- a/tests/unit/core/attachments/conversationDeletion.test.ts
+++ b/tests/unit/core/attachments/conversationDeletion.test.ts
@@ -1,0 +1,52 @@
+import '@/providers';
+
+import { VaultDurableStorage } from '@/app/storage/VaultDurableStorage';
+import { AttachmentStore } from '@/core/attachments/AttachmentStore';
+import { SessionStorage } from '@/core/bootstrap/SessionStorage';
+import GrimoirePlugin from '@/main';
+
+function setup() {
+  const textFiles = new Map<string, string>();
+  const binaryFiles = new Map<string, ArrayBuffer>();
+  const adapter = {
+    coordinationKey: {},
+    exists: async (path: string) => textFiles.has(path) || binaryFiles.has(path),
+    read: async (path: string) => textFiles.get(path)!,
+    write: async (path: string, content: string) => { textFiles.set(path, content); },
+    rename: async (from: string, to: string) => { textFiles.set(to, textFiles.get(from)!); textFiles.delete(from); },
+    delete: async (path: string) => { textFiles.delete(path); binaryFiles.delete(path); },
+    listFilesRecursive: async (prefix: string) => [...textFiles.keys()].filter(path => path.startsWith(prefix + '/')),
+    listFiles: async (prefix: string) => [...textFiles.keys(), ...binaryFiles.keys()].filter(path => path.startsWith(prefix + '/')),
+    readBinary: async (path: string) => binaryFiles.get(path)!,
+    writeBinary: async (path: string, bytes: ArrayBuffer) => { binaryFiles.set(path, bytes); },
+    getResourcePath: (path: string) => path,
+  };
+  const attachments = new AttachmentStore(adapter);
+  const sessions = new SessionStorage(adapter as never, new VaultDurableStorage(adapter));
+  const plugin = new GrimoirePlugin({ workspace: { getLeavesOfType: () => [] } } as never, {} as never);
+  (plugin as any).storage = { sessions, attachments };
+  (plugin as any).conversations = [{ id: 'delete-me', providerId: 'codex', messages: [] }];
+  return { plugin, attachments, sessions, textFiles };
+}
+
+test('deleting another conversation must retain draft attachments', async () => {
+  const { plugin, attachments } = setup();
+  const draft = await attachments.put(new Uint8Array([1, 2, 3]).buffer, 'image/png');
+  await plugin.deleteConversation('delete-me');
+  expect(await attachments.read(draft.hash, draft.mediaType)).not.toBeNull();
+});
+
+test('deleting another conversation must retain future-schema attachments', async () => {
+  const { plugin, attachments, textFiles, sessions } = setup();
+  const image = await attachments.put(new Uint8Array([1, 2, 3]).buffer, 'image/png');
+  textFiles.set('.grimoire/sessions/future.meta.json', JSON.stringify({
+    schemaVersion: 2, recordId: 'future', revision: 1, updatedAt: 1,
+    payload: { id: 'future', title: 'Future', createdAt: 1, updatedAt: 1,
+      messages: [{ id: 'm', role: 'user', content: 'image', timestamp: 1,
+        images: [{ ...image, id: 'i', data: '', name: 'picture.png' }] }],
+    },
+  }));
+  expect((await sessions.listConversations()).unreadable).toHaveLength(1);
+  await plugin.deleteConversation('delete-me');
+  expect(await attachments.read(image.hash, image.mediaType)).not.toBeNull();
+});

--- a/tests/unit/core/attachments/hydrateImages.test.ts
+++ b/tests/unit/core/attachments/hydrateImages.test.ts
@@ -1,6 +1,5 @@
 import type { AttachmentStore } from '@/core/attachments/AttachmentStore';
 import {
-  collectReferencedHashes,
   hydrateImageAttachments,
   hydrateImages,
 } from '@/core/attachments/hydrateImages';
@@ -91,27 +90,5 @@ describe('hydrateImages', () => {
 
     await expect(hydrateImages(undefined, store)).resolves.toBeUndefined();
     expect(store.read).not.toHaveBeenCalled();
-  });
-});
-
-describe('collectReferencedHashes', () => {
-  it('gathers every hash still referenced, across conversations', () => {
-    const other = 'b'.repeat(64);
-
-    const hashes = collectReferencedHashes([
-      { messages: [messageWithImage({ hash: HASH })] },
-      { messages: [messageWithImage({ hash: other })] },
-      { messages: [messageWithImage({ hash: HASH })] },
-    ]);
-
-    expect(hashes).toEqual(new Set([HASH, other]));
-  });
-
-  it('skips attachments that were never stored', () => {
-    expect(collectReferencedHashes([{ messages: [messageWithImage({})] }])).toEqual(new Set());
-  });
-
-  it('handles conversations without messages', () => {
-    expect(collectReferencedHashes([{}, { messages: [] }])).toEqual(new Set());
   });
 });

--- a/tests/unit/core/runtime/execution/ExecutionAdapterSession.test.ts
+++ b/tests/unit/core/runtime/execution/ExecutionAdapterSession.test.ts
@@ -427,7 +427,6 @@ describe('turn metadata carries the native identities', () => {
     expect(stream.consumeTurnMetadata()).toEqual({
       wasSent: true,
       userMessageId: 'native-message-1',
-      assistantMessageId: 'assistant-1',
     });
   });
 

--- a/tests/unit/features/chat/application/ChatExecutionCoordinator.test.ts
+++ b/tests/unit/features/chat/application/ChatExecutionCoordinator.test.ts
@@ -106,11 +106,9 @@ describe('chat execution coordinator', () => {
         id: `assistant-${started.runId}`,
         role: 'assistant',
         content: 'Botanically, yes.',
-        // The provider's own name for the answer, which is what a rewind or a
-        // fork resumes at. A second question, on the field that asks it.
-        assistantMessageId: `result-${started.runId}`,
       }),
     ]);
+    expect((await storedMessages(harness)).at(-1)?.assistantMessageId).toBeUndefined();
   });
 
   describe('the session binding', () => {
@@ -702,7 +700,10 @@ describe('chat execution coordinator', () => {
       nextLeaseId: () => lifecycleLeaseId(opaque('lease', 9)),
       assistantMessageIdForRun: forRunId => `assistant-${forRunId}`,
     });
-    const ticket = await coordinator.submitTurn(turnCommand());
+    const turnMetadata = jest.fn()
+      .mockReturnValueOnce({ assistantMessageId: 'native-answer' })
+      .mockReturnValue({});
+    const ticket = await coordinator.submitTurn(turnCommand({ turnMetadata }));
     const started = await ticket.started;
     harness.backend.emit(started.runId, {
       kind: 'output-delta',
@@ -727,11 +728,61 @@ describe('chat execution coordinator', () => {
 
     await coordinator.retryPersistence(CONVERSATION_ID);
 
+    expect(turnMetadata).toHaveBeenCalledTimes(1);
+    const record = await harness.conversations.read(CONVERSATION_ID);
+    expect(record.kind === 'present' && record.metadata.messages?.at(-1)?.assistantMessageId).toBe('native-answer');
     expect(coordinator.getProjection(CONVERSATION_ID)?.turns[0]?.persistence).toBe('saved');
     await expect(ticket.completion).resolves.toEqual(expect.objectContaining({
       runId: started.runId,
     }));
     coordinator.dispose();
+  });
+
+  it('honors Stop while opening a session without dispatching a run', async () => {
+    const harness = await createHarness();
+    let release!: () => void;
+    let entered!: () => void;
+    const gate = new Promise<void>(resolve => { release = resolve; });
+    const opening = new Promise<void>(resolve => { entered = resolve; });
+    const create = harness.registry.createSession.bind(harness.registry);
+    jest.spyOn(harness.registry, 'createSession').mockImplementation(async command => {
+      entered();
+      await gate;
+      return create(command);
+    });
+    const start = jest.spyOn(harness.registry, 'startRun');
+    const ticket = await harness.coordinator.submitTurn(turnCommand());
+    const rejected = ticket.completion.catch(error => error as Error);
+    await opening;
+    await harness.coordinator.cancelActive(CONVERSATION_ID);
+    release();
+    expect(await rejected).toEqual(expect.objectContaining({ message: 'Chat turn was cancelled before dispatch.' }));
+    expect(start).not.toHaveBeenCalled();
+    harness.coordinator.dispose();
+  });
+
+  it('forwards Stop requested while the kernel is admitting a run', async () => {
+    const harness = await createHarness();
+    let release!: () => void;
+    let entered!: () => void;
+    const gate = new Promise<void>(resolve => { release = resolve; });
+    const admitting = new Promise<void>(resolve => { entered = resolve; });
+    const start = harness.registry.startRun.bind(harness.registry);
+    jest.spyOn(harness.registry, 'startRun').mockImplementation(async (session, request) => {
+      entered();
+      await gate;
+      return start(session, request);
+    });
+    const cancel = jest.spyOn(harness.registry, 'cancelRun');
+    const ticket = await harness.coordinator.submitTurn(turnCommand());
+    await admitting;
+    await harness.coordinator.cancelActive(CONVERSATION_ID);
+    expect(cancel).not.toHaveBeenCalled();
+    release();
+    const started = await ticket.started;
+    await waitUntil(() => cancel.mock.calls.length > 0, 'cancellation forwarded');
+    expect(cancel).toHaveBeenCalledWith(started.runId, { code: 'user' });
+    harness.coordinator.dispose();
   });
 
   it('refuses a conversation this build cannot read, by name', async () => {

--- a/tests/unit/features/chat/application/ChatProjectionAttachment.test.ts
+++ b/tests/unit/features/chat/application/ChatProjectionAttachment.test.ts
@@ -262,7 +262,7 @@ describe('chat projection attachment', () => {
     // addresses after one.
     expect(storedMessage?.id).toBe(`assistant-${started.runId}`);
     expect(drawn.state.messages.at(-1)?.id).toBe(storedMessage?.id);
-    expect(storedMessage?.assistantMessageId).toBe(`result-${started.runId}`);
+    expect(storedMessage?.assistantMessageId).toBeUndefined();
   });
 
   it('draws a turn the kernel was already running when the tab opened', async () => {

--- a/tests/unit/features/chat/controllers/InputController.preparation.test.ts
+++ b/tests/unit/features/chat/controllers/InputController.preparation.test.ts
@@ -1,0 +1,140 @@
+import '@/providers';
+
+import { createMockDeps } from '@test/helpers/inputControllerHarness';
+
+import { InputController } from '@/features/chat/controllers/InputController';
+
+beforeAll(() => {
+  globalThis.requestAnimationFrame = (cb: FrameRequestCallback) => { cb(0); return 0; };
+});
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>(r => { resolve = r; });
+  return { promise, resolve };
+}
+
+function projection() {
+  return {
+    send: jest.fn().mockResolvedValue({
+      userMessage: { content: 'request' },
+      ticket: { completion: Promise.resolve({ terminal: { kind: 'succeeded' } }) },
+    }),
+    cancel: jest.fn().mockResolvedValue(undefined),
+    settled: jest.fn().mockResolvedValue(undefined),
+  };
+}
+
+test('stopping during initialization must prevent later dispatch', async () => {
+  const deps = createMockDeps();
+  const p = projection();
+  deps.getProjectionExecution = () => p as never;
+  const ready = deferred<boolean>();
+  const entered = deferred<void>();
+  deps.ensureServiceInitialized = jest.fn(() => { entered.resolve(); return ready.promise; });
+  deps.getInputEl().value = 'Change my note';
+  const controller = new InputController(deps);
+  const sending = controller.sendMessage();
+  await entered.promise;
+  controller.cancelStreaming();
+  ready.resolve(true);
+  await sending;
+  expect(p.cancel).toHaveBeenCalledTimes(1);
+  expect(p.send).not.toHaveBeenCalled();
+});
+
+test.each(['failed', 'invalidated', 'indeterminate', 'interrupted'])(
+  'terminal %s must hold queued followups', async kind => {
+    jest.useFakeTimers();
+    try {
+      const deps = createMockDeps();
+      const p = projection();
+      p.send.mockResolvedValue({
+        userMessage: { content: 'request' },
+        ticket: { completion: Promise.resolve({ terminal: { kind } }) },
+      });
+      deps.getProjectionExecution = () => p as never;
+      deps.getInputEl().value = 'First request';
+      const controller = new InputController(deps);
+      deps.state.queue.enqueue({ content: 'Dependent followup', images: undefined, editorContext: null, canvasContext: null });
+      await controller.sendMessage();
+      expect(deps.state.queue.isPaused).toBe(true);
+    } finally {
+      jest.clearAllTimers();
+      jest.useRealTimers();
+    }
+  },
+);
+
+test('failed initialization must preserve the unsent draft', async () => {
+  const deps = createMockDeps();
+  const p = projection();
+  deps.getProjectionExecution = () => p as never;
+  deps.ensureServiceInitialized = jest.fn().mockResolvedValue(false);
+  deps.getInputEl().value = 'Important unsent request';
+  await new InputController(deps).sendMessage();
+  expect(p.send).not.toHaveBeenCalled();
+  expect(deps.getInputEl().value).toBe('Important unsent request');
+});
+
+test('an initialization exception restores text and images', async () => {
+  const deps = createMockDeps();
+  const p = projection();
+  deps.getProjectionExecution = () => p as never;
+  deps.ensureServiceInitialized = jest.fn().mockRejectedValue(new Error('CLI unavailable'));
+  const images = [{ id: 'image-1', name: 'note.png', mediaType: 'image/png' as const, data: 'AQID', size: 3, source: 'paste' as const }];
+  const manager = deps.getImageContextManager()!;
+  jest.spyOn(manager, 'getAttachedImages').mockReturnValue(images);
+  deps.getInputEl().value = '  Keep my formatting\n';
+  await new InputController(deps).sendMessage();
+  expect(deps.getInputEl().value).toBe('  Keep my formatting\n');
+  expect(manager.setImages).toHaveBeenCalledWith(images);
+  expect(deps.state.isStreaming).toBe(false);
+  expect(p.send).not.toHaveBeenCalled();
+});
+
+test('a failed start preserves a newer draft and queues the original request', async () => {
+  const deps = createMockDeps();
+  const ready = deferred<boolean>();
+  const entered = deferred<void>();
+  deps.ensureServiceInitialized = () => { entered.resolve(); return ready.promise; };
+  deps.getInputEl().value = 'Original request';
+  const sending = new InputController(deps).sendMessage();
+  await entered.promise;
+  deps.getInputEl().value = 'New draft';
+  ready.resolve(false);
+  await sending;
+  expect(deps.getInputEl().value).toBe('New draft');
+  expect(deps.state.queue.items[0].content).toBe('Original request');
+  expect(deps.state.queue.isPaused).toBe(true);
+});
+
+test('a drained message returns to the head of the queue when initialization fails', async () => {
+  const deps = createMockDeps();
+  deps.ensureServiceInitialized = jest.fn().mockResolvedValue(false);
+  deps.state.queue.enqueue({ content: 'Later', images: undefined, editorContext: null, canvasContext: null });
+  deps.getInputEl().value = 'Draft';
+  const request = { text: 'Queued', currentNotePath: 'original.md' };
+  await new InputController(deps).sendMessage({ content: 'Queued', turnRequestOverride: request });
+  expect(deps.state.queue.items.map(item => item.content)).toEqual(['Queued', 'Later']);
+  expect(deps.state.queue.items[0].turnRequest).toEqual(request);
+  expect(deps.getInputEl().value).toBe('Draft');
+  expect(deps.state.queue.isPaused).toBe(true);
+});
+
+test('completion must not overwrite the provider checkpoint with the display message id', async () => {
+  const deps = createMockDeps();
+  const nativeId = '8baecb38-3c01-4bc9-8447-2ec235a2057c';
+  const assistant = { id: 'assistant-run-1', role: 'assistant' as const,
+    content: 'Answer', timestamp: 1, assistantMessageId: nativeId };
+  deps.state.addMessage(assistant);
+  const p = projection();
+  p.send.mockResolvedValue({
+    userMessage: { content: 'request' },
+    ticket: { completion: Promise.resolve({ terminal: { kind: 'succeeded' }, assistantMessageId: assistant.id }) },
+  });
+  deps.getProjectionExecution = () => p as never;
+  deps.getInputEl().value = 'A request';
+  await new InputController(deps).sendMessage();
+  expect(assistant.assistantMessageId).toBe(nativeId);
+});

--- a/tests/unit/features/chat/controllers/InputController.test.ts
+++ b/tests/unit/features/chat/controllers/InputController.test.ts
@@ -2516,7 +2516,8 @@ describe('InputController - Message Queue', () => {
       expect(mockNotice).toHaveBeenCalledWith('Failed to initialize agent service. Please try again.');
       expect(deps.streamController.hideThinkingIndicator).toHaveBeenCalled();
       expect(deps.state.isStreaming).toBe(false);
-      expect(deps.state.hasPendingConversationSave).toBe(true);
+      expect(deps.state.hasPendingConversationSave).toBe(false);
+      expect(inputEl.value).toBe('test message');
       expect((deps as any).mockAgentService.query).not.toHaveBeenCalled();
     });
   });
@@ -2538,7 +2539,8 @@ describe('InputController - Message Queue', () => {
       await controller.sendMessage();
 
       expect(mockNotice).toHaveBeenCalledWith('Agent service not available. Please reload the plugin.');
-      expect(deps.state.hasPendingConversationSave).toBe(true);
+      expect(deps.state.hasPendingConversationSave).toBe(false);
+      expect(inputEl.value).toBe('test message');
       expect((deps as any).mockAgentService.query).not.toHaveBeenCalled();
     });
   });

--- a/tests/unit/features/inline-edit/ui/InlineEditModal.openAndWait.test.ts
+++ b/tests/unit/features/inline-edit/ui/InlineEditModal.openAndWait.test.ts
@@ -128,6 +128,7 @@ describe('InlineEditModal - openAndWait', () => {
       });
       const editorView = {
         state: {
+          field: jest.fn(),
           doc: {
             line: jest.fn(() => ({ from: 0 })),
             lineAt: jest.fn(() => ({ from: 0 })),
@@ -234,6 +235,7 @@ describe('InlineEditModal - openAndWait', () => {
       });
       const editorView = {
         state: {
+          field: jest.fn(),
           doc: {
             line: jest.fn(() => ({ from: 0 })),
             lineAt: jest.fn(() => ({ from: 0 })),
@@ -344,6 +346,7 @@ describe('InlineEditModal - openAndWait', () => {
       });
       const editorView = {
         state: {
+          field: jest.fn(),
           doc: {
             line: jest.fn(() => ({ from: 0 })),
             lineAt: jest.fn(() => ({ from: 0 })),
@@ -438,6 +441,7 @@ describe('InlineEditModal - openAndWait', () => {
       });
       const editorView = {
         state: {
+          field: jest.fn(),
           doc: {
             line: jest.fn(() => ({ from: 0 })),
             lineAt: jest.fn(() => ({ from: 0, number: 1 })),
@@ -581,6 +585,7 @@ describe('InlineEditModal - openAndWait', () => {
       });
       const editorView = {
         state: {
+          field: jest.fn(),
           doc: {
             line: jest.fn(() => ({ from: 0 })),
             lineAt: jest.fn(() => ({ from: 0, number: 1 })),
@@ -687,6 +692,7 @@ describe('InlineEditModal - openAndWait', () => {
       });
       const editorView = {
         state: {
+          field: jest.fn(),
           doc: {
             line: jest.fn(() => ({ from: 0 })),
             lineAt: jest.fn(() => ({ from: 0, number: 1 })),
@@ -819,6 +825,7 @@ describe('InlineEditModal - openAndWait', () => {
       });
       const editorView = {
         state: {
+          field: jest.fn(),
           doc: {
             line: jest.fn(() => ({ from: 0 })),
             lineAt: jest.fn(() => ({ from: 0, number: 1 })),
@@ -925,6 +932,7 @@ describe('InlineEditModal - openAndWait', () => {
       });
       const editorView = {
         state: {
+          field: jest.fn(),
           doc: {
             line: jest.fn(() => ({ from: 0 })),
             lineAt: jest.fn(() => ({ from: 0, number: 1 })),

--- a/tests/unit/features/inline-edit/ui/InlineEditModal.range.test.ts
+++ b/tests/unit/features/inline-edit/ui/InlineEditModal.range.test.ts
@@ -1,0 +1,58 @@
+import '@/providers';
+
+import { EditorState } from '@codemirror/state';
+
+import { InlineEditModal } from '@/features/inline-edit/ui/InlineEditModal';
+import * as editorUtils from '@/utils/editor';
+
+test.each([
+  { change: { from: 0, insert: 'NEW ' }, expected: 'NEW prefix REPLACEMENT suffix', decision: 'accept' },
+  { change: { from: 8, to: 9, insert: '!' }, expected: 'prefix T!RGET suffix', decision: 'reject' },
+  { change: { from: 0, to: 20, insert: 'short' }, expected: 'short', decision: 'reject' },
+  { change: { from: 0, insert: 'NEW\n' }, expected: 'NEW\nprefix REPLACEMENT suffix', decision: 'accept', beforeDiff: true },
+  { change: { from: 8, to: 9, insert: '!' }, expected: 'prefix T!RGET suffix', decision: 'reject', beforeDiff: true },
+  { change: { from: 7, insert: 'ADDED ' }, expected: 'prefix ADDED REPLACEMENT suffix', decision: 'accept' },
+  { change: { from: 13, insert: ' ADDED' }, expected: 'prefix REPLACEMENT ADDED suffix', decision: 'accept' },
+])('applies only to a valid mapped range: $expected', async ({ change, expected, decision, beforeDiff }) => {
+  const ownerDocument = { addEventListener: jest.fn(), removeEventListener: jest.fn() };
+  const editorView = {
+    state: EditorState.create({ doc: 'prefix TARGET suffix' }),
+    dom: { ownerDocument, addEventListener: jest.fn(), removeEventListener: jest.fn() },
+    dispatch(transaction: any) { this.state = this.state.update(transaction).state; },
+  };
+  const editor = {
+    getCursor: (side: string) => ({ line: 0, ch: side === 'from' ? 7 : 13 }),
+    getSelection: () => 'TARGET',
+    replaceRange: jest.fn((text, from, to) => {
+      const doc = editorView.state.doc;
+      editorView.dispatch({ changes: {
+        from: doc.line(from.line + 1).from + from.ch,
+        to: doc.line(to.line + 1).from + to.ch,
+        insert: text,
+      } });
+    }),
+  };
+  const plugin = {
+    getApplicationRuntimeOrNull: () => null,
+    settings: { hiddenProviderCommands: {} },
+  };
+  const app = { vault: { getFiles: () => [], getAllLoadedFiles: () => [] } };
+  const spy = jest.spyOn(editorUtils, 'getEditorView').mockReturnValue(editorView as never);
+  const modal = new InlineEditModal(app as never, plugin as never, editor as never,
+    { editor } as never, { mode: 'selection', selectedText: 'TARGET' }, 'note.md');
+  try {
+    const completed = modal.openAndWait();
+    const controller = (modal as any).controller;
+    if (beforeDiff) editorView.dispatch({ changes: change });
+    controller.editedText = 'REPLACEMENT';
+    controller.showDiffInPlace();
+    if (!beforeDiff) editorView.dispatch({ changes: change });
+    controller.accept();
+    controller.accept();
+    await expect(completed).resolves.toMatchObject({ decision });
+    expect(editorView.state.doc.toString()).toBe(expected);
+  } finally {
+    (modal as any).controller?.reject();
+    spy.mockRestore();
+  }
+});

--- a/tests/unit/providers/claude/ClaudeExecutionBackend.test.ts
+++ b/tests/unit/providers/claude/ClaudeExecutionBackend.test.ts
@@ -667,6 +667,41 @@ describe('ClaudeExecutionBackend', () => {
     expect(forked.getSnapshot().nativeSessionRef).toBe('source-session');
   });
 
+  it.each([false, true])('resumes an explicit execution checkpoint with a warm query: %s', async (warm) => {
+    const fixture = createFixture();
+    const session = await createSession(fixture.backend, 'native-session');
+    if (warm) {
+      const first = collectEvents(session.createRun(request('1', 'default')));
+      await waitFor(() => fixture.query.received.length === 1);
+      fixture.query.emit(resultMessage('message-1', 'done', 'result-1'));
+      await first;
+    }
+    const query = warm ? new FakeQuery() : fixture.query;
+    fixture.factory.nextQuery = query;
+    const events = collectEvents(session.createRun({
+      ...request('2', 'default'),
+      resumeCheckpoint: 'assistant-checkpoint',
+    }));
+    await waitFor(() => query.received.length === 1);
+    expect(fixture.factory.inputs.at(-1)?.nativeSessionRef).toBe('native-session');
+    expect(fixture.factory.inputs.at(-1)?.resumeAt).toBe('assistant-checkpoint');
+    expect(fixture.factory.inputs.at(-1)?.forkSession).toBe(false);
+    expect(fixture.factory.inputs).toHaveLength(warm ? 2 : 1);
+    query.emit(resultMessage('message-1', 'resumed', 'result-2'));
+    expectTerminal(await events, 'succeeded', 'completed');
+  });
+
+  it('rejects a checkpoint without a native session before starting a query', async () => {
+    const fixture = createFixture();
+    const session = await createSession(fixture.backend);
+    const events = await collectEvents(session.createRun({
+      ...request('1', 'default'),
+      resumeCheckpoint: 'assistant-checkpoint',
+    }));
+    expectTerminal(events, 'invalidated', 'pre-dispatch-rejected');
+    expect(fixture.factory.inputs).toHaveLength(0);
+  });
+
   it('rewinds files while quiescent and resumes the next query at the assistant checkpoint', async () => {
     const fixture = createFixture({
       invocations: {


### PR DESCRIPTION
## Problem

Chat failures and cancellation during startup could discard drafts or send queued work unexpectedly. Inline edits could replace stale document offsets, deleting a conversation could remove attachments still owned by drafts or unreadable session records, and Claude checkpoints could resolve to the latest conversation instead of the selected answer.

## Root Cause

Preparation cleared input before dispatch was assured; cancellation was lost across asynchronous admission boundaries; non-success terminals were not consistently treated as failures. Attachment collection assumed persisted, readable conversations were the complete reference set. Native assistant UUIDs were conflated with display/result IDs, and Claude ignored the execution request's checkpoint.

## Approach

- Restore unsent text and images without overwriting newer drafts, preserve Stop across startup/admission, and pause queues after failure or interruption.
- Map inline edit ranges through document changes and reject proposals whose target was edited.
- Retain shared attachment bytes on conversation deletion. Orphans can remain until collection has a complete reference set.
- Persist provider-native message IDs at the answer's persistence barrier, independently of display identity. Pass Claude checkpoints to the SDK and restart a warm query when an explicit checkpoint requires it.
- Add focused regressions and a real Claude reload/checkpoint test; repair its durable adapter wiring and timeout cleanup.
- Update locked transitive dependencies to `hono@4.13.5`, `js-yaml@3.15.2`, and `js-yaml@4.3.2` to clear the dependency audit. The existing manifest ranges and seven-day release-age policy are unchanged.

## Architecture

- [x] Claude SDK behavior remains inside its provider adapter; shared chat lifecycle and metadata contracts remain provider-neutral.
- [x] Checked sibling consumers through unit/integration coverage and live provider smoke tests. No shared ACP transport changes.

## Security And Privacy

No authorization, credential, MCP, or external-path boundary changes. Checkpoint restart preserves the existing native-task ownership guard and rejects a checkpoint without a native session. Tests use synthetic conversations and temporary scratch vaults; raw live transcripts and local diagnostic artifacts are excluded.

## Verification

```text
npm run test -- --selectProjects unit
npm run test -- --selectProjects unit --runInBand --detectOpenHandles
npm run test -- --selectProjects integration
npm run typecheck
npm run lint
npm ci
npm audit
npm audit --omit=dev
npm audit signatures
npm run check:lockfile-age
OBSIDIAN_VAULT=/tmp/grimoire-no-auto-install-review npm run build:release
```

- 595 unit suites / 9,204 tests passed; 6 integration suites / 164 tests passed. Opt-in suites remain skipped in the ordinary integration run.
- The parallel unit run warned about worker shutdown; the diagnostic serial run passed and exited without reporting open handles.
- Real CLI projection tests on macOS: Claude 2.1.265 passed all 8 scenarios, including native checkpoint restoration; Codex 0.153.4 with `gpt-5.6-luna` passed reply, tool execution, reload/resume, and durable queue scenarios.
- Basic reply/persistence smoke tests passed for OpenCode, Qwen Code, Kimi Code, Gemini CLI, Grok Build, and Antigravity CLI. MiMoCode was unavailable locally. The initial Codex default model was unsupported by the signed-in account; the explicit Luna run passed.
- Live runs are automated integration checks, not manual Obsidian UI verification. Manual Obsidian verification: not run.

## Generated Artifacts

- [x] Release build passed source/CSS/dependency review gates and isolated bundle load/view smoke checks. Root release artifacts match `dist/grimoire` byte-for-byte.
- [x] Only three transitive lockfile entries were updated; `package.json` remains unchanged. No plugin version changes; generated bundles and local-only artifacts are excluded.

## Review Checklist

- [x] Changes address chat state preservation and checkpoint correctness, with regression tests.
- [x] Native checkpoint behavior is verified against real SDK output.
- [x] Development artifacts are in English; automated and manual verification are distinguished above.
