### PR TITLE
fix(history): let the popover use the room a wide pane has

### DIFF
--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -376,9 +376,15 @@ the toolbar, because a line inside a box that has one is a second box.
 
 ### 11.5 History
 
-A 352px popover hanging off the button that opened it, at `top: 44px; right: 8px`, radius 8,
+A 480px popover hanging off the button that opened it, at `top: 44px; right: 8px`, radius 8,
 `--grimoire-lift-1`. It was a sheet inset 13px on all four sides: looking for another conversation is
 not a reason to lose sight of this one.
+
+The cap was 352, and a cap is only doing work above the pane width where `calc(100% - 16px)` stops
+being the smaller half of the `min()`. Below 368px the popover is sized by its pane and the number is
+inert, which is the default right sidebar; above it the title's room froze at 317px, so a 1000px tab
+scanned the same 55 characters a 400px one did. 480 gives the title about 70 characters, inside the
+45-75 a reader scans; the full tab width this list carried before Nordic is what put it past that.
 
 A 34px search row, then rows of 56px at radius 4 with a hover wash. The open conversation carries a
 1.5px accent leading rule. A row is two lines: the title has the first to itself, full width, and

--- a/src/style/components/history.css
+++ b/src/style/components/history.css
@@ -2,6 +2,14 @@
  * History is a popover hanging off the control that opened it, not a sheet
  * covering the conversation behind it. Looking for another conversation is not
  * a reason to lose sight of this one.
+ *
+ * The cap was 352px, which froze the title's room at 317px however wide the
+ * pane grew: a 1000px tab scanned the same 55 characters a 400px one did, so a
+ * number written for the wide case did nothing in it. 480 buys about 70
+ * characters, which is inside the measure a reader can scan; the full tab width
+ * this list once used is what put it past that. The second half of `min()` is
+ * untouched, so the default right-sidebar pane is governed by its own width as
+ * before and sees no change at all.
  */
 .grimoire-history-menu {
   position: absolute;
@@ -12,7 +20,7 @@
   z-index: 40;
   display: none;
   box-sizing: border-box;
-  width: min(352px, calc(100% - var(--grimoire-space-16)));
+  width: min(480px, calc(100% - var(--grimoire-space-16)));
   max-height: min(520px, calc(100% - var(--grimoire-header-h) - var(--grimoire-space-24)));
   overflow: hidden;
   border: 1px solid var(--grimoire-line);

--- a/tests/unit/style/historyCss.test.ts
+++ b/tests/unit/style/historyCss.test.ts
@@ -23,7 +23,7 @@ describe('history.css', () => {
     expect(menuRule).toContain('right: var(--grimoire-space-8)');
     expect(menuRule).toContain('bottom: auto');
     expect(menuRule).toContain('left: auto');
-    expect(menuRule).toContain('width: min(352px, calc(100% - var(--grimoire-space-16)))');
+    expect(menuRule).toContain('width: min(480px, calc(100% - var(--grimoire-space-16)))');
     expect(menuRule).toContain('box-shadow: var(--grimoire-lift-1)');
     expect(getRule(css, '.grimoire-history-menu.visible')).toContain('display: grid');
     // No header band, so no close button in one: the panel opens on its search


### PR DESCRIPTION
## Problem

`.grimoire-history-menu` was capped at `width: min(352px, calc(100% - var(--grimoire-space-16)))`.
A cap only does work above the pane width where the second half of the `min()` stops being the
smaller one, which is 368px. Below that the popover is sized by its pane and the number is inert,
and that is the default right sidebar. Above it the title's room froze at 317px and stayed there,
so a 1000px main tab scanned the same titles a 400px one did.

The number written for the wide case was doing nothing in it.

Fixes #172.

## Measurements

Rendered with the harness in [`docs/design-system.md`](docs/design-system.md) §16, against the
`app.css` inside the installed Obsidian 1.13.7 `.asar`, using the built root `styles.css`.

| pane | popover | title room | before |
| --- | --- | --- | --- |
| 300px (default right sidebar) | 284px | 249px | unchanged, cap inert |
| 400px | 384px | 349px | 352px / 317px |
| 700px | 480px | 445px | 352px / 317px |
| 1000px | 480px | 445px | 352px / 317px |

## Approach

Raise the cap to 480 and leave the rest alone. The second half of `min()` is untouched, so a narrow
pane still sizes the popover itself and it still cannot reach the edge. The shape the original
comment defends is unchanged: this is a popover hanging off the control that opened it, not a sheet
over the conversation.

480 rather than the 560 the issue proposed. A line a reader scans holds 45 to 75 characters; 480
gives the title about 70 and stays inside that, while 560 gives about 90 and lands past it. The full
tab width this list carried before Nordic is what put it past that measure in the first place, and
that is the complaint the 352 was answering.

## What the issue got wrong, and what is deliberately not changed

The issue describes the row as title, then preview, then a stamp clamped to 160px, and reads the
title as losing a competition inside the row. There is no preview line: Nordic removed it, and
§11.5 records that. The title owns the first line full width.

The 160px clamp is on `.grimoire-history-item-time` and bounds the time against the model label on
the row's second line, which is why the comment above it exists: without it a model label arriving
as a whole billing path took the line. It never competed with the title, so it stays.

## Notes

Users on the default right-sidebar placement see no change. The cap was already inert for them.

`docs/design-system.md` §11.5 named the old number in prose and moves with the CSS. The drawing does
not draw this popover, so it is untouched.

## Testing

- `npm run test -- --selectProjects unit` (9208 tests)
- `npm run typecheck`
- `npm run lint`
- `node scripts/check-review-css.mjs`
