### PR TITLE
docs(history): name the row height the rule actually sets

### DIFF
--- a/src/style/components/history.css
+++ b/src/style/components/history.css
@@ -198,7 +198,7 @@ input.grimoire-history-search-input {
  * still shifts nothing, which is what §11.5 always claimed and this is the
  * first arrangement in which it is true.
  *
- * The cost is the row: 36px became 48, so about a third fewer conversations
+ * The cost is the row: 36px became 56, so about a third fewer conversations
  * are in view. This is not the second line Nordic removed — that one carried
  * four facts in mono under every title and turned a list into a wall. This one
  * carries what was already on the row, moved off the title's line.


### PR DESCRIPTION
The summary comment above `.grimoire-history-item` said the row went from 36px to 48. The rule under it sets 56.

48 is the figure the row was designed at, and the comment two lines below explains why it could not stay: two lines and a 24px hit target come to 42, so at 48 with no vertical padding the ground closed on the title above and the controls below with three pixels to spare. The 6px vertical padding that answered that put the row at 56, and the summary never followed.

"About a third fewer conversations are in view" still holds: 36 into 56 is 64%.

Comment only, one line. Noticed while redrawing this surface in #178.