### PR TITLE
fix(kimicode): detect default Windows executable

### DIFF
--- a/src/providers/kimicode/runtime/KimicodeCliResolver.ts
+++ b/src/providers/kimicode/runtime/KimicodeCliResolver.ts
@@ -7,6 +7,7 @@ import { resolveCliExecutable } from '../../../utils/resolveCliExecutable';
 import { getKimicodeProviderSettings } from '../settings';
 
 const KIMI_CODE_DEFAULT_BIN = path.join(os.homedir(), '.kimi-code', 'bin', 'kimi');
+const KIMI_CODE_DEFAULT_WINDOWS_BIN = `${KIMI_CODE_DEFAULT_BIN}.exe`;
 
 export class KimicodeCliResolver {
   private readonly cachedHostname = getHostnameKey();
@@ -48,7 +49,7 @@ export class KimicodeCliResolver {
   ): string | null {
     const hostnamePath = (hostnamePaths?.[this.cachedHostname] ?? '').trim();
     return resolveCliExecutable('kimi', [hostnamePath, legacyPath], envText, {
-      fallbackPaths: [KIMI_CODE_DEFAULT_BIN],
+      fallbackPaths: [KIMI_CODE_DEFAULT_WINDOWS_BIN, KIMI_CODE_DEFAULT_BIN],
     });
   }
 

--- a/tests/unit/providers/kimicode/KimicodeCliResolver.test.ts
+++ b/tests/unit/providers/kimicode/KimicodeCliResolver.test.ts
@@ -1,3 +1,6 @@
+import * as os from 'node:os';
+import * as path from 'node:path';
+
 import * as fs from 'fs';
 
 import { KimicodeCliResolver } from '@/providers/kimicode/runtime/KimicodeCliResolver';
@@ -62,5 +65,16 @@ describe('KimicodeCliResolver', () => {
     );
 
     expect(resolved).toBeNull();
+  });
+
+  it('detects the default Windows kimi.exe installation', () => {
+    const defaultExecutable = path.join(os.homedir(), '.kimi-code', 'bin', 'kimi.exe');
+    mockedExists.mockImplementation((filePath: string) => filePath === defaultExecutable);
+    mockedStat.mockReturnValue({ isFile: () => true });
+
+    const resolver = new KimicodeCliResolver();
+    const resolved = resolver.resolve({}, '', '');
+
+    expect(resolved).toBe(defaultExecutable);
   });
 });


### PR DESCRIPTION
## Problem

Kimi Code installs its Windows launcher at `~/.kimi-code/bin/kimi.exe`, but
Grimoire's known-install fallback only probes the extensionless
`~/.kimi-code/bin/kimi`. Users must configure the executable manually when the
Obsidian process cannot discover the newly installed CLI through `PATH`.

Fixes #184 

## Root Cause

`resolveCliExecutable` expands `PATHEXT` candidates when searching directories
from `PATH`. Explicit fallback paths are validated as complete file paths, so
the extensionless Kimi fallback never resolves the real Windows executable.

## Approach

- Add `~/.kimi-code/bin/kimi.exe` as the first Kimi-owned known-install fallback.
- Preserve the existing extensionless fallback for other platforms.
- Add a focused regression test for the default Windows installation path.

The change remains provider-local and does not alter shared CLI resolution for
other providers.

## Verification

Automated:

- Focused `KimicodeCliResolver` unit suite: 4 passed.
- `npm run typecheck`: passed.
- `npm run lint`: passed.
- `npm run build:release`: passed, including source/CSS/dependency review,
  release metadata validation, isolated bundle load, and `grimoire-view` smoke check.
- The full unit suite retains two unrelated host-locale failures on Windows
  (`16,000` versus `16 000`); the affected files are unchanged from `origin/main`.

Manual:

- Built commit `eec473d2` and installed it in Windows desktop Obsidian.
- Removed the manually configured Kimi Code CLI path after restarting Obsidian.
- Grimoire then detected `~/.kimi-code/bin/kimi.exe` automatically and the Kimi
  provider remained connected.

## Security And Privacy

- No credentials, account data, prompts, or logs are read or persisted.
- Process arguments and provider permissions are unchanged.
- The change only adds one deterministic local executable fallback candidate.