### PR TITLE
fix(providers): detect default Windows CLI installs

### DIFF
--- a/src/providers/codex/runtime/CodexBinaryLocator.ts
+++ b/src/providers/codex/runtime/CodexBinaryLocator.ts
@@ -1,3 +1,5 @@
+import * as os from 'node:os';
+
 import * as fs from 'fs';
 import * as path from 'path';
 
@@ -86,5 +88,24 @@ export function resolveCodexCliPath(
   }
 
   const customEnv = parseEnvironmentVariables(envText || '');
-  return findCodexBinaryPath(customEnv.PATH, hostPlatform);
+  const detectedPath = findCodexBinaryPath(customEnv.PATH, hostPlatform);
+  if (detectedPath) {
+    return detectedPath;
+  }
+
+  if (hostPlatform === 'win32') {
+    const localAppData = process.env.LOCALAPPDATA
+      || path.join(os.homedir(), 'AppData', 'Local');
+    const desktopAppBinary = path.join(
+      localAppData,
+      'Programs',
+      'OpenAI',
+      'Codex',
+      'bin',
+      'codex.exe',
+    );
+    return isExistingFile(desktopAppBinary) ? desktopAppBinary : null;
+  }
+
+  return null;
 }

--- a/src/providers/grok/AGENTS.md
+++ b/src/providers/grok/AGENTS.md
@@ -13,7 +13,7 @@
 - Preserve Grok Build-native behavior and file formats where possible.
 - Launch Grok with `grok agent stdio`, not the `acp` subcommand used by other providers.
 - Use `GROK_HOME` for Grimoire-managed launch artifacts under `.grimoire/grok/`.
-- Resolve CLI paths from per-host settings only; fall back to the `grok` command on `PATH` when no configured binary exists.
+- Resolve CLI paths from per-host settings first, then the `grok` command on `PATH`, then the native Windows fallback `~/.grok/bin/grok.exe`.
 - Keep auth and session discovery env-driven (`GROK_AUTH_PATH`, `GROK_HOME` in provider env vars). When Grimoire redirects `GROK_HOME` to `.grimoire/grok/`, bridge auth with `GROK_AUTH_PATH` resolved from provider env plus process env, not from the managed home path.
 - Grok sessions persist as JSONL under `<GROK data dir>/sessions/`; history hydration still needs runtime discovery before it can replace the scaffold store.
 - Do not project Grok provider state into generic chat UI code. Use provider helpers and shared contracts.

--- a/src/providers/grok/runtime/GrokCliResolver.ts
+++ b/src/providers/grok/runtime/GrokCliResolver.ts
@@ -1,7 +1,12 @@
+import * as os from 'node:os';
+import * as path from 'node:path';
+
 import { getRuntimeEnvironmentText } from '../../../core/providers/providerEnvironment';
 import { getHostnameKey } from '../../../utils/env';
 import { resolveCliExecutable } from '../../../utils/resolveCliExecutable';
 import { getGrokProviderSettings } from '../settings';
+
+const GROK_DEFAULT_WINDOWS_BIN = path.join(os.homedir(), '.grok', 'bin', 'grok.exe');
 
 export class GrokCliResolver {
   private readonly cachedHostname = getHostnameKey();
@@ -42,7 +47,9 @@ export class GrokCliResolver {
     envText: string,
   ): string | null {
     const hostnamePath = (hostnamePaths?.[this.cachedHostname] ?? '').trim();
-    return resolveCliExecutable('grok', [hostnamePath, legacyPath], envText);
+    return resolveCliExecutable('grok', [hostnamePath, legacyPath], envText, {
+      fallbackPaths: [GROK_DEFAULT_WINDOWS_BIN],
+    });
   }
 
   reset(): void {

--- a/src/providers/kimicode/runtime/KimicodeCliResolver.ts
+++ b/src/providers/kimicode/runtime/KimicodeCliResolver.ts
@@ -7,6 +7,7 @@ import { resolveCliExecutable } from '../../../utils/resolveCliExecutable';
 import { getKimicodeProviderSettings } from '../settings';
 
 const KIMI_CODE_DEFAULT_BIN = path.join(os.homedir(), '.kimi-code', 'bin', 'kimi');
+const KIMI_CODE_DEFAULT_WINDOWS_BIN = `${KIMI_CODE_DEFAULT_BIN}.exe`;
 
 export class KimicodeCliResolver {
   private readonly cachedHostname = getHostnameKey();
@@ -48,7 +49,7 @@ export class KimicodeCliResolver {
   ): string | null {
     const hostnamePath = (hostnamePaths?.[this.cachedHostname] ?? '').trim();
     return resolveCliExecutable('kimi', [hostnamePath, legacyPath], envText, {
-      fallbackPaths: [KIMI_CODE_DEFAULT_BIN],
+      fallbackPaths: [KIMI_CODE_DEFAULT_WINDOWS_BIN, KIMI_CODE_DEFAULT_BIN],
     });
   }
 

--- a/src/providers/mimocode/runtime/MimocodeCliResolver.ts
+++ b/src/providers/mimocode/runtime/MimocodeCliResolver.ts
@@ -7,6 +7,7 @@ import { resolveCliExecutable } from '../../../utils/resolveCliExecutable';
 import { getMimocodeProviderSettings } from '../settings';
 
 const MIMOCODE_DEFAULT_BIN = path.join(os.homedir(), '.mimocode', 'bin', 'mimo');
+const MIMOCODE_DEFAULT_WINDOWS_BIN = `${MIMOCODE_DEFAULT_BIN}.exe`;
 
 export class MimocodeCliResolver {
   private readonly cachedHostname = getHostnameKey();
@@ -48,7 +49,7 @@ export class MimocodeCliResolver {
   ): string | null {
     const hostnamePath = (hostnamePaths?.[this.cachedHostname] ?? '').trim();
     return resolveCliExecutable('mimo', [hostnamePath, legacyPath], envText, {
-      fallbackPaths: [MIMOCODE_DEFAULT_BIN],
+      fallbackPaths: [MIMOCODE_DEFAULT_WINDOWS_BIN, MIMOCODE_DEFAULT_BIN],
     });
   }
 

--- a/tests/unit/providers/codex/runtime/CodexCliResolver.test.ts
+++ b/tests/unit/providers/codex/runtime/CodexCliResolver.test.ts
@@ -1,3 +1,6 @@
+import * as os from 'node:os';
+import * as path from 'node:path';
+
 import * as fs from 'fs';
 
 import { CodexCliResolver } from '@/providers/codex/runtime/CodexCliResolver';
@@ -54,9 +57,10 @@ describe('CodexCliResolver', () => {
   });
 
   it('auto-detects from the runtime PATH when no configured path is valid', () => {
-    mockedExists.mockImplementation((filePath: string) => filePath === '/custom/bin/codex');
+    const runtimeExecutable = path.join('/custom/bin', 'codex');
+    mockedExists.mockImplementation((filePath: string) => filePath === runtimeExecutable);
     mockedStat.mockImplementation((filePath: string) => ({
-      isFile: () => filePath === '/custom/bin/codex',
+      isFile: () => filePath === runtimeExecutable,
     }));
 
     const resolver = new CodexCliResolver();
@@ -64,9 +68,24 @@ describe('CodexCliResolver', () => {
       { 'other-host': '/other/codex' },
       '',
       'PATH=/custom/bin',
+      { hostPlatform: 'linux' },
     );
 
-    expect(resolved).toBe('/custom/bin/codex');
+    expect(resolved).toBe(runtimeExecutable);
+  });
+
+  it('detects the default Windows desktop-app codex.exe installation', () => {
+    const localAppData = process.env.LOCALAPPDATA
+      || path.join(os.homedir(), 'AppData', 'Local');
+    const defaultExecutable = path.join(localAppData, 'Programs', 'OpenAI', 'Codex', 'bin', 'codex.exe');
+    mockedExists.mockImplementation((filePath: string) => filePath === defaultExecutable);
+    mockedStat.mockImplementation((filePath: string) => ({
+      isFile: () => filePath === defaultExecutable,
+    }));
+
+    const resolver = new CodexCliResolver();
+
+    expect(resolver.resolve({}, '', '', { hostPlatform: 'win32' })).toBe(defaultExecutable);
   });
 
   it('returns a Linux-side command in WSL mode without host filesystem validation', () => {

--- a/tests/unit/providers/grok/GrokCliResolver.test.ts
+++ b/tests/unit/providers/grok/GrokCliResolver.test.ts
@@ -1,3 +1,6 @@
+import * as os from 'node:os';
+import * as path from 'node:path';
+
 import * as fs from 'fs';
 
 import { GrokCliResolver } from '@/providers/grok/runtime/GrokCliResolver';
@@ -62,5 +65,15 @@ describe('GrokCliResolver', () => {
     );
 
     expect(resolved).toBeNull();
+  });
+
+  it('detects the default Windows grok.exe installation', () => {
+    const defaultExecutable = path.join(os.homedir(), '.grok', 'bin', 'grok.exe');
+    mockedExists.mockImplementation((filePath: string) => filePath === defaultExecutable);
+    mockedStat.mockReturnValue({ isFile: () => true });
+
+    const resolver = new GrokCliResolver();
+
+    expect(resolver.resolve({}, '', '')).toBe(defaultExecutable);
   });
 });

--- a/tests/unit/providers/kimicode/KimicodeCliResolver.test.ts
+++ b/tests/unit/providers/kimicode/KimicodeCliResolver.test.ts
@@ -1,3 +1,6 @@
+import * as os from 'node:os';
+import * as path from 'node:path';
+
 import * as fs from 'fs';
 
 import { KimicodeCliResolver } from '@/providers/kimicode/runtime/KimicodeCliResolver';
@@ -62,5 +65,16 @@ describe('KimicodeCliResolver', () => {
     );
 
     expect(resolved).toBeNull();
+  });
+
+  it('detects the default Windows kimi.exe installation', () => {
+    const defaultExecutable = path.join(os.homedir(), '.kimi-code', 'bin', 'kimi.exe');
+    mockedExists.mockImplementation((filePath: string) => filePath === defaultExecutable);
+    mockedStat.mockReturnValue({ isFile: () => true });
+
+    const resolver = new KimicodeCliResolver();
+    const resolved = resolver.resolve({}, '', '');
+
+    expect(resolved).toBe(defaultExecutable);
   });
 });

--- a/tests/unit/providers/mimocode/MimocodeCliResolver.test.ts
+++ b/tests/unit/providers/mimocode/MimocodeCliResolver.test.ts
@@ -1,3 +1,6 @@
+import * as os from 'node:os';
+import * as path from 'node:path';
+
 import * as fs from 'fs';
 
 import { MimocodeCliResolver } from '@/providers/mimocode/runtime/MimocodeCliResolver';
@@ -62,5 +65,15 @@ describe('MimocodeCliResolver', () => {
     );
 
     expect(resolved).toBeNull();
+  });
+
+  it('detects the default Windows mimo.exe installation', () => {
+    const defaultExecutable = path.join(os.homedir(), '.mimocode', 'bin', 'mimo.exe');
+    mockedExists.mockImplementation((filePath: string) => filePath === defaultExecutable);
+    mockedStat.mockReturnValue({ isFile: () => true });
+
+    const resolver = new MimocodeCliResolver();
+
+    expect(resolver.resolve({}, '', '')).toBe(defaultExecutable);
   });
 });


### PR DESCRIPTION
## Problem

Kimi Code, MiMoCode, Codex, and Grok are not auto-detected at their native
default Windows installation paths when those directories are absent from the
Obsidian process `PATH`. All four providers work after configuring their full
executable paths manually.

Fixes #186 

## Approach

- Probe `~/.kimi-code/bin/kimi.exe` before Kimi's extensionless fallback.
- Probe `~/.mimocode/bin/mimo.exe` before MiMoCode's extensionless fallback.
- Probe `%LOCALAPPDATA%/Programs/OpenAI/Codex/bin/codex.exe` after Codex's
  configured-path and `PATH` search.
- Probe `~/.grok/bin/grok.exe` after Grok's configured-path and `PATH` search.
- Keep every fallback provider-owned; shared resolver behavior is unchanged.
- Add focused regression coverage for every observed Windows path.

## Verification

Automated:

- Focused resolver suites: 18 tests passed across Kimi Code, MiMoCode, Codex,
  and Grok.
- `npm run typecheck`: passed.
- `npm run lint`: passed.
- `npm run build:release`: passed, including source/CSS/dependency review,
  release metadata validation, isolated bundle load, and `grimoire-view` smoke check.

Manual, Windows desktop Obsidian:

- Installed the release build with a rollback backup.
- Restarted Obsidian and removed every manual provider CLI path.
- Kimi Code, MiMoCode, Codex, and Grok were all detected automatically.
- A new conversation responded successfully through every provider.
- OpenRouter configured through MiMoCode also responded successfully.
- Gemini remained auto-detected and a new Gemini conversation responded; no
  Gemini change is included in this PR.

## Security And Privacy

- No credentials, account data, prompts, or provider logs are read or persisted.
- Process arguments, authentication, and permission behavior are unchanged.
- The change only adds deterministic local executable candidates after existing
  configured-path and `PATH` resolution.